### PR TITLE
Fix CLI arguments and tool names in documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ src/power_framework/
 └── mcp/
     ├── __init__.py
     ├── __main__.py     # python -m entry point
-    └── server.py       # FastMCP server (5 tools)
+    └── power_server.py # FastMCP server (5 tools)
 
 tests/
 ├── test_cli.py         # CLI functional tests

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,16 +20,24 @@ power [-h] [-v] {init,lint,index,ingest,search} ...
 Scaffold a new OKF-compliant vault.
 
 ```
-power init [path]
+power init path
 ```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `path` | Yes | Path to create the vault directory |
 
 ### `lint`
 
 Run health checks on a vault.
 
 ```
-power lint [--vault-path PATH]
+power lint path
 ```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `path` | Yes | Path to the vault directory |
 
 Checks:
 - Missing or invalid YAML frontmatter
@@ -42,8 +50,12 @@ Checks:
 Generate hierarchical indexes.
 
 ```
-power index [--vault-path PATH]
+power index path
 ```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `path` | Yes | Path to the vault directory |
 
 Creates `index.md` (overview) and per-folder `_index.md` (detailed entries).
 
@@ -52,22 +64,29 @@ Creates `index.md` (overview) and per-folder `_index.md` (detailed entries).
 Create a new note with validated OKF metadata.
 
 ```
-power ingest --type TYPE --title TITLE --description DESC [--tags TAGS] [--resource URL] [--vault-path PATH]
+power ingest path --type TYPE --title TITLE --description DESC [--tags TAGS] [--resource URL] [--overwrite]
 ```
 
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--type` | Yes | Note type (`Project`, `Area`, `Resource`, `Daily Log`, `Archive`, `System Guide`) |
-| `--title` | Yes | Note title (max 120 chars) |
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `path` | Yes | Path to the vault directory |
+| `--type`, `-t` | Yes | Note type (`Project`, `Area`, `Resource`, `Daily Log`, `Archive`, `System Guide`) |
+| `--title` | Yes | Note title |
 | `--description` | Yes | One-line description (max 150 chars) |
-| `--tags` | No | Comma-separated tags |
+| `--tags` | No | Space-separated tags |
 | `--resource` | No | URL to external resource |
-| `--vault-path` | No | Path to vault |
+| `--overwrite` | No | Overwrite existing note |
 
 ### `search`
 
 Full-text search across vault notes.
 
 ```
-power search QUERY [--vault-path PATH]
+power search path query [--max-results MAX_RESULTS]
 ```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `path` | Yes | Path to the vault directory |
+| `query` | Yes | Search query (supports multiple terms and "quoted phrases") |
+| `--max-results`| No | Maximum number of results (default: 20) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,17 +41,17 @@ power ingest --title "My Note" --type Resource --description "A useful resource"
 ## Run health checks
 
 ```bash
-power lint
+power lint .
 ```
 
 ## Generate index
 
 ```bash
-power index
+power index .
 ```
 
 ## Search
 
 ```bash
-power search "my query"
+power search . "my query"
 ```

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -59,12 +59,12 @@ Create a new note with strict OKF metadata frontmatter.
 | `tags` | `string[]` | No | List of tags |
 | `vault_path` | `string` | No | Path to vault root |
 
-### `search_vault`
+### `search_vault_tool`
 
 Full-text search across vault notes.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `query` | `string` | Yes | Search query |
-| `max_results` | `integer` | No | Max results (default: 10) |
+| `max_results` | `integer` | No | Max results (default: 20) |
 | `vault_path` | `string` | No | Path to vault root |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,9 +6,6 @@ repo_url: "https://github.com/weby-homelab/power-framework"
 repo_name: weby-homelab/power-framework
 edit_uri: "edit/main/docs/"
 
-extra_files:
-  - robots.txt
-
 theme:
   name: material
   palette:
@@ -30,6 +27,7 @@ markdown_extensions:
       alternate_style: true
   - toc:
       permalink: true
+      slugify: !!python/name:pymdownx.slugs.uslugify
 
 nav:
   - Home: index.md


### PR DESCRIPTION
Closes #52

- Fixes cli.md and getting-started.md to document the required positional path argument.
- Fixes architecture.md to reference power_server.py.
- Fixes mcp-server.md to reference search_vault_tool.
- Enables Unicode slugify in mkdocs.yml.