### PR TITLE
style: fix Ruff formatting check failure in CI (fixes #66)

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -93,4 +93,3 @@ def test_ingest_note_tool(sample_vault: Path) -> None:
         vault_path=str(sample_vault),
     )
     assert "Error: Note already exists" in result_fail
-

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -192,4 +192,3 @@ class TestNoteFile:
         )
         assert note.has_valid_metadata is False
         assert note.note_type is None
-

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -172,9 +172,8 @@ class TestSearchVault:
     def test_search_vault_fallback_on_sqlite_error(self, sample_vault: Path):
         import sqlite3
         from unittest.mock import patch
-        with patch("sqlite3.connect", side_effect=sqlite3.Error("Mocked SQLite Error")):
 
+        with patch("sqlite3.connect", side_effect=sqlite3.Error("Mocked SQLite Error")):
             results = search_vault(sample_vault, "Test")
             assert len(results) > 0
             assert any("Test" in r.title for r in results)
-


### PR DESCRIPTION
This PR applies 'ruff format' to the modified test files to fix the styling format check failure in CI.