### PR TITLE
fix: remove PyPI publish step — project not registered on PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   release:
@@ -37,6 +36,3 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
-
-      - name: Publish to PyPI (Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The release workflow fails with:

```
Trusted publishing exchange failure: invalid-publisher — 
Publisher with matching claims was not found
```

The `power-framework` package has never been published to PyPI, so the OIDC trusted publisher has no corresponding configuration. Until the project is registered on PyPI and a trusted publisher is configured there, this step always fails.

**Fix:** Remove the PyPI publish step. The GitHub Release already includes `.whl` and `.tar.gz` artifacts — users can install via `pip install https://github.com/weby-homelab/P.O.W.E.R/releases/download/vX.X.X/power_framework-X.X.X-py3-none-any.whl` or `pip install git+https://github.com/weby-homelab/P.O.W.E.R.git`.

When ready for PyPI:
1. Register `power-framework` on pypi.org
2. Add trusted publisher with workflow `release.yml`
3. Add the publish step back