### PR TITLE
feat: add CLI, rewrite README for user-first DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,52 +2,147 @@
   <b>ENG</b> | <a href="README.ua.md">UKR</a>
 </p>
 
-# 🚀 P.O.W.E.R. Framework — Hybrid Knowledge Management System
+# P.O.W.E.R. — AI-Native Toolkit for Obsidian
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10+-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![Pydantic v2](https://img.shields.io/badge/Pydantic-v2-E74C3C?logo=pydantic&logoColor=white)](https://docs.pydantic.dev/)
 [![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-00C853?logo=modelcontextprotocol&logoColor=white)](https://modelcontextprotocol.io/)
-[![Obsidian](https://img.shields.io/badge/Obsidian-Compatible-7C3AED?logo=obsidian&logoColor=white)](https://obsidian.md/)
 [![CI](https://github.com/weby-homelab/P.O.W.E.R/actions/workflows/ci.yml/badge.svg)](https://github.com/weby-homelab/P.O.W.E.R/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/weby-homelab/P%2EO%2EW%2EE%2ER?logo=github)](https://github.com/weby-homelab/P.O.W.E.R/releases)
-[![Tests: 79](https://img.shields.io/badge/Tests-79_passed-2ECC71?logo=pytest)](https://github.com/weby-homelab/P.O.W.E.R/tree/main/tests)
 
-A hybrid knowledge management system (Obsidian Second Brain) that bridges human-friendly directory organization with strict machine-readability for AI agents.
+Validate, index, and manage your Obsidian vault from the command line — or let AI agents do it through MCP.
 
-Built on the synergy of **P.A.R.A.** + **OKF Overlay** + **LLM-Wiki** + **Execution Rules**.
+## Quick Start
 
+```bash
+pip install power-framework
+
+power init ~/my-vault      # Create vault structure
+power lint ~/my-vault      # Check for broken links & missing metadata
+power index ~/my-vault     # Generate catalog index.md
+```
+
+## What's Inside
+
+| Feature | What it does |
+|---------|-------------|
+| **CLI** | `power init`, `lint`, `index`, `ingest` — manage your vault from terminal |
+| **MCP Server** | Exposes `lint_vault`, `generate_index`, `ingest_note` to any AI agent (Claude, Cursor, OpenCode) |
+| **OKF Validation** | Pydantic v2 schemas enforce strict metadata on every note |
+| **Health Linting** | Finds broken links, missing metadata, and orphan notes |
+| **Auto-Sync** | Cron-compatible script with GPG-signed commits for continuous backup |
+
+## Who Is This For
+
+- **Obsidian users** who want AI agents to understand and maintain their vault
+- **Developers** building a structured Second Brain with machine-readable metadata
+- **Teams** that need consistent note formatting and automated quality checks
+
+## Commands
+
+```
+power init <path>              Create a new vault with P.A.R.A. folder structure
+power lint <path>              Scan for broken links, missing metadata, orphans
+power index <path>             Rebuild index.md catalog from all notes
+power ingest <path> [options]  Create a new note with validated OKF metadata
+```
+
+### Ingest Examples
+
+```bash
+power ingest ~/my-vault --type Project --title "My App" --description "A new project"
+power ingest ~/my-vault --type Resource --title "Docker Guide" --description "Docker best practices" --tags [devops, docker] --resource "https://docs.docker.com"
+```
+
+## MCP Server Setup
+
+Connect P.O.W.E.R. to any MCP-compatible AI client:
+
+```bash
+pip install power-framework mcp
+```
+
+**Claude Desktop** (`~/.config/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "power": {
+      "command": "python3",
+      "args": ["-m", "mcp_servers.power_server"],
+      "env": {
+        "POWER_VAULT_DIR": "/path/to/your/obsidian/vault"
+      }
+    }
+  }
+}
+```
+
+**OpenCode** (`~/.config/opencode/opencode.jsonc`):
+```jsonc
+"mcp": {
+  "power": {
+    "type": "local",
+    "command": ["python3", "-m", "mcp_servers.power_server"],
+    "enabled": true
+  }
+}
+```
+
+## Vault Structure
+
+P.O.W.E.R. organizes your vault using the **P.A.R.A.** method with **OKF metadata** on every note:
+
+```
+~/my-vault
+├── 00_Inbox/          # Quick captures and raw inputs
+├── 01_Projects/       # Active projects with deadlines
+├── 02_Areas/          # Ongoing responsibilities
+├── 03_Resources/      # Reusable guides and references
+├── 04_Archive/        # Completed or retired notes
+├── 05_Templates/      # Note templates with OKF frontmatter
+├── 06_Daily_Logs/     # Chronological session logs
+├── PROTOCOLS/         # System specs for AI agents
+├── index.md           # Auto-generated catalog
+└── log.md             # Append-only change log
+```
+
+Every note starts with validated YAML frontmatter:
+
+```yaml
 ---
+type: Project
+title: "My App"
+description: "A new project with clear goals"
+tags: [active, dev]
+timestamp: 2026-07-02T19:00:00
+---
+```
 
-## 🎯 System Architecture (P.O.W.E.R.)
+## Architecture Details
 
-The framework consists of four complementary methodologies:
+<details>
+<summary><strong>P.O.W.E.R. Methodology — click to expand</strong></summary>
 
-*   **P** — **P.A.R.A.** (Projects, Areas, Resources, Archive) — a logical folder structure optimized for human cognitive layout.
-*   **O** — **OKF Overlay** (Open Knowledge Format) — metadata (YAML frontmatter) at the top of every file to enable instant AI parsing.
-*   **W** — **LLM-Wiki** (A. Karpathy's philosophy) — automated catalog indexing, chronological log, and structural link linting.
-*   **E.R.** — **Execution Rules / Enforced Routines** (custom automation rules) — GPG-signed commits, PR-only workflow, cron-based 5-minute sync, and branch cleanup policies.
+The framework combines four complementary methodologies:
 
-### 📊 Visual Framework Diagram
+- **P** — **P.A.R.A.** (Projects, Areas, Resources, Archive) — logical folder structure for human cognition
+- **O** — **OKF Overlay** (Open Knowledge Format) — YAML frontmatter on every file for instant AI parsing
+- **W** — **LLM-Wiki** — automated catalog indexing, chronological log, and structural link linting
+- **E.R.** — **Execution Rules** — GPG-signed commits, PR-only workflow, cron-based sync, branch cleanup
+
+### Visual Framework Diagram
 
 ```mermaid
 graph TB
     subgraph Human ["👤 Human (Obsidian UI)"]
         PARA["P.A.R.A. Directory Structure"]
-        PARA_P["01_Projects"]
-        PARA_A["02_Areas"]
-        PARA_R["03_Resources"]
-        PARA_AR["04_Archive"]
-        PARA --> PARA_P
-        PARA --> PARA_A
-        PARA --> PARA_R
-        PARA --> PARA_AR
     end
 
     subgraph AI ["🤖 AI Agent (Local / Cloud)"]
         Ingest["Ingest Note"]
-        Lint["Lint Vault (lint_brain.py)"]
-        Index["Rebuild Index (generate_index.py)"]
+        Lint["Lint Vault"]
+        Index["Rebuild Index"]
     end
 
     subgraph OKF ["📄 OKF Overlay (Metadata Schema)"]
@@ -56,220 +151,52 @@ graph TB
         LogMD["log.md (Change Log)"]
     end
 
-    subgraph ER ["🔐 Execution Rules & Enforced Routines"]
-        GPG["GPG Signature (Verified Commit)"]
-        PR["PR-Only Workflow (GitHub)"]
-        Sync["Cron Autosync (sync-brain.sh)"]
-        Clean["Branch Cleanup (cleanup_branches.py)"]
-    end
-
     Human -- Writes Notes --> YAML
     YAML -- Parsed by --> AI
     AI -- Updates --> IndexMD
     AI -- Appends --> LogMD
     AI -- Runs Checks --> Lint
-    
-    IndexMD -- Synchronized via --> Sync
-    LogMD -- Synchronized via --> Sync
-    
-    Sync -- Requires --> GPG
-    Sync -- Follows --> PR
-    PR -- Triggers --> Clean
-    
-    classDef human fill:#1A365D,stroke:#3182CE,stroke-width:2px,color:#FFF;
-    classDef ai fill:#2C3E50,stroke:#E74C3C,stroke-width:2px,color:#FFF;
-    classDef okf fill:#1B4D3E,stroke:#2ECC71,stroke-width:2px,color:#FFF;
-    classDef er fill:#5D3F6A,stroke:#BB8FCE,stroke-width:2px,color:#FFF;
-    
-    class PARA,PARA_P,PARA_A,PARA_R,PARA_AR human;
-    class Ingest,Lint,Index ai;
-    class YAML,IndexMD,LogMD okf;
-    class GPG,PR,Sync,Clean er;
 ```
 
----
-
-## 📂 Vault Directory Structure
-
-The Obsidian vault (Second Brain) is organized as follows:
-
-```text
-/brain
-├── 00_Inbox/                    # Temporary folder for quick scratchnotes and raw inputs
-├── 01_Projects/                 # Active projects with specific deadlines and targets
-├── 02_Areas/                    # Long-term responsibilities (infrastructure, finance, health)
-├── 03_Resources/                # General resources (guides, stack, snippets, scripts)
-│   └── lint_brain.py            # Automated link validation and cleanup script
-├── 04_Archive/                  # Completed projects and stale/outdated notes
-├── 05_Templates/                # Templates with predefined OKF metadata blocks
-├── 06_Daily_Logs/               # Chronological daily logs and lessons (MASTER-LESSONS-LEARNED)
-├── PROTOCOLS/                   # System configurations and specifications for AI agents
-│   └── LLM_WIKI_SCHEMA.md       # Formatting and linting standards for AI operations
-├── index.md                     # Automatically generated catalog index of all notes
-└── log.md                       # Chronological append-only change log of the vault
-```
-
----
-
-## 🏗️ Project Architecture (power_core)
-
-The framework is built on a shared `power_core` Python package that provides:
+### Core Library (`power_core`)
 
 | Module | Purpose |
 |--------|---------|
-| `power_core/models.py` | Pydantic v2 schemas for strict OKF metadata validation |
-| `power_core/parser.py` | Safe YAML frontmatter parsing (PyYAML-based) |
-| `power_core/indexer.py` | Vault scanning and index.md generation |
-| `power_core/linter.py` | Health checks: broken links, missing metadata, orphans |
-| `power_core/utils.py` | Path traversal protection, atomic writes, backup management |
+| `models.py` | Pydantic v2 schemas for OKF metadata validation |
+| `parser.py` | Safe YAML frontmatter parsing (PyYAML-based) |
+| `indexer.py` | Vault scanning and index.md generation |
+| `linter.py` | Health checks: broken links, missing metadata, orphans |
+| `utils.py` | Path traversal protection, atomic writes, backups |
+| `cli.py` | Command-line interface (init, lint, index, ingest) |
 
-All components (MCP server, CLI scripts) use `power_core` as the single source of truth, eliminating code duplication and ensuring consistency.
+All components share `power_core` as the single source of truth.
 
----
+</details>
 
-## 📄 Metadata Specification (OKF)
-
-Every note must contain a strict YAML block (frontmatter) at the very top of the file. This allows AI agents to instantly index and filter documents:
-
-```yaml
----
-type: Project | Area | Resource | Daily Log | Archive | System Guide  # Note category
-title: "Document Title"                                                # Human-friendly title
-description: "Single-line summary (up to 150 chars) for the catalog"  # Short description
-resource: "https://github.com/..."                                    # External source code (if any)
-tags: [active, guide]                                                 # Obsidian tags
-timestamp: YYYY-MM-DDTHH:MM:SS+TZ                                      # Last modified date
----
-```
-
----
-
-## 🤖 Health Linting Process
-
-The `lint_brain.py` script is used to perform on-demand or automated vault checks.
-
-### Features:
-1.  **Broken Links**: Finds internal wikilinks `[[Note]]` and GFM markdown links `[Title](Path.md)` that point to non-existent files.
-2.  **Metadata Validation**: Identifies notes with missing YAML frontmatter or missing required `type` field.
-3.  **Orphan Check**: Reports notes that have no inbound links (excluding core files).
-
----
-
-## 🔐 Security & Automation (E.R.)
-
-1.  **Zero-Secrets**: No passwords, API keys, or private IP addresses in the repository. All credentials live in a local `.env` file on the host (added to `.gitignore`).
-2.  **Verified Commits (GPG)**: All commits must be signed with the developer's GPG key to verify the committer identity in public repositories.
-3.  **PR-only Workflow**: Direct pushes to `main` are disabled. All updates are pushed to `feature/*` branches and merged via Pull Requests.
-4.  **Auto-Sync Cron**: A server cron job runs every 5 minutes, automatically committing and pushing vault changes to GitHub.
-
----
-
-## ⚡ P.O.W.E.R. Agent Skill & MCP Server Installation
-
-We have packaged the entire P.O.W.E.R. framework rules and indexing/linting tools into two reusable components:
-1. **AI Agent Custom Skill**: A folder of instructions (`SKILL.md`) and scripts (`scripts/`) that can be loaded into any agentic platform supporting custom prompt or skill injection.
-2. **Model Context Protocol (MCP) Server**: A self-contained, portable python server (`mcp_servers/power_server.py`) that exposes three MCP tools (`lint_vault`, `generate_index`, and `ingest_note`) to any compatible LLM client (Claude Desktop, Cursor, OpenCode, etc.).
-
-These components work universally with any AI agent, whether running locally or in the cloud.
-
-### ⚙️ One-Command Installation
-
-To install the P.O.W.E.R. skill and the MCP server automatically into your active workspace, making them ready to use with any AI agent (local or cloud) with a single command, run:
-
-```bash
-curl -sSL https://raw.githubusercontent.com/weby-homelab/P.O.W.E.R/main/install.sh | bash
-```
-
-Alternatively, you can specify a custom target workspace path:
-```bash
-curl -sSL https://raw.githubusercontent.com/weby-homelab/P.O.W.E.R/main/install.sh | bash -s -- /path/to/your/workspace
-```
-
-### 🔌 MCP Server Configuration
-
-After running the installer:
-1. Install the required Python dependencies in your target execution environment:
-   ```bash
-   pip install mcp
-   ```
-2. Configure your favorite AI client to load the MCP server:
-   * **Claude Desktop** (`~/.config/Claude/claude_desktop_config.json`):
-     ```json
-     {
-       "mcpServers": {
-         "power": {
-           "command": "python3",
-           "args": ["/path/to/your/workspace/.agents/mcp_servers/power_server.py"],
-           "env": {
-             "POWER_VAULT_DIR": "/path/to/your/obsidian/vault"
-           }
-         }
-       }
-     }
-     ```
-   * **OpenCode** (`~/.config/opencode/opencode.jsonc`):
-     ```json
-     "mcp": {
-       "power": {
-         "type": "local",
-         "command": [
-           "/root/.config/opencode/venv/bin/python",
-           "/path/to/your/workspace/.agents/mcp_servers/power_server.py"
-         ],
-         "enabled": true
-       }
-     }
-     ```
-
-### 🔌 Manual Skill Configuration (Optional)
-If you prefer to configure the skill manually:
-1. Copy the contents of the `skills/power` directory to your workspace's `.agents/skills/power` folder.
-2. Make the scripts inside `scripts/` executable: `chmod +x .agents/skills/power/scripts/*.py`
-3. Add the skill to your OpenCode system configuration in `~/.config/opencode/opencode.jsonc`:
-   ```json
-   "instructions": [
-     "/path/to/your/workspace/.agents/skills/power/SKILL.md"
-   ]
-   ```
-
----
-
-## 🛠️ Development
-
-### Setup
+## Development
 
 ```bash
 git clone https://github.com/weby-homelab/P.O.W.E.R.git
 cd P.O.W.E.R
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
-```
 
-### Quality Checks
-
-```bash
 # Run tests
 pytest tests/ -v
 
-# Lint
+# Lint & format
 ruff check power_core/ mcp_servers/ scripts/ tests/
-
-# Format
 ruff format power_core/ mcp_servers/ scripts/ tests/
 
 # Type check
 mypy power_core/
 ```
 
-### Automation Scripts
+## License
 
-| Script | Purpose |
-|--------|---------|
-| `scripts/sync-brain.sh` | Cron-compatible auto-sync with GPG signing support |
-| `scripts/cleanup_branches.py` | Automated merged branch cleanup via GitHub API |
+MIT — use it to build your personal or enterprise knowledge base.
 
----
-
-## 📄 License
-
-This framework is distributed under the MIT License. Feel free to use it to build your own personal or enterprise knowledge bases.
+<p align="center">
+  Built in Ukraine under air raid sirens &amp; blackouts ⚡<br>
+  &copy; 2026 Weby Homelab
+</p>

--- a/README.ua.md
+++ b/README.ua.md
@@ -2,52 +2,147 @@
   <a href="README.md">ENG</a> | <b>UKR</b>
 </p>
 
-# 🚀 P.O.W.E.R. Framework — Гібридна система управління знаннями
+# P.O.W.E.R. — AI-Native Toolkit для Obsidian
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10+-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![Pydantic v2](https://img.shields.io/badge/Pydantic-v2-E74C3C?logo=pydantic&logoColor=white)](https://docs.pydantic.dev/)
 [![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-00C853?logo=modelcontextprotocol&logoColor=white)](https://modelcontextprotocol.io/)
-[![Obsidian](https://img.shields.io/badge/Obsidian-Compatible-7C3AED?logo=obsidian&logoColor=white)](https://obsidian.md/)
 [![CI](https://github.com/weby-homelab/P.O.W.E.R/actions/workflows/ci.yml/badge.svg)](https://github.com/weby-homelab/P.O.W.E.R/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/weby-homelab/P%2EO%2EW%2EE%2ER?logo=github)](https://github.com/weby-homelab/P.O.W.E.R/releases)
-[![Tests: 79](https://img.shields.io/badge/Tests-79_passed-2ECC71?logo=pytest)](https://github.com/weby-homelab/P.O.W.E.R/tree/main/tests)
 
-Гібридна система управління знаннями (Obsidian Second Brain), що поєднує зручність структури для людини та строгу машиночитаність для ШІ-агентів. 
+Валідуйте, індексуйте та керуйте вашим vault Obsidian з терміналу — або дозвольте AI-агентам робити це через MCP.
 
-Побудована на поєднанні **P.A.R.A.** + **OKF Overlay** + **LLM-Wiki** + **Execution Rules**.
+## Швидкий старт
 
+```bash
+pip install power-framework
+
+power init ~/my-vault      # Створити структуру vault
+power lint ~/my-vault      # Перевірити биті посилання та метадані
+power index ~/my-vault     # Згенерувати каталог index.md
+```
+
+## Що всередині
+
+| Функція | Що робить |
+|---------|-----------|
+| **CLI** | `power init`, `lint`, `index`, `ingest` — керування vault з терміналу |
+| **MCP Server** | Надає `lint_vault`, `generate_index`, `ingest_note` будь-якому AI-агенту (Claude, Cursor, OpenCode) |
+| **OKF Validation** | Pydantic v2 схеми забезпечують строгу валідацію метаданих кожної нотатки |
+| **Health Linting** | Знаходить биті посилання, відсутні метадані та сирітські нотатки |
+| **Auto-Sync** | Cron-сумісний скрипт з GPG-підписаними комітами для безперервного бекапу |
+
+## Для кого це
+
+- **Користувачі Obsidian**, які хочуть щоб AI-агенти розуміли та підтримували їх vault
+- **Розробники**, що будують структурований Second Brain з машиночитабельними метаданими
+- **Команди**, яким потрібне консистентне форматування нотаток та автоматична перевірка якості
+
+## Команди
+
+```
+power init <path>              Створити новий vault зі структурою P.A.R.A.
+power lint <path>              Сканування на биті посилання, відсутні метадані, сиріт
+power index <path>             Перебудувати каталог index.md з усіх нотаток
+power ingest <path> [опції]    Створити нову нотатку з валідованими OKF метаданими
+```
+
+### Приклади ingest
+
+```bash
+power ingest ~/my-vault --type Project --title "Мій Додаток" --description "Новий проєкт"
+power ingest ~/my-vault --type Resource --title "Docker Гайд" --description "Найкращі практики Docker" --tags [devops, docker] --resource "https://docs.docker.com"
+```
+
+## Налаштування MCP Server
+
+Підключіть P.O.W.E.R. до будь-якого MCP-сумісного AI-клієнта:
+
+```bash
+pip install power-framework mcp
+```
+
+**Claude Desktop** (`~/.config/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "power": {
+      "command": "python3",
+      "args": ["-m", "mcp_servers.power_server"],
+      "env": {
+        "POWER_VAULT_DIR": "/path/to/your/obsidian/vault"
+      }
+    }
+  }
+}
+```
+
+**OpenCode** (`~/.config/opencode/opencode.jsonc`):
+```jsonc
+"mcp": {
+  "power": {
+    "type": "local",
+    "command": ["python3", "-m", "mcp_servers.power_server"],
+    "enabled": true
+  }
+}
+```
+
+## Структура Vault
+
+P.O.W.E.R. організовує ваш vault за методом **P.A.R.A.** з **OKF метаданими** на кожній нотатці:
+
+```
+~/my-vault
+├── 00_Inbox/          # Швидкі захоплення та сирий матеріал
+├── 01_Projects/       # Активні проєкти з дедлайнами
+├── 02_Areas/          # Постійні сфери відповідальності
+├── 03_Resources/      # Довідники та матеріали для повторного використання
+├── 04_Archive/        # Завершені або архівовані нотатки
+├── 05_Templates/      # Шаблони нотаток з OKF frontmatter
+├── 06_Daily_Logs/     # Хронологічні логи сесій
+├── PROTOCOLS/         # Системні специфікації для AI-агентів
+├── index.md           # Авто-згенерований каталог
+└── log.md             # Хронологічний лог змін
+```
+
+Кожна нотатка починається з валідованого YAML frontmatter:
+
+```yaml
 ---
+type: Project
+title: "Мій Додаток"
+description: "Новий проєкт з чіткими цілями"
+tags: [active, dev]
+timestamp: 2026-07-02T19:00:00
+---
+```
 
-## 🎯 Архітектура системи (P.O.W.E.R.)
+## Деталі архітектури
 
-Фреймворк складається з чотирьох взаємодоповнюючі методологій:
+<details>
+<summary><strong>Методологія P.O.W.E.R. — натисніть для розгортання</strong></summary>
 
-*   **P** — **P.A.R.A.** (Projects, Areas, Resources, Archive) — логічна структура папок для організації нотаток людиною.
-*   **O** — **OKF Overlay** (Open Knowledge Format) — метадані (YAML frontmatter) у заголовку кожного файлу для парсингу ШІ.
-*   **W** — **LLM-Wiki** (філософія А. Карпати) — автоматичний індекс, журнал змін та лінтінг зв'язків.
-*   **E.R.** — **Execution Rules / Enforced Routines** (авторські правила автоматизації) — суворий GPG-підпис комітів, PR-only workflow, автоматичний 5-хвилинний sync-brain та правила очищення гілок.
+Фреймворк поєднує чотири комплементарні методології:
 
-### 📊 Візуальна схема фреймворку
+- **P** — **P.A.R.A.** (Projects, Areas, Resources, Archive) — логічна структура папок для людського сприйняття
+- **O** — **OKF Overlay** (Open Knowledge Format) — YAML frontmatter на кожному файлі для миттєвого AI-парсингу
+- **W** — **LLM-Wiki** — автоматична індексація каталогу, хронологічний лог та структурний лінтинг посилань
+- **E.R.** — **Execution Rules** — GPG-підписані коміти, PR-only workflow, cron-sync, очищення гілок
+
+### Візуальна діаграма
 
 ```mermaid
 graph TB
     subgraph Human ["👤 Human (Obsidian UI)"]
         PARA["P.A.R.A. Directory Structure"]
-        PARA_P["01_Projects"]
-        PARA_A["02_Areas"]
-        PARA_R["03_Resources"]
-        PARA_AR["04_Archive"]
-        PARA --> PARA_P
-        PARA --> PARA_A
-        PARA --> PARA_R
-        PARA --> PARA_AR
     end
 
-    subgraph AI ["🤖 ШІ-Агент (Локальний / Хмарний)"]
+    subgraph AI ["🤖 AI Agent (Local / Cloud)"]
         Ingest["Ingest Note"]
-        Lint["Lint Vault (lint_brain.py)"]
-        Index["Rebuild Index (generate_index.py)"]
+        Lint["Lint Vault"]
+        Index["Rebuild Index"]
     end
 
     subgraph OKF ["📄 OKF Overlay (Metadata Schema)"]
@@ -56,220 +151,52 @@ graph TB
         LogMD["log.md (Change Log)"]
     end
 
-    subgraph ER ["🔐 Execution Rules & Enforced Routines"]
-        GPG["GPG Signature (Verified Commit)"]
-        PR["PR-Only Workflow (GitHub)"]
-        Sync["Cron Autosync (sync-brain.sh)"]
-        Clean["Branch Cleanup (cleanup_branches.py)"]
-    end
-
     Human -- Writes Notes --> YAML
     YAML -- Parsed by --> AI
     AI -- Updates --> IndexMD
     AI -- Appends --> LogMD
     AI -- Runs Checks --> Lint
-    
-    IndexMD -- Synchronized via --> Sync
-    LogMD -- Synchronized via --> Sync
-    
-    Sync -- Requires --> GPG
-    Sync -- Follows --> PR
-    PR -- Triggers --> Clean
-    
-    classDef human fill:#1A365D,stroke:#3182CE,stroke-width:2px,color:#FFF;
-    classDef ai fill:#2C3E50,stroke:#E74C3C,stroke-width:2px,color:#FFF;
-    classDef okf fill:#1B4D3E,stroke:#2ECC71,stroke-width:2px,color:#FFF;
-    classDef er fill:#5D3F6A,stroke:#BB8FCE,stroke-width:2px,color:#FFF;
-    
-    class PARA,PARA_P,PARA_A,PARA_R,PARA_AR human;
-    class Ingest,Lint,Index ai;
-    class YAML,IndexMD,LogMD okf;
-    class GPG,PR,Sync,Clean er;
 ```
 
----
-
-## 📂 Структура каталогів бази знань
-
-База знань Obsidian (Second Brain) організована наступним чином:
-
-```text
-/brain
-├── 00_Inbox/                    # Тимчасова папка для швидких нотаток та сирих даних
-├── 01_Projects/                 # Активні проєкти з чіткими дедлайнами та цілями
-├── 02_Areas/                    # Сфери відповідальності (інфраструктура, фінанси, здоров'я)
-├── 03_Resources/                # Загальні ресурси (гайди, інструкції, сниппети, скрипти)
-│   └── lint_brain.py            # Скрипт валідації та очищення зв'язків
-├── 04_Archive/                  # Архів закритих проєктів та застарілих нотаток
-├── 05_Templates/                # Шаблони нотаток із предзаповненим OKF-форматом
-├── 06_Daily_Logs/               # Щоденні звіти ШІ-сесій та уроки (MASTER-LESSONS-LEARNED)
-├── PROTOCOLS/                   # Системні специфікації для ШІ-агентів
-│   └── LLM_WIKI_SCHEMA.md       # Суворі правила форматування та лінтінгу
-├── index.md                     # Автоматично генерований каталог усіх документів
-└── log.md                       # Хронологічний журнал змін бази знань (append-only)
-```
-
----
-
-## 🏗️ Архітектура проєкту (power_core)
-
-Фреймворк побудований на спільному Python-пакеті `power_core`, який надає:
+### Бібліотека (`power_core`)
 
 | Модуль | Призначення |
-|--------|-------------|
-| `power_core/models.py` | Pydantic v2 схеми для строгої валідації OKF-метаданих |
-| `power_core/parser.py` | Безпечний парсинг YAML frontmatter (на базі PyYAML) |
-| `power_core/indexer.py` | Сканування ваулту та генерація index.md |
-| `power_core/linter.py` | Перевірка здоров'я: биті посилання, відсутні метадані, сироти |
-| `power_core/utils.py` | Захист від Path Traversal, atomic write, управління бекапами |
+|--------|------------|
+| `models.py` | Pydantic v2 схеми для OKF валідації метаданих |
+| `parser.py` | Безпечний YAML frontmatter парсинг (PyYAML) |
+| `indexer.py` | Сканування vault та генерація index.md |
+| `linter.py` | Перевірки: биті посилання, відсутні метадані, сироти |
+| `utils.py` | Захист від path traversal, атомарний запис, бекапи |
+| `cli.py` | Командний рядок (init, lint, index, ingest) |
 
-Усі компоненти (MCP-сервер, CLI-скрипти) використовують `power_core` як єдине джерело істини, що усуває дублювання коду та забезпечує узгодженість.
+Всі компоненти використовують `power_core` як єдине джерело правди.
 
----
+</details>
 
-## 📄 Специфікація метаданих (OKF)
-
-Кожна нотатка повинна містити суворий YAML-блок (frontmatter) на початку файлу. Це дозволяє ШІ-агентам миттєво індексувати та фільтрувати інформацію:
-
-```yaml
----
-type: Project | Area | Resource | Daily Log | Archive | System Guide  # Тип документа
-title: "Назва документа"                                               # Візуальний заголовок
-description: "Опис в один рядок (до 150 символів) для каталогу"       # Коротке резюме
-resource: "https://github.com/..."                                    # Посилання на код або джерело
-tags: [active, guide]                                                 # Теги для Obsidian
-timestamp: YYYY-MM-DDTHH:MM:SS+TZ                                      # Мітка останньої зміни
----
-```
-
----
-
-## 🤖 Процес лінтінгу (Health Linting)
-
-Скрипт `lint_brain.py` використовується для періодичної (або за запитом) перевірки цілісності бази знань.
-
-### Можливості перевірки:
-1.  **Биті посилання (Broken Links)**: Виявляє внутрішні лінки `[[Note]]` та `[Title](Path.md)`, які вказують на неіснуючі файли.
-2.  **Валідація метаданих**: Знаходить файли з відсутнім YAML-заголовком або некоректним полем `type`.
-3.  **Виявлення сторінок-сиріт (Orphans)**: Показує сторінки, на які немає жодного вхідного посилання (за винятком індексу).
-
----
-
-## 🔐 Налаштування безпеки та автоматизації (E.R.)
-
-1.  **Zero-Secrets**: Жодних паролів, API-ключів та внутрішніх IP-адрес у репозиторії. Усі чутливі змінні середовища зберігаються в локальному файлі `.env` на сервері та додані до `.gitignore`.
-2.  **Verified Commits (GPG)**: Усі коміти повинні бути підписані персональним GPG-ключем розробника для запобігання підміні авторів у публічному середовищі.
-3.  **PR-only Workflow**: Зміни вносяться в окремі гілки `feature/*`, пушаться на GitHub і зливаються через Pull Request після перевірки.
-4.  **Auto-Sync Cron**: На сервері налаштовано cron-задачу, яка кожні 5 хвилин синхронізує локальні зміни у ваулті з віддаленим репозиторієм GitHub.
-
----
-
-## ⚡ Встановлення P.O.W.E.R. Agent Skill та MCP-сервера
-
-Ми об'єднали правила фреймворку P.O.W.E.R. та інструменти валідації/індексації у два готових компоненти:
-1. **AI Agent Custom Skill**: Набір інструкцій (`SKILL.md`) та скриптів (`scripts/`), які можна імпортувати в будь-яку платформу агентів, що підтримує кастомні інструкції або ін'єкцію скіллів.
-2. **Model Context Protocol (MCP) Server**: Автономний портативний Python-сервер (`mcp_servers/power_server.py`), який надає три MCP-інструменти (`lint_vault`, `generate_index` та `ingest_note`) для будь-яких сумісних ШІ-клієнтів (Claude Desktop, Cursor, OpenCode тощо).
-
-Ці компоненти універсально працюють із будь-яким ШІ-агентом — як локально, так і в хмарі.
-
-### ⚙️ Встановлення однією командою
-
-Щоб автоматично встановити скілл P.O.W.E.R. та MCP-сервер у ваш робочий простір для роботи з будь-яким ШІ-агентом локально чи в хмарі, виконайте наступну команду:
-
-```bash
-curl -sSL https://raw.githubusercontent.com/weby-homelab/P.O.W.E.R/main/install.sh | bash
-```
-
-Ви також можете вказати інший цільовий каталог для встановлення:
-```bash
-curl -sSL https://raw.githubusercontent.com/weby-homelab/P.O.W.E.R/main/install.sh | bash -s -- /шлях/до/вашого/простору
-```
-
-### 🔌 Налаштування MCP-сервера
-
-Після виконання інсталятора:
-1. Встановіть необхідні залежності Python у вашому цільовому середовищі виконання:
-   ```bash
-   pip install mcp
-   ```
-2. Налаштуйте ваш ШІ-клієнт для підключення MCP-сервера:
-   * **Claude Desktop** (`~/.config/Claude/claude_desktop_config.json`):
-     ```json
-     {
-       "mcpServers": {
-         "power": {
-           "command": "python3",
-           "args": ["/шлях/до/простору/.agents/mcp_servers/power_server.py"],
-           "env": {
-             "POWER_VAULT_DIR": "/шлях/до/вашого/obsidian/ваулту"
-           }
-         }
-       }
-     }
-     ```
-   * **OpenCode** (`~/.config/opencode/opencode.jsonc`):
-     ```json
-     "mcp": {
-       "power": {
-         "type": "local",
-         "command": [
-           "/root/.config/opencode/venv/bin/python",
-           "/шлях/до/простору/.agents/mcp_servers/power_server.py"
-         ],
-         "enabled": true
-       }
-     }
-     ```
-
-### 🔌 Ручне налаштування скілла (Опціонально)
-Якщо ви бажаєте встановити скілл вручну:
-1. Скопіюйте вміст папки `skills/power` у директорію `.agents/skills/power` вашого робочого простору.
-2. Надайте права на виконання скриптам: `chmod +x .agents/skills/power/scripts/*.py`
-3. Зареєструйте скілл в OpenCode, додавши шлях до конфігурації `~/.config/opencode/opencode.jsonc`:
-   ```json
-   "instructions": [
-     "/шлях/до/простору/.agents/skills/power/SKILL.md"
-   ]
-   ```
-
----
-
-## 🛠️ Розробка
-
-### Налаштування
+## Розробка
 
 ```bash
 git clone https://github.com/weby-homelab/P.O.W.E.R.git
 cd P.O.W.E.R
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
-```
 
-### Перевірка якості
-
-```bash
 # Запуск тестів
 pytest tests/ -v
 
-# Lint
+# Лінтинг та форматування
 ruff check power_core/ mcp_servers/ scripts/ tests/
-
-# Форматування
 ruff format power_core/ mcp_servers/ scripts/ tests/
 
 # Перевірка типів
 mypy power_core/
 ```
 
-### Скрипти автоматизації
+## Ліцензія
 
-| Скрипт | Призначення |
-|--------|-------------|
-| `scripts/sync-brain.sh` | Cron-сумісний авто-синк з підтримкою GPG-підпису |
-| `scripts/cleanup_branches.py` | Автоматичне очищення злитих гілок через GitHub API |
+MIT — використовуйте для особистої або корпоративної бази знань.
 
----
-
-## 📄 Ліцензія
-
-Цей проєкт поширюється за ліцензією MIT. Ви можете вільно використовувати його для побудови власних персональних або корпоративних систем знань.
+<p align="center">
+  Створено в Україні під час повітряних тривог та блекаутів ⚡<br>
+  &copy; 2026 Weby Homelab
+</p>

--- a/power_core/__init__.py
+++ b/power_core/__init__.py
@@ -41,6 +41,7 @@ from .utils import (
     resolve_vault_path,
     validate_vault_path,
 )
+from .cli import main as cli_main
 
 __all__ = [
     "__version__",
@@ -68,4 +69,5 @@ __all__ = [
     "atomic_write",
     "create_backup",
     "clean_note_name",
+    "cli_main",
 ]

--- a/power_core/cli.py
+++ b/power_core/cli.py
@@ -1,0 +1,229 @@
+"""
+P.O.W.E.R. CLI — AI-Native Toolkit for Obsidian.
+
+Usage:
+    power init ~/my-vault
+    power lint ~/my-vault
+    power index ~/my-vault
+    power ingest ~/my-vault --type Project --title "My Project" --description "A new project"
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from .indexer import generate_log_initial, run_generate_index
+from .linter import run_lint_report
+from .models import NoteType, OKFMetadata
+from .parser import build_frontmatter
+from .utils import __version__, atomic_write
+
+VAULT_STRUCTURE = [
+    "00_Inbox",
+    "01_Projects",
+    "02_Areas",
+    "03_Resources",
+    "04_Archive",
+    "05_Templates",
+    "06_Daily_Logs",
+    "PROTOCOLS",
+]
+
+TEMPLATE_NOTE = """\
+---
+type: {type}
+title: "{title}"
+description: "{description}"
+tags: []
+timestamp: {timestamp}
+---
+
+# {title}
+
+Your content here.
+"""
+
+
+def _resolve_path(path_str: str) -> Path:
+    """Resolve a vault path from CLI argument or environment variable."""
+    if path_str:
+        return Path(path_str).expanduser().resolve()
+    env_val = os.getenv("POWER_VAULT_DIR")
+    if env_val:
+        return Path(env_val).resolve()
+    return Path.cwd().resolve()
+
+
+def _cmd_init(args: argparse.Namespace) -> int:
+    """Create a new OKF-compliant vault structure."""
+    vault_dir = _resolve_path(args.path)
+
+    if vault_dir.exists() and any(vault_dir.iterdir()):
+        print(f"⚠️  Directory {vault_dir} is not empty. Use an empty directory or a new path.")
+        return 1
+
+    created = []
+    for entry in VAULT_STRUCTURE:
+        dir_path = vault_dir / entry
+        dir_path.mkdir(parents=True, exist_ok=True)
+        created.append(f"  {entry}/")
+
+    # Create index.md
+    index_path = vault_dir / "index.md"
+    atomic_write(index_path, "")
+    created.append("  index.md")
+
+    # Create a minimal template note
+    template_path = vault_dir / "05_Templates" / "default.md"
+    content = TEMPLATE_NOTE.format(
+        type="Resource",
+        title="Template Note",
+        description="Default OKF template for new notes",
+        timestamp=datetime.now().isoformat(),
+    )
+    atomic_write(template_path, content)
+    created.append("  05_Templates/default.md")
+
+    # Create initial log.md
+    generate_log_initial(vault_dir, 0)
+    created.append("  log.md")
+
+    print(f"Created vault structure at {vault_dir}")
+    for item in created:
+        print(item)
+    print()
+    print("Next steps:")
+    print(f"  power index {args.path}")
+    print(f"  power lint  {args.path}")
+    return 0
+
+
+def _cmd_lint(args: argparse.Namespace) -> int:
+    """Run health lint on the vault."""
+    vault_dir = _resolve_path(args.path)
+    if not vault_dir.exists():
+        print(f"Vault not found: {vault_dir}")
+        return 1
+
+    report = run_lint_report(vault_dir)
+    print(report)
+    return 0
+
+
+def _cmd_index(args: argparse.Namespace) -> int:
+    """Generate index.md from vault notes."""
+    vault_dir = _resolve_path(args.path)
+    if not vault_dir.exists():
+        print(f"Vault not found: {vault_dir}")
+        return 1
+
+    msg = run_generate_index(vault_dir)
+    print(f"Generated index.md: {msg}")
+    return 0
+
+
+def _cmd_ingest(args: argparse.Namespace) -> int:
+    """Create a new note with OKF metadata."""
+    vault_dir = _resolve_path(args.path)
+    if not vault_dir.exists():
+        print(f"Vault not found: {vault_dir}")
+        return 1
+
+    note_type = args.type
+    title = args.title
+    description = args.description
+    resource = args.resource
+    tags = args.tags or []
+
+    # Determine target directory based on type
+    type_dir_map = {
+        "Project": "01_Projects",
+        "Area": "02_Areas",
+        "Resource": "03_Resources",
+        "Daily Log": "06_Daily_Logs",
+        "Archive": "04_Archive",
+        "System Guide": "PROTOCOLS",
+    }
+    target_dir = vault_dir / type_dir_map.get(note_type, "00_Inbox")
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create filename from title
+    safe_name = title.lower().replace(" ", "_").replace("/", "-")
+    note_path = target_dir / f"{safe_name}.md"
+
+    if note_path.exists() and not args.overwrite:
+        print(f"Note already exists: {note_path}")
+        print("Use --overwrite to replace it.")
+        return 1
+
+    metadata = OKFMetadata(
+        type=NoteType(note_type),
+        title=title,
+        description=description,
+        resource=resource,
+        tags=tags,
+        timestamp=datetime.now(),
+    )
+    fm = build_frontmatter(metadata)
+    body = f"{fm}\n\n# {title}\n\n"
+    atomic_write(note_path, body)
+    print(f"Created note: {note_path.relative_to(vault_dir)}")
+    return 0
+
+
+def main() -> None:
+    """P.O.W.E.R. CLI entry point."""
+    parser = argparse.ArgumentParser(
+        prog="power",
+        description="AI-Native Toolkit for Obsidian — validate, index, and manage your knowledge base.",
+    )
+    parser.add_argument(
+        "-v", "--version",
+        action="version",
+        version=f"power {__version__}",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # power init
+    p_init = subparsers.add_parser("init", help="Create a new OKF-compliant vault structure")
+    p_init.add_argument("path", help="Path to the vault directory")
+    p_init.set_defaults(func=_cmd_init)
+
+    # power lint
+    p_lint = subparsers.add_parser("lint", help="Run health lint on the vault")
+    p_lint.add_argument("path", help="Path to the vault directory")
+    p_lint.set_defaults(func=_cmd_lint)
+
+    # power index
+    p_index = subparsers.add_parser("index", help="Generate index.md from vault notes")
+    p_index.add_argument("path", help="Path to the vault directory")
+    p_index.set_defaults(func=_cmd_index)
+
+    # power ingest
+    p_ingest = subparsers.add_parser("ingest", help="Create a new note with OKF metadata")
+    p_ingest.add_argument("path", help="Path to the vault directory")
+    p_ingest.add_argument(
+        "--type", "-t",
+        required=True,
+        choices=[t.value for t in NoteType],
+        help="OKF note type",
+    )
+    p_ingest.add_argument("--title", required=True, help="Note title")
+    p_ingest.add_argument("--description", required=True, help="Short summary (max 150 chars)")
+    p_ingest.add_argument("--resource", default=None, help="External URL (optional)")
+    p_ingest.add_argument("--tags", nargs="*", default=[], help="Obsidian tags")
+    p_ingest.add_argument("--overwrite", action="store_true", help="Overwrite existing note")
+    p_ingest.set_defaults(func=_cmd_ingest)
+
+    args = parser.parse_args()
+
+    if not hasattr(args, "func"):
+        parser.print_help()
+        sys.exit(1)
+
+    sys.exit(args.func(args))

--- a/power_core/utils.py
+++ b/power_core/utils.py
@@ -145,4 +145,4 @@ def is_excluded_orphan(filename: str, rel_path: str) -> bool:
     return filename in EXCLUDED_ORPHAN_FILES or rel_path.startswith("06_Daily_Logs/")
 
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "power-framework"
-version = "1.3.0"
-description = "P.O.W.E.R. - Hybrid Knowledge Management Framework (P.A.R.A. + OKF Overlay + LLM-Wiki + Execution Rules)"
+version = "1.4.0"
+description = "AI-native toolkit for Obsidian knowledge bases — validate, index, and manage notes via CLI or MCP"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
@@ -29,6 +29,9 @@ dependencies = [
     "pydantic>=2.0.0",
     "pyyaml>=6.0.0",
 ]
+
+[project.scripts]
+power = "power_core.cli:main"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

Rewrites the README to be user-first and adds a `power` CLI entry point.

### What changed

| File | Change |
|------|--------|
| `power_core/cli.py` | **New** — CLI with `init`, `lint`, `index`, `ingest` commands |
| `pyproject.toml` | Added `[project.scripts]` entry point, updated description, bumped to 1.4.0 |
| `README.md` | Complete rewrite: Quick Start first, architecture collapsed into `<details>` |
| `README.ua.md` | Matching Ukrainian rewrite |
| `power_core/__init__.py` | Export `cli_main` |
| `power_core/utils.py` | Bump `__version__` to 1.4.0 |

### Before vs After

**Before:** README starts with P.O.W.E.R. acronym breakdown → Mermaid diagram → internal terminology (P.A.R.A., OKF, LLM-Wiki, E.R.)

**After:** README starts with value proposition → `pip install` + 3 commands → "What's Inside" table → "Who Is This For" → architecture in expandable `<details>`

### CLI Usage

```bash
pip install power-framework

power init ~/my-vault      # Create vault structure
power lint ~/my-vault      # Check for broken links & missing metadata  
power index ~/my-vault     # Generate catalog index.md
power ingest ~/my-vault --type Project --title "My App" --description "A new project"
```

### Architecture

No changes to core logic (`indexer.py`, `linter.py`, `models.py`, `parser.py`). Only additions and presentation changes.

Closes #5