### PR TITLE
fix: correct Ukrainian report link in both README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ power index ~/my-vault     # Generate catalog index.md
 
 Read the full technical report on the transition from flat to hierarchical indexing:
 - **[English: Hierarchical Index Migration Report](docs/hierarchical-index-migration.md)** — performance metrics, architecture, insights
-- **[Українська: Звіт міграції на ієрархічний індекс](docs/hierarchical-index-migration.md)** — повний технічний звіт
+- **[Українська: Звіт міграції на ієрархічний індекс](docs/hierarchical-index-migration.ua.md)** — повний технічний звіт
 
 ## Who Is This For
 

--- a/README.ua.md
+++ b/README.ua.md
@@ -37,8 +37,8 @@ power index ~/my-vault     # Згенерувати каталог index.md
 ## Звіт міграції
 
 Повний технічний звіт про перехід від плоского до ієрархічного індексування:
-- **[English: Hierarchical Index Migration Report](docs/hierarchical-index-migration.md)** — метрики продуктивності, архітектура, інсайти
-- **[Українська: Звіт міграції на ієрархічний індекс](docs/hierarchical-index-migration.md)** — детальний технічний звіт з метриками
+- **[English: Hierarchical Index Migration Report](docs/hierarchical-index-migration.md)** — performance metrics, architecture, insights
+- **[Українська: Звіт міграції на ієрархічний індекс](docs/hierarchical-index-migration.ua.md)** — детальний технічний звіт з метриками
 
 ## Для кого це
 

--- a/docs/hierarchical-index-migration.ua.md
+++ b/docs/hierarchical-index-migration.ua.md
@@ -1,0 +1,488 @@
+---
+type: Resource
+title: "P.O.W.E.R. Hierarchical Index Migration Report (UA)"
+description: "Технічний звіт про перехід від плоского до ієрархічного індексування в P.O.W.E.R. framework, включаючи метрики продуктивності, причини та інсайти."
+tags: [power, indexing, performance, migration, report, ai-agents]
+timestamp: 2026-07-03T02:20:00
+---
+
+# P.O.W.E.R. Звіт міграції на ієрархічний індекс
+
+**Дата:** 03 липня 2026
+**Версія:** P.O.W.E.R. v1.4.0
+**Автор:** Weby Homelab AI Team
+**Статус:** Завершено, Production
+
+---
+
+## Зміст
+
+1. [Вступ](#вступ)
+2. [До міграції: Плоска модель](#до-міграції-плоска-модель)
+3. [Проблеми плоскої моделі](#проблеми-плоскої-моделі)
+4. [Рішення: Ієрархічна модель](#рішення-ієрархічна-модель)
+5. [Архітектура нової системи](#архітектура-нової-системи)
+6. [Метрики продуктивності](#метрики-продуктивності)
+7. [Вплив на AI-агентів](#вплив-на-ai-агентів)
+8. [Ключові інсайти та зауваження](#ключові-інсайти-та-зауваження)
+9. [Висновки](#висновки)
+10. [Додатки](#додатки)
+
+---
+
+## Вступ
+
+Цей звіт документує повний цикл розробки, тестування та деплою **ієрархічної системи індексування** для фреймворку P.O.W.E.R. (P.A.R.A. + OKF Overlay + LLM-Wiki + Execution Rules). Міграція була викликана критичною потребою оптимізації споживання контексту AI-агентів при роботі з великими базами знань.
+
+**Масштаб:** 324 нотатки в production vault
+**Ефект:** ~75-94% економії токенів при читанні індексу
+**PR:** [#13](https://github.com/weby-homelab/P.O.W.E.R/pull/13) — злито в `main`
+
+---
+
+## До міграції: Плоска модель
+
+### Структура
+
+До міграції `index.md` генерувався як **єдиний плоский каталог**, що містив всі нотатки, згруповані за типом:
+
+```markdown
+# Knowledge Catalog (OKF Index)
+
+## Projects
+- **[Power-Safety-UA](01_Projects/Power_Safety_UA.md)** - Production monitoring...
+- **[Weby-QRank](01_Projects/Weby-QRank.md)** - Community reputation...
+... (ще 12 записів)
+
+## Areas
+- **[PROD Safety Mandate](02_Areas/PROD_Safety_Mandate.md)** - Production rules...
+... (ще 9 записів)
+
+## Daily Logs
+- **[2026-07-03 Session](06_Daily_Logs/2026-07-03_session.md)** - ...
+... (ще 282 записів)
+```
+
+### Генерація
+
+```python
+# power_core/indexer.py (стара версія)
+def scan_vault_notes(vault_dir: Path):
+    concepts = {}
+    for root, dirs, files in os.walk(vault_dir):
+        for file in files:
+            if file.endswith(".md"):
+                metadata = validate_metadata(content)
+                concepts[metadata.type].append((rel_path, title, desc))
+    return concepts
+```
+
+### Результат
+
+- **Один файл** `index.md` містив **всі 324 записи**
+- Розмір файлу: ~100KB+ (залежно від кількості нотаток)
+- AI-агенти завантажували **весь файл** при кожному зверненні до brain
+- Не було механізму читання "по частинах"
+
+---
+
+## Проблеми плоскої моделі
+
+### 1. Контекстне навантаження на AI-агентів
+
+| Сценарій | Токенів | Коментар |
+|----------|---------|----------|
+| Читання всього `index.md` (324 нотатки) | ~25,000+ | Кожен запит до brain |
+| Читання + аналіз конкретного проєкту | ~30,000+ | index.md + нотатка |
+| Читання всіх `.md` файлів vault | ~500,000+ | Катастрофа |
+
+**Проблема:** Навіть коли агенту потрібна інформація про один проєкт, він змушений завантажувати індекс з 324 записами, 285 з яких — Daily Logs, які йому не потрібні.
+
+### 2. Лінійне зростання з розміром vault
+
+```
+Токени = O(n) де n = кількість нотаток
+
+100 нотаток  → ~8,000 токенів
+500 нотаток  → ~40,000 токенів  ← вже критично
+1,000 нотаток → ~80,000 токенів ← займає половину контексту
+5,000 нотаток → ~400,000 токенів ← неможливо працювати
+```
+
+### 3. Відсутність on-demand доступу
+
+Агент не міг:
+- Отримати список нотаток **тільки** з `01_Projects/`
+- Побачити деталі (теги, дати, шляхи) **тільки** для релевантної категорії
+- Уникнути завантаження 285 записів Daily Logs коли шукає інформацію про проєкт
+
+### 4. Неефективність для nested структур
+
+Vault містить підпапки:
+```
+01_Projects/
+├── Power-Safety-UA/
+│   ├── Release v3.2.3.md
+│   └── Architecture.md
+├── Weby-QRank/
+│   └── Backend.md
+└── Docker-Mailserver-GUI.md
+```
+
+Плоский індекс не відображав цю ієрархію — всі нотатки були "в купі".
+
+---
+
+## Рішення: Ієрархічна модель
+
+### Концепція
+
+Замість одного великого файлу — **дворівнева система**:
+
+```
+Рівень 1: index.md          → Навігаційна карта (хто є, скільки нотаток)
+Рівень 2: */_index.md       → Детальні каталоги по категоріях
+```
+
+### Принцип роботи
+
+```
+Агент запитує: "Що таке Power-Safety-UA?"
+
+Старий підхід:
+1. Завантажити index.md (25,000 токенів) ← ВСІ 324 записи
+2. Знайти Power-Safety-UA в списку
+3. Прочитати нотатку
+
+Новий підхід:
+1. Завантажити index.md (1,000 токенів) ← ТІЛЬКИ таблиця
+2. Бачить: "01_Projects: 15 нотаток"
+3. Викликає read_sub_index("01_Projects") (5,000 токенів)
+4. Знаходить Power-Safety-UA з описом
+5. Прочитати нотатку
+
+Економія: 25,000 → 6,000 токенів (76%)
+```
+
+---
+
+## Архітектура нової системи
+
+### Файлова структура
+
+```
+vault/
+├── index.md                    # 1,015 bytes — навігаційна карта
+├── log.md                      # хронологічний журнал
+├── 00_Inbox/
+│   └── _index.md               # 3 нотатки
+├── 01_Projects/
+│   ├── _index.md               # 15 нотаток
+│   └── Power-Safety-UA/
+│       └── _index.md           # nested sub-index
+├── 02_Areas/
+│   └── _index.md               # 10 нотаток
+├── 03_Resources/
+│   └── _index.md               # 8 нотаток
+├── 04_Archive/
+│   └── _index.md               # 3 нотатки
+└── 06_Daily_Logs/
+    └── _index.md               # 285 нотаток (найбільший)
+```
+
+### Приклад `index.md` (Рівень 1)
+
+```markdown
+---
+type: System Guide
+title: "Second Brain Index"
+description: "Hierarchical navigation map for the knowledge vault"
+timestamp: 2026-07-03T02:16:19
+---
+
+# Knowledge Catalog
+
+## Navigation Map
+
+| Category | Notes | Sub-Index |
+|----------|-------|-----------|
+| 00 Inbox | 3 | [_index.md](00_Inbox/_index.md) |
+| 01 Projects | 15 | [_index.md](01_Projects/_index.md) |
+| 02 Areas | 10 | [_index.md](02_Areas/_index.md) |
+| 03 Resources | 8 | [_index.md](03_Resources/_index.md) |
+| 04 Archive | 3 | [_index.md](04_Archive/_index.md) |
+| 06 Daily Logs | 285 | [_index.md](06_Daily_Logs/_index.md) |
+
+## Agent Protocol
+
+1. **Read this file** — identify the relevant category.
+2. **Read the sub-index** — load `folder/_index.md` for detailed entries.
+3. **Read specific notes** — only when the sub-index indicates relevance.
+4. **NEVER glob all `.md` files** — use sub-indexes as a map.
+```
+
+### Приклад `_index.md` (Рівень 2)
+
+```markdown
+---
+type: System Guide
+title: "01 Projects Sub-Index"
+description: "Detailed catalog of all notes in 01 Projects"
+timestamp: 2026-07-03T02:16:19
+---
+
+# 01 Projects — Detailed Index
+
+## Power-Safety-UA (Power-Safety-UA) v2.0
+- **Path:** `01_Projects/Power_Safety_UA_Strategy.md`
+- **Type:** Project
+- **Description:** Hardware sensors are the only source of objective truth...
+- **Tags:** [prod, docker, monitoring]
+- **Updated:** 2026-06-05
+
+## Weby-QRank Architecture
+- **Path:** `01_Projects/Weby-QRank/Architecture.md`
+- **Type:** Project
+- **Description:** Community reputation system backend...
+- **Tags:** [telegram, community, backend]
+- **Updated:** 2026-06-28
+```
+
+### Новий MCP інструмент: `read_sub_index`
+
+```python
+@server.call_tool()
+async def call_tool(name, arguments):
+    if name == "read_sub_index":
+        category = arguments["category"]  # "01_Projects"
+        sub_index_path = vault_path / category / "_index.md"
+        if sub_index_path.exists():
+            return sub_index_path.read_text()
+        # Auto-generate if missing
+        return run_generate_sub_index(vault_path, category)
+```
+
+---
+
+## Метрики продуктивності
+
+### Розмір файлів
+
+| Файл | Розмір | Токенів (приблизно) |
+|------|--------|---------------------|
+| `index.md` (новий) | 1,015 bytes | ~250 |
+| `index.md` (старий) | ~100,000 bytes | ~25,000 |
+| `01_Projects/_index.md` | 5,353 bytes | ~1,300 |
+| `06_Daily_Logs/_index.md` | 100,391 bytes | ~25,000 |
+
+### Сценарії використання
+
+#### Сценарій 1: Пошук інформації про проєкт
+
+| Підхід | Токенів | Ефективність |
+|--------|---------|-------------|
+| Старий (flat index) | 25,000 | Завантажує ВСЕ |
+| Новий (index + sub-index) | 1,550 | Тільки релевантне |
+| **Економія** | **23,450 (94%)** | |
+
+#### Сценарій 2: Повний огляд vault
+
+| Підхід | Токенів | Ефективність |
+|--------|---------|-------------|
+| Старий (flat index) | 25,000 | Один файл |
+| Новий (index + всі sub-indexes) | 53,000 | Розподілено |
+| **Примітка** | Більше сумарно, але **завантажується частинами** | |
+
+#### Сценарій 3: Щоденна робота (90% випадків)
+
+Агенту потрібна інформація з **однієї категорії**:
+
+| Підхід | Токенів |
+|--------|---------|
+| Старий | 25,000 (завжди весь index) |
+| Новий | 1,550 (index + один sub-index) |
+| **Економія** | **23,450 (94%)** |
+
+### Масштабованість
+
+| Кількість нотаток | Flat index (токени) | Hierarchical (токени) | Економія |
+|-------------------|---------------------|----------------------|----------|
+| 100 | ~8,000 | ~1,200 | 85% |
+| 324 (поточний) | ~25,000 | ~1,550 | 94% |
+| 1,000 | ~80,000 | ~2,500 | 97% |
+| 5,000 | ~400,000 | ~5,000 | 99% |
+
+**Висновок:** Чим більший vault — тим більша економія. Ієрархічна модель масштабується **O(log n)**, тоді як плоска — **O(n)**.
+
+---
+
+## Вплив на AI-агентів
+
+### Зміна поведінки агентів
+
+**До:**
+```
+1. Отримав запит → прочитав index.md (25K токенів)
+2. Знайшов категорію → прочитав нотатку
+3. Загальна витрата: 25K + нотатка
+```
+
+**Після:**
+```
+1. Отримав запит → прочитав index.md (1K токенів)
+2. Визначив категорію → read_sub_index("01_Projects") (5K токенів)
+3. Знайшов нотатку → прочитав нотатку
+4. Загальна витрата: 6K + нотатка
+```
+
+### Оновлені конфігурації
+
+**`AGENTS.md` (v11.0):**
+- Додано Hierarchical Navigation Protocol
+- Додано заборону на `glob **/*.md`
+- Додано Token Efficiency Table
+
+**`opencode.jsonc` — оновлені system prompts:**
+- `build` — "HIERARCHICAL INDEX PROTOCOL" з 4 правилами
+- `reviewer` — "NEVER glob **/*.md"
+- `architect` — "Use MCP read_sub_index()"
+- `explorer` — "NEVER glob **/*.md"
+
+### Оновлення MCP Server
+
+| Інструмент | Статус | Призначення |
+|-----------|--------|-------------|
+| `lint_vault` | Існуючий | Перевірка здоров'я vault |
+| `generate_index` | Оновлений | Генерація ієрархічного індексу |
+| `read_sub_index` | Новий | On-demand читання категорії |
+| `ingest_note` | Оновлений | Створення нотатки + оновлення індексу |
+
+---
+
+## Ключові інсайти та зауваження
+
+### Технічні інсайти
+
+1. **NameError в f-string:** `f"[{_index.md}]"` інтерпретує `_index` як змінну. Правильно: `f"[_index.md]"`. Ця помилка зламала 7 тестів одночасно.
+
+2. **PEP 668 (Externally-Managed Environments):** На Ubuntu 24.04+ `pip3 install` блокується. Рішення: використовувати venv або `--break-system-packages`. Для MCP-серверів opencode використовує власний venv у `/root/.config/opencode/venv/`.
+
+3. **Git rebase conflicts:** Коли remote branch має дивергентні коміти, `git reset --hard origin/main` + force push чистіший за вирішення 6-файлових merge conflictів.
+
+4. **Backward compatibility:** `run_generate_index()` (flat mode) збережено для зворотної сумісності. Існуючий код не зламається.
+
+### Архітектурні рішення
+
+5. **Чому таблиця, а не список:** Таблиця в `index.md` дає миттєвий огляд кількості нотаток по категоріях без читання деталей. Агент бачить "06_Daily_Logs: 285" і розуміє — це велика категорія, читати тільки якщо потрібно.
+
+6. **Чому не видаляти flat mode:** Деякі інструменти можуть залежати від старого формату. Збереження обох режимів дає гнучкість міграції.
+
+7. **Nested sub-indexes:** Система автоматично генерує `_index.md` для підпапок (наприклад, `01_Projects/Power-Safety-UA/_index.md`). Це дозволяє агенту drill down ще глибше.
+
+### Застереження
+
+8. **Daily Logs — найбільша категорія:** 285 нотаток в одному `_index.md` (~100KB). Для дуже активних vault варто розглянути місячну агрегацію (`06_Daily_Logs/2026-07/_index.md`).
+
+9. **Індекс не замінює пошук:** `_index.md` містить тільки метадані (назва, опис, теги). Для пошуку за вмістом нотаток потрібен повнотекстовий пошук (FTS).
+
+10. **Агенти потребують навчання:** Без оновлених system prompts агенти продовжуватимуть читати всі `.md` файли. Критично оновити `AGENTS.md` та `opencode.jsonc`.
+
+### Оптимізація
+
+11. **Token Efficiency — реальні цифри:**
+    - Flat index для 324 нотаток: ~25,000 токенів
+    - Hierarchical (index + 1 sub-index): ~1,550 токенів
+    - Для типового запиту (90% випадків): **94% економії**
+
+12. **Масштабованість:** При 5,000 нотаток flat index займе ~400,000 токенів (половина контексту GPT-4). Hierarchical — ~5,000 токенів (1.25%).
+
+---
+
+## Висновки
+
+### Досягнення
+
+1. **75-94% економії токенів** при типових запитах AI-агентів до Second Brain
+2. **Масштабована архітектура** — O(log n) замість O(n)
+3. **On-demand доступ** — агенти читають тільки релевантні категорії
+4. **Backward compatible** — існуючий код продовжує працювати
+5. **100/100 тестів** — повне покриття нової функціональності
+6. **Production deploy** — 324 нотатки проіндексовано, MCP server оновлено
+7. **Агенти навчені** — всі system prompts оновлено з hierarchical rules
+
+### Підсумкові метрики
+
+| Метрика | До | Після | Зміна |
+|---------|----|------|-------|
+| Розмір index.md | ~100KB | 1KB | -99% |
+| Токенів на запит | ~25,000 | ~1,550 | -94% |
+| Файлів індексу | 1 | 10 | +9 |
+| Тестів | 80 | 100 | +20 |
+| MCP інструментів | 3 | 4 | +1 |
+
+### Рекомендації для колег
+
+1. **Завжди використовуйте `read_sub_index`** замість читання всього vault
+2. **Ніколи не робіть `glob **/*.md`** — це спалює токени без користі
+3. **Оновлюйте індекс після кожної зміни** — викликайте `generate_index`
+4. **Дотримуйтесь OKF frontmatter** — без нього нотатка не потрапить в індекс
+5. **Моніторьте розмір Daily Logs** — при >500 нотатках розгляньте місячну агрегацію
+
+### Майбутні покращення
+
+- [ ] Місячна агрегація для Daily Logs (`06_Daily_Logs/YYYY-MM/_index.md`)
+- [ ] Full-text search (FTS) інтеграція для пошуку за вмістом
+- [ ] Incremental indexing — оновлювати тільки змінені папки
+- [ ] Sub-index compression для дуже великих категорій
+- [ ] MCP tool `search_notes(query)` для повнотекстового пошуку
+
+---
+
+## Додатки
+
+### A. Змінені файли (PR #13)
+
+| Файл | Змін рядків | Призначення |
+|------|------------|-------------|
+| `power_core/indexer.py` | +190 | Ядро ієрархічного індексу |
+| `power_core/__init__.py` | +16 | Нові експорти |
+| `power_core/cli.py` | +12 | Hierarchical за замовчуванням |
+| `mcp_servers/power_server.py` | +91 | read_sub_index tool |
+| `skills/power/SKILL.md` | +41 | Navigation Protocol |
+| `skills/power/scripts/generate_index.py` | +14 | Оновлений CLI |
+| `tests/conftest.py` | +19 | Nested fixture |
+| `tests/test_indexer.py` | +199 | 20 нових тестів |
+| `tests/test_linter.py` | +2 | Оновлений count |
+| `README.md` | +49 | Оновлена документація |
+
+**Всього:** +585 / -48 рядків, 10 файлів
+
+### B. Команди для використання
+
+```bash
+# Генерація ієрархічного індексу
+power index /path/to/vault
+
+# Через Python
+python3 -c "
+from power_core import run_generate_hierarchical_index
+from pathlib import Path
+run_generate_hierarchical_index(Path('/path/to/vault'))
+"
+
+# Через MCP (в агенті)
+# read_sub_index(category="01_Projects")
+# generate_index()
+```
+
+### C. Посилання
+
+- **Репозиторій:** https://github.com/weby-homelab/P.O.W.E.R
+- **PR #13:** https://github.com/weby-homelab/P.O.W.E.R/pull/13 (реалізація hierarchical index)
+- **PR #14:** https://github.com/weby-homelab/P.O.W.E.R/pull/14 (цей звіт)
+
+---
+
+*Звіт підготовлено: 2026-07-03T02:20:00Z*
+*P.O.W.E.R. Framework v1.4.0*
+*Weby Homelab AI Team*


### PR DESCRIPTION
## Problem

Both README.md and README.ua.md had the Ukrainian report link pointing to the English version (`docs/hierarchical-index-migration.md`) instead of a separate Ukrainian file.

## Fix

- Created `docs/hierarchical-index-migration.ua.md` — full Ukrainian translation of the migration report
- Updated `README.md` — ENG link → `hierarchical-index-migration.md`, UKR link → `hierarchical-index-migration.ua.md`
- Updated `README.ua.md` — ENG link → `hierarchical-index-migration.md`, UKR link → `hierarchical-index-migration.ua.md`

## Files Changed

| File | Changes |
|------|---------|
| `docs/hierarchical-index-migration.ua.md` | +488 lines (new) |
| `README.md` | 1 line fix |
| `README.ua.md` | 1 line fix |

**Total:** +491 / -3 lines, 3 files