### PR TITLE
docs: v1.8.0 MkDocs updates — FastMCP 3.x, new tools, architecture

### DIFF
--- a/docs/api/constants.md
+++ b/docs/api/constants.md
@@ -1,0 +1,11 @@
+# Constants (`power_framework.core.constants`)
+
+::: power_framework.core.constants
+    options:
+      members:
+        - EXCLUDED_DIRS
+        - EXCLUDED_ORPHAN_FILES
+        - PARA_FOLDERS_
+        - SKIP_FILES
+        - SYSTEM_SKIP_PARTS
+      show_root_heading: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,45 +5,59 @@
 ```
 src/power_framework/
 ├── __init__.py         # Public API exports
+├── py.typed            # PEP 561 marker
 ├── core/
 │   ├── __init__.py     # Re-exports all core modules
 │   ├── cli.py          # CLI entry point (argparse) — 11 commands
-│   ├── healer.py       # Frontmatter Healer (new in v1.7.1)
-│   ├── markdown_checks.py  # Markdown quality checks (new in v1.7.1)
-│   ├── models.py       # OKFMetadata, NoteType, constants
-│   ├── parser.py       # YAML frontmatter parsing
-│   ├── linter.py       # Vault health + ROT audit + A2 scoring
+│   ├── constants.py    # Centralized constants (v1.8.0)
+│   ├── healer.py       # Frontmatter Healer
+│   ├── markdown_checks.py  # Markdown quality checks
+│   ├── models.py       # OKFMetadata, NoteType, NoteStatus
+│   ├── parser.py       # YAML frontmatter parsing (PyYAML)
+│   ├── linter.py       # Vault health + ROT audit + archive
 │   ├── indexer.py      # Hierarchical index generation
 │   ├── relations.py    # Entity extraction + relation suggestions (Graph RAG)
-│   ├── rot_scoring.py  # A2 scoring: dedup, freshness, link rot, usage (new in v1.7.1)
-│   ├── searcher.py     # Full-text search with scoring
-│   └── utils.py        # Path safety, atomic writes, version
+│   ├── rot_scoring.py  # A2 scoring: dedup, freshness, link rot, usage
+│   ├── searcher.py     # Full-text search (FTS5/Vector/Hybrid)
+│   └── utils.py        # Path safety, atomic writes, version, rate limiter
 └── mcp/
-    ├── __init__.py
+    ├── __init__.py     # Package marker
     ├── __main__.py     # python -m entry point
-    └── power_server.py # FastMCP server (11 tools)
+    └── power_server.py # FastMCP 3.x server (12 tools + health)
 
 tests/
 ├── test_cli.py         # CLI functional tests
-├── test_healer.py      # Healer unit tests (new in v1.7.1)
+├── test_healer.py      # Healer unit tests
 ├── test_indexer.py     # Indexer unit tests
 ├── test_integration.py # Full-cycle integration tests
 ├── test_linter.py      # Linter tests
 ├── test_mcp_server.py  # MCP tool tests
-├── test_markdown_checks.py  # Markdown quality tests (new in v1.7.1)
+├── test_markdown_checks.py  # Markdown quality tests
 ├── test_models.py      # Model validation tests
 ├── test_parser.py      # Parser tests
 ├── test_relations.py   # Relation suggestions tests
 ├── test_rot.py         # ROT audit tests
-├── test_rot_scoring.py # A2 scoring tests (new in v1.7.1)
+├── test_rot_scoring.py # A2 scoring tests
 ├── test_searcher.py    # Search scoring tests
 └── test_security.py    # Path traversal + atomic write tests
 ```
 
 ## Design decisions
 
-- **`src/` layout** — Standard Python packaging practice, prevents import confusion
-- **FastMCP** — Decorator-based MCP server, ~60% less boilerplate than raw Server
-- **Pydantic v2** — `model_dump()` instead of `dict()`, strict validation
+- **`src/` layout** — Standard Python packaging, prevents import confusion
+- **FastMCP 3.x (Prefect)** — Modern MCP framework with structured `ToolError`, `ErrorHandlingMiddleware`, `mask_error_details`, async tools, HTTP transport
+- **Pydantic v2** — `model_dump()`, strict validation, `field_validator`, UTC-aware timestamps
 - **Atomic file writes** — `os.replace()` for crash-safe config persistence
-- **Pure Python** — Zero external runtime deps beyond `mcp`, `pydantic`, `pyyaml`
+- **Path traversal protection** — `Path.relative_to()` boundary checking (not string-prefix)
+- **SSRF hardening** — LinkRotChecker blocks private/loopback/link-local IPs
+- **XDG cache dir** — `.power_search.db` stored in `~/.cache/power-framework/`, not inside vault
+- **Centralized constants** — `core/constants.py` as single source for all exclusion lists, skip files, system dirs
+- **Strict mypy** — All 17 source files pass `--strict` type checking
+- **Transport flexibility** — stdio (local) or HTTP (Docker) via `POWER_MCP_TRANSPORT` env var
+
+## API boundaries
+
+- **Core library** — All business logic lives in `power_framework.core`. Importable from `power_framework.core` or top-level `power_framework`.
+- **CLI** — Thin argparser wrapper delegating to core functions. Entry: `power_framework.core.cli:main`.
+- **MCP server** — Thin orchestration layer delegating to core. Uses `asyncio.to_thread()` for all filesystem I/O. Async tools with `ToolError` for structured errors.
+- **No circular dependencies** — Core never imports from `mcp`. MCP imports only from core.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,10 +3,16 @@
 ## Installation
 
 ```bash
-pip install power-framework
+pip install git+https://github.com/weby-homelab/power-framework.git@v1.8.0
 ```
 
-Verify the installation:
+Alternatively, install from a GitHub Release:
+
+```bash
+pip install https://github.com/weby-homelab/power-framework/releases/download/v1.8.0/power_framework-1.8.0-py3-none-any.whl
+```
+
+Verify:
 
 ```bash
 power --version
@@ -16,10 +22,9 @@ power --version
 
 ```bash
 power init my-vault
-cd my-vault
 ```
 
-This creates the P.A.R.A. directory structure:
+Creates the P.A.R.A. directory structure:
 
 ```
 vault/
@@ -29,48 +34,85 @@ vault/
 ├── 03_Resources/
 ├── 04_Archive/
 ├── 05_Templates/
-└── 06_Daily_Logs/
+├── 06_Daily_Logs/
+├── PROTOCOLS/
+├── index.md
+└── log.md
 ```
 
 ## Add notes
 
 ```bash
-power ingest --title "My Note" --type Resource --description "A useful resource"
+power ingest ~/my-vault --type Project --title "My Project" --description "A new project"
 ```
 
 ## Run health checks
 
 ```bash
-power lint .
+power lint ~/my-vault
 ```
 
 ## Auto-heal frontmatter
 
 ```bash
-power heal .                  # Preview changes (dry run)
-power heal . --no-dry-run     # Apply fixes
+power heal ~/my-vault                  # Preview (dry run)
+power heal ~/my-vault --no-dry-run     # Apply fixes
 ```
 
 ## Check markdown quality
 
 ```bash
-power markdown-check .
+power markdown-check ~/my-vault
 ```
 
 ## Generate index
 
 ```bash
-power index .
+power index ~/my-vault
 ```
 
-## Search
+## Search the vault
 
 ```bash
-power search . "my query"
+power search ~/my-vault "my query"
+power search ~/my-vault "my query" --mode hybrid --max-results 10
 ```
 
-## Run ROT audit with extended scoring
+## ROT audit with extended scoring
 
 ```bash
-power rot . --extended
+power rot ~/my-vault --extended
 ```
+
+## Archive stale notes
+
+```bash
+power archive ~/my-vault                  # Preview (dry run)
+power archive ~/my-vault --no-dry-run     # Move to 04_Archive/
+```
+
+## Suggest related notes (Graph RAG)
+
+```bash
+power suggest-related ~/my-vault
+```
+
+## Cron maintenance
+
+```bash
+power cron ~/my-vault
+```
+
+## MCP server
+
+Start the MCP server for AI agent integration:
+
+```bash
+# Local (stdio)
+python -m power_framework.mcp
+
+# HTTP (Docker / remote)
+POWER_MCP_TRANSPORT=http python -m power_framework.mcp
+```
+
+See [MCP Server](mcp-server.md) for full documentation.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,27 +1,86 @@
-# MCP Server
+# MCP Server (FastMCP 3.x)
 
-The P.O.W.E.R. Framework exposes its full functionality via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), enabling AI agents to interact with your Obsidian vault directly.
+The P.O.W.E.R. Framework exposes its full functionality via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), powered by [FastMCP 3.x](https://gofastmcp.com) (Prefect). This enables AI agents (Claude, OpenCode, Cursor) to interact with your knowledge vault directly.
 
-## Running
+## Transport modes
+
+### Local (stdio) — default
 
 ```bash
 python -m power_framework.mcp
 ```
 
-Or via a direct script:
+The server starts with **stdio** transport — ideal for local AI clients like Claude Desktop or OpenCode.
 
-```python
-from power_framework.mcp.power_server import run
-import asyncio
+### HTTP (Docker / remote) — v1.8.0
 
-asyncio.run(run())
+Set `POWER_MCP_TRANSPORT=http` for HTTP mode with `/health` endpoint on port 8000:
+
+```bash
+POWER_MCP_TRANSPORT=http python -m power_framework.mcp
 ```
 
-## Available Tools
+Docker Compose example:
+
+```yaml
+services:
+  power-mcp:
+    image: weby-homelab/power-framework:v1.8.0
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./vault:/vault:ro
+    environment:
+      - POWER_VAULT_DIR=/vault
+      - POWER_MCP_TRANSPORT=http
+    cap_drop:
+      - ALL
+    read_only: true
+```
+
+Health check: `GET http://localhost:8000/health`
+
+## Client configuration
+
+**Claude Desktop** (`~/.config/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "power": {
+      "command": "python3",
+      "args": ["-m", "power_framework.mcp"],
+      "env": {
+        "POWER_VAULT_DIR": "/path/to/your/vault"
+      }
+    }
+  }
+}
+```
+
+**OpenCode** (`~/.config/opencode/opencode.jsonc`):
+
+```jsonc
+"mcp": {
+  "power": {
+    "type": "local",
+    "command": ["python3", "-m", "power_framework.mcp"],
+    "enabled": true
+  }
+}
+```
+
+## Error handling (v1.8.0)
+
+All tools raise structured `ToolError` exceptions with descriptive messages. The server uses `mask_error_details=True` and `ErrorHandlingMiddleware` — internal stack traces are hidden from clients, only user-facing messages are exposed.
+
+## Available tools
+
+12 MCP tools are exposed, all asynchronous with `asyncio.to_thread()` for filesystem I/O.
 
 ### `lint_vault`
 
-Run health checks on a vault. Returns metadata issues, broken links, and orphans.
+Run health checks: missing metadata, broken links, orphans, stale notes.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -29,15 +88,24 @@ Run health checks on a vault. Returns metadata issues, broken links, and orphans
 
 ### `generate_index`
 
-Compile hierarchical index (`index.md` + per-folder `_index.md` files).
+Compile hierarchical index (`index.md` + per-folder `_index.md` files). Rate limited: 5/min.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `vault_path` | `string` | No | Path to vault root |
 
-### `read_sub_index`
+### `read_sub_index` *(read-only since v1.8.0)*
 
-Read a specific P.A.R.A. category sub-index on-demand.
+Read a specific P.A.R.A. category sub-index. Read-only — does not generate files.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `category` | `string` | Yes | Folder name (e.g. `01_Projects`) |
+| `vault_path` | `string` | No | Path to vault root |
+
+### `ensure_sub_index` *(new in v1.8.0)*
+
+Generate and read a sub-index for a category. Write path — use when `_index.md` is missing.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -46,14 +114,14 @@ Read a specific P.A.R.A. category sub-index on-demand.
 
 ### `ingest_note`
 
-Create a new note with strict OKF metadata frontmatter.
+Create a new note with strict OKF metadata. Rebuilds index + appends to log.md. Rate limited: 10/min.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | `string` | Yes | Note filename |
-| `note_type` | `string` | Yes | Type (`Project`, `Area`, etc.) |
+| `note_type` | `string` | Yes | `Project`, `Area`, `Resource`, `Daily Log`, `Archive`, `System Guide` |
 | `title` | `string` | Yes | Page title |
-| `description` | `string` | Yes | Short description |
+| `description` | `string` | Yes | Short description (max 150 chars) |
 | `content` | `string` | Yes | Body content |
 | `resource` | `string` | No | External URL |
 | `tags` | `string[]` | No | List of tags |
@@ -61,17 +129,18 @@ Create a new note with strict OKF metadata frontmatter.
 
 ### `search_vault_tool`
 
-Full-text search across vault notes.
+Full-text search across all vault notes. Three modes: `fts` (BM25, default), `vector` (TF cosine), `hybrid` (RRF fusion).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `query` | `string` | Yes | Search query |
 | `max_results` | `integer` | No | Max results (default: 20) |
+| `search_mode` | `string` | No | `fts`, `vector`, or `hybrid` (default: `fts`) |
 | `vault_path` | `string` | No | Path to vault root |
 
-### `synthesize_session` *(new in v1.6.0)*
+### `synthesize_session`
 
-Create a session synthesis note with auto-classified OKF frontmatter, governance metadata, Graph RAG links, and full index/log maintenance. Implements the Agent Auto-Ingest Feedback Loop.
+Agent Auto-Ingest Feedback Loop. Create session synthesis notes with governance metadata, Graph RAG links, and full index/log maintenance.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -82,50 +151,58 @@ Create a session synthesis note with auto-classified OKF frontmatter, governance
 | `note_type` | `string` | No | Default: `Daily Log` |
 | `tags` | `string[]` | No | List of tags |
 | `related` | `string[]` | No | Graph RAG links to related notes |
-| `owner` | `string` | No | Responsible entity |
+| `owner` | `string` | No | Responsible person/team |
 | `vault_path` | `string` | No | Path to vault root |
 
-### `run_rot_audit` *(new in v1.7.0)*
+### `rot_audit`
 
-Run a ROT (Redundant, Outdated, Trivial) audit on the vault. Returns categorized issues.
+ROT (Redundant, Outdated, Trivial) audit. Use `extended=True` for A2 scoring (content dedup, link rot, freshness, usage).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `vault_path` | `string` | No | Path to vault root |
+| `extended` | `boolean` | No | Enable A2 scoring (default: false) |
 
-### `archive_stale_notes` *(new in v1.7.0)*
+### `archive_notes`
 
-Auto-archive stale notes older than the threshold to `04_Archive/`.
+Move stale/expired notes to `04_Archive/`. Uses `dry_run=True` by default for safe preview.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `stale_days` | `integer` | No | Days without change to consider stale (default: 90) |
 | `dry_run` | `boolean` | No | Preview without moving (default: true) |
 | `vault_path` | `string` | No | Path to vault root |
 
-### `suggest_related_notes` *(new in v1.7.0)*
+### `suggest_related_tool`
 
-Suggest cross-note relations based on keyword and tag overlap analysis.
+Auto-suggest related notes based on keyword and tag overlap (Graph RAG).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `target_path` | `string` | No | Analyze relations for a specific note |
-| `max_results` | `integer` | No | Maximum suggestions (default: 10) |
+| `max_results` | `integer` | No | Maximum suggestions (default: 5) |
 | `vault_path` | `string` | No | Path to vault root |
 
-### `heal_frontmatter_tool` *(new in v1.7.1)*
+### `heal_frontmatter_tool`
 
-Scan and heal missing/invalid frontmatter fields across vault notes.
+Scan and heal missing/invalid frontmatter fields. Dry run by default.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `dry_run` | `boolean` | No | Preview without editing (default: true) |
 | `vault_path` | `string` | No | Path to vault root |
 
-### `check_markdown_tool` *(new in v1.7.1)*
+### `check_markdown_tool`
 
-Check markdown quality issues across the vault: trailing whitespace, list markers, header jumps, code language.
+Check markdown quality: trailing whitespace, list markers, header jumps, code language hints.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `vault_path` | `string` | No | Path to vault root |
+
+## Security
+
+- **Error masking** — Internal stack traces hidden from clients
+- **Rate limiting** — Write tools (ingest, synthesize): 10/min; Index generation: 5/min
+- **Path traversal** — All vault paths validated via `Path.relative_to()` boundary check
+- **SSRF protection** — Link rot checks block private/loopback/link-local IPs
+- **Docker hardening** — `cap_drop: [ALL]`, `read_only: true`, non-root user

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - Linter: api/linter.md
       - Healer: api/healer.md
       - Markdown Checks: api/markdown_checks.md
+      - Constants: api/constants.md
       - ROT Scoring: api/rot_scoring.md
       - Searcher: api/searcher.md
       - Utils: api/utils.md


### PR DESCRIPTION
## Summary

MkDocs documentation overhaul for v1.8.0:

- **architecture.md** — added , FastMCP 3.x design decisions, SSRF, XDG cache, mypy strict, transport flexibility
- **mcp-server.md** — complete rewrite: FastMCP 3.x, all 12 tools (including new ), HTTP transport, Docker setup, error handling, security
- **getting-started.md** — updated install to GitHub URL, added archive/cron/suggest commands, MCP server quick start
- **api/constants.md** — new API page for centralized constants module
- **mkdocs.yml** — added  to API nav

Closes #1