### PR TITLE
docs: update api utils version to 1.5.1 and fix install.sh

### DIFF
--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -14,6 +14,6 @@ Utility functions for path safety, file I/O, and versioning.
 
 | Name | Value |
 |------|-------|
-| `__version__` | `"1.4.0"` |
+| `__version__` | `"1.5.1"` |
 | `VAULT_STRUCTURE` | `dict[str, str]` of P.A.R.A. folders |
 | `PARA_FOLDERS` | `list[str]` of folder names |

--- a/install.sh
+++ b/install.sh
@@ -7,10 +7,10 @@
 set -euo pipefail
 
 # Read version from source if available locally, otherwise use fallback
-if [ -f "power_core/utils.py" ]; then
-    VERSION=$(python3 -c "exec(open('power_core/utils.py').read()); print(__version__)" 2>/dev/null || echo "1.4.0")
+if [ -f "src/power_framework/core/utils.py" ]; then
+    VERSION=$(python3 -c "exec(open('src/power_framework/core/utils.py').read()); print(__version__)" 2>/dev/null || echo "1.5.1")
 else
-    VERSION="1.4.0"
+    VERSION="1.5.1"
 fi
 TARGET_DIR="${1:-$PWD}"
 REPO_URL="https://raw.githubusercontent.com/weby-homelab/power-framework/main"


### PR DESCRIPTION
Closes #60. Updates the `__version__` constant in API documentation and fixes paths/fallbacks in `install.sh`.