### PR TITLE
fix: sort imports in __init__.py to pass ruff I001

### DIFF
--- a/power_core/__init__.py
+++ b/power_core/__init__.py
@@ -14,6 +14,7 @@ Usage:
 
 from __future__ import annotations
 
+from .cli import main as cli_main
 from .indexer import generate_index_content, run_generate_index, scan_vault_notes
 from .linter import LintResult, run_lint_report, run_lint_vault
 from .models import (
@@ -41,7 +42,6 @@ from .utils import (
     resolve_vault_path,
     validate_vault_path,
 )
-from .cli import main as cli_main
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
CI failed with `I001 [*] Import block is un-sorted or un-formatted` in `power_core/__init__.py`.

Moved `from .cli import main as cli_main` to its correct alphabetical position (before `.indexer`).