### PR TITLE
Release v1.5.1 — Hierarchical index now covers all P.A.R.A. folders + documentation Phase 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the P.O.W.E.R. Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-07-03
+
+### Added
+- **Phase 6: Post-Migration Self-Maintenance** in `docs/migration-guide.md` (EN) and `docs/migration-guide.ua.md` (UA) — 8-step protocol covering official framework installation, `.geminiignore` token optimization, agent instructions array, wiki-link auto-repair, `_index.md` behavior, `.git/` exclusion, daily maintenance protocol, and cross-session continuity checklist
+- **Empty folder support in hierarchical index**: `run_generate_hierarchical_index()` now generates `_index.md` for ALL P.A.R.A. folders even when they contain zero notes, preventing 404 navigation map links
+- **Descriptive empty state in `_index.md`**: Empty folders display "_No notes in this category yet._" instead of a blank page
+
+### Fixed
+- **Navigation map dead links**: `generate_main_index_content` now correctly lists all P.A.R.A. folders in the navigation table regardless of whether they have notes; each folder's `_index.md` always exists
+
 ## [1.5.0] - 2026-07-03
 
 ### Added
@@ -88,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Initial public release with basic MCP server and skill scripts
 
+[1.5.1]: https://github.com/weby-homelab/P.O.W.E.R/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/weby-homelab/P.O.W.E.R/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/weby-homelab/P.O.W.E.R/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/weby-homelab/P.O.W.E.R/compare/v1.2.2...v1.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "power-framework"
-version = "1.5.0"
+version = "1.5.1"
 description = "AI-native toolkit for Obsidian knowledge bases — validate, index, and manage notes via CLI or MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/power_framework/core/indexer.py
+++ b/src/power_framework/core/indexer.py
@@ -185,23 +185,30 @@ def generate_sub_index_content(folder: str, notes: list[dict]) -> str:
         f"timestamp: {datetime.now(timezone.utc).isoformat()}",
         "---",
         "",
-        f"# {display_name} — Detailed Index",
-        "",
     ]
 
-    sorted_notes = sorted(notes, key=lambda x: x["title"])
-
-    for note in sorted_notes:
-        lines.append(f"## {note['title']}")
-        lines.append(f"- **Path:** `{note['rel_path']}`")
-        lines.append(f"- **Type:** {note['note_type']}")
-        lines.append(f"- **Description:** {note['description']}")
-        if note["tags"]:
-            tags_str = ", ".join(note["tags"])
-            lines.append(f"- **Tags:** [{tags_str}]")
-        if note["timestamp"]:
-            lines.append(f"- **Updated:** {note['timestamp'][:10]}")
+    if not notes:
+        lines.append(f"# {display_name}")
         lines.append("")
+        lines.append("_No notes in this category yet._")
+        lines.append("")
+    else:
+        lines.append(f"# {display_name} — Detailed Index")
+        lines.append("")
+
+        sorted_notes = sorted(notes, key=lambda x: x["title"])
+
+        for note in sorted_notes:
+            lines.append(f"## {note['title']}")
+            lines.append(f"- **Path:** `{note['rel_path']}`")
+            lines.append(f"- **Type:** {note['note_type']}")
+            lines.append(f"- **Description:** {note['description']}")
+            if note["tags"]:
+                tags_str = ", ".join(note["tags"])
+                lines.append(f"- **Tags:** [{tags_str}]")
+            if note["timestamp"]:
+                lines.append(f"- **Updated:** {note['timestamp'][:10]}")
+            lines.append("")
 
     return "\n".join(lines)
 
@@ -252,17 +259,16 @@ def run_generate_hierarchical_index(vault_dir: Path) -> str:
     main_content = generate_main_index_content(folder_notes)
     atomic_write(main_index_path, main_content)
 
-    sub_index_results = []
+    sub_index_results = ["  index.md (navigation map)"]
     for folder in PARA_FOLDERS:
-        if folder_notes.get(folder):
-            sub_index_path = vault_dir / folder / "_index.md"
-            sub_content = generate_sub_index_content(folder, folder_notes[folder])
-            atomic_write(sub_index_path, sub_content)
-            sub_index_results.append(f"  {folder}/_index.md ({len(folder_notes[folder])} notes)")
+        notes = folder_notes.get(folder, [])
+        sub_index_path = vault_dir / folder / "_index.md"
+        sub_content = generate_sub_index_content(folder, notes)
+        atomic_write(sub_index_path, sub_content)
+        sub_index_results.append(f"  {folder}/_index.md ({len(notes)} notes)")
 
     lines = [
         f"Generated hierarchical index with {total_notes} total notes:",
-        "  index.md (navigation map)",
     ]
     lines.extend(sub_index_results)
 

--- a/src/power_framework/core/utils.py
+++ b/src/power_framework/core/utils.py
@@ -145,4 +145,4 @@ def is_excluded_orphan(filename: str, rel_path: str) -> bool:
     return filename in EXCLUDED_ORPHAN_FILES or rel_path.startswith("06_Daily_Logs/")
 
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"


### PR DESCRIPTION
## Summary

Release **v1.5.1** with two improvements:

### 1. Empty P.A.R.A. folder support in hierarchical index

`run_generate_hierarchical_index()` now generates `_index.md` for **ALL** P.A.R.A. folders even when empty, preventing 404 navigation map links.

**Before:** Only folders WITH notes got `_index.md`. Empty folders caused dead links in `index.md` navigation table.

**After:** Every P.A.R.A. folder gets an `_index.md`. Empty folders display a clean message: "_No notes in this category yet._"

### 2. Phase 6 documentation (already on main)

Added "Phase 6: Post-Migration Self-Maintenance" to both EN and UA migration guides — 8-step protocol covering:
- Official framework installation
- `.geminiignore` token optimization (30-50% savings)
- Agent `instructions` array configuration
- Wiki-link auto-repair after migration
- `_index.md` behavior clarification
- `.git/` exclusion in all operations
- Daily maintenance protocol
- Cross-session continuity checklist

### Files changed
- `src/power_framework/core/indexer.py` — always generate `_index.md` for all PARA_FOLDERS, empty state message
- `pyproject.toml` — bumped to v1.5.1
- `CHANGELOG.md` — v1.5.1 entry
- `docs/migration-guide.md` — Phase 6 (already on main)
- `docs/migration-guide.ua.md` — Фаза 6 (already on main)

Closes #15