### PR TITLE
fix: add LLM-Wiki and Execution Rules to Mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,16 +139,25 @@ graph TB
         PARA["P.A.R.A. Directory Structure"]
     end
 
+    subgraph OKF ["📄 OKF Overlay (Metadata Schema)"]
+        YAML["YAML Frontmatter"]
+    end
+
+    subgraph Wiki ["📖 LLM-Wiki (Karpathy's Philosophy)"]
+        IndexMD["index.md (Auto Catalog)"]
+        LogMD["log.md (Change Log)"]
+        Lint["Link Linting"]
+    end
+
     subgraph AI ["🤖 AI Agent (Local / Cloud)"]
         Ingest["Ingest Note"]
-        Lint["Lint Vault"]
         Index["Rebuild Index"]
     end
 
-    subgraph OKF ["📄 OKF Overlay (Metadata Schema)"]
-        YAML["YAML Frontmatter"]
-        IndexMD["index.md (Catalog)"]
-        LogMD["log.md (Change Log)"]
+    subgraph ER ["🔐 Execution Rules"]
+        GPG["GPG-Signed Commits"]
+        PR["PR-Only Workflow"]
+        Sync["Cron Auto-Sync"]
     end
 
     Human -- Writes Notes --> YAML
@@ -156,6 +165,10 @@ graph TB
     AI -- Updates --> IndexMD
     AI -- Appends --> LogMD
     AI -- Runs Checks --> Lint
+    IndexMD -. Synced via .-> Sync
+    LogMD -. Synced via .-> Sync
+    Sync --> GPG
+    GPG --> PR
 ```
 
 ### Core Library (`power_core`)

--- a/README.ua.md
+++ b/README.ua.md
@@ -134,21 +134,30 @@ timestamp: 2026-07-02T19:00:00
 ### Візуальна діаграма
 
 ```mermaid
-graph LR
+graph TB
     subgraph Human ["👤 Human (Obsidian UI)"]
         PARA["P.A.R.A. Directory Structure"]
     end
 
+    subgraph OKF ["📄 OKF Overlay (Metadata Schema)"]
+        YAML["YAML Frontmatter"]
+    end
+
+    subgraph Wiki ["📖 LLM-Wiki (філософія Karpathy)"]
+        IndexMD["index.md (Авто-каталог)"]
+        LogMD["log.md (Лог змін)"]
+        Lint["Лінтинг посилань"]
+    end
+
     subgraph AI ["🤖 AI Agent (Local / Cloud)"]
         Ingest["Ingest Note"]
-        Lint["Lint Vault"]
         Index["Rebuild Index"]
     end
 
-    subgraph OKF ["📄 OKF Overlay (Metadata Schema)"]
-        YAML["YAML Frontmatter"]
-        IndexMD["index.md (Catalog)"]
-        LogMD["log.md (Change Log)"]
+    subgraph ER ["🔐 Execution Rules"]
+        GPG["GPG-підписані коміти"]
+        PR["PR-Only Workflow"]
+        Sync["Cron Auto-Sync"]
     end
 
     Human -- Writes Notes --> YAML
@@ -156,6 +165,10 @@ graph LR
     AI -- Updates --> IndexMD
     AI -- Appends --> LogMD
     AI -- Runs Checks --> Lint
+    IndexMD -. Synced via .-> Sync
+    LogMD -. Synced via .-> Sync
+    Sync --> GPG
+    GPG --> PR
 ```
 
 ### Бібліотека (`power_core`)


### PR DESCRIPTION
The Mermaid diagram was missing two of the four P.O.W.E.R. components:

- Added **LLM-Wiki** subgraph (index.md, log.md, link linting)
- Added **Execution Rules** subgraph (GPG, PR-only, cron sync)
- Fixed matching diagram in README.ua.md

Now all four letters (P, O, W, E.R.) are visually represented.