### PR TITLE
docs: add API documentation for new v2.0 RAG modules

### DIFF
--- a/docs/api/chunker.md
+++ b/docs/api/chunker.md
@@ -1,0 +1,30 @@
+# Chunker
+
+## `SemanticChunker`
+
+Class for splitting markdown notes into contextualized chunks using the Anthropic Contextual Retrieval pattern.
+
+### Constructor
+
+```python
+SemanticChunker(mode: ChunkMode = "headers", chunk_size: int = 512, chunk_overlap: int = 0)
+```
+
+- `mode` (ChunkMode): The splitting mode, one of:
+  - `"headers"` (default): Split by H2 (`##`) and H3 (`###`) headers.
+  - `"paragraphs"`: Split by double newlines.
+  - `"fixed"`: Split by fixed character counts.
+- `chunk_size` (int): Target character count for `"fixed"` mode. Default is `512`.
+- `chunk_overlap` (int): Overlap character count for `"fixed"` mode. Default is `0`.
+
+### Methods
+
+#### `chunk(content: str, title: str = "", description: str = "") -> list[str]`
+
+Split raw markdown content into chunks, prepending document-level context to each chunk.
+
+- **Parameters**:
+  - `content` (str): Raw markdown document (frontmatter is automatically stripped).
+  - `title` (str): Optional document title.
+  - `description` (str): Optional document description.
+- **Returns**: A list of chunk strings, each prefixed with `[Document: {title} | Description: {description}]\n`.

--- a/docs/api/embeddings.md
+++ b/docs/api/embeddings.md
@@ -1,0 +1,29 @@
+# Embeddings
+
+## `EmbeddingManager`
+
+Class for managing local dense vector embeddings using the `fastembed` library. It loads a pre-trained ONNX model for CPU-optimized inference.
+
+### Constructor
+
+```python
+EmbeddingManager(model_name: str = "BAAI/bge-small-en-v1.5")
+```
+
+- `model_name`: The name of the fastembed model to load. Default is `"BAAI/bge-small-en-v1.5"` (384-dimensional).
+
+### Methods
+
+#### `embed(text: str) -> list[float]`
+
+Generate a dense vector embedding for a single text string.
+
+- **Parameters**: `text` (str).
+- **Returns**: A list of floats representing the embedding vector.
+
+#### `embed_batch(texts: list[str]) -> list[list[float]]`
+
+Generate dense vector embeddings for a list of text strings in batch.
+
+- **Parameters**: `texts` (list of strings).
+- **Returns**: A list of float lists, where each list is the embedding vector for the corresponding input text.

--- a/docs/api/query_expansion.md
+++ b/docs/api/query_expansion.md
@@ -1,0 +1,29 @@
+# Query Expansion
+
+## `QueryExpander`
+
+Class for expanding a search query into multiple variants using a local synonym map and an optional LLM-based fallback.
+
+### Constructor
+
+```python
+QueryExpander(use_llm: bool = False, api_key: str | None = None)
+```
+
+- `use_llm` (bool): Whether to enable LLM-based query expansion. Default is `False`.
+- `api_key` (str | None): Optional OpenRouter API key. If not provided, falls back to the `OPENROUTER_API_KEY` environment variable.
+
+### Attributes
+
+#### `SYNONYM_MAP`
+
+A class-level dictionary containing bidirectional synonym mappings (English & Ukrainian) for key terms (e.g. *deploy* ↔ *розгортання*, *docker* ↔ *container*).
+
+### Methods
+
+#### `expand(query: str) -> list[str]`
+
+Expand the search query into unique variants.
+
+- **Parameters**: `query` (str): The search query.
+- **Returns**: A list of unique expanded search queries (always includes the original query).

--- a/docs/api/reranker.md
+++ b/docs/api/reranker.md
@@ -1,0 +1,24 @@
+# Reranker
+
+## `RerankerManager`
+
+Class for managing local Cross-Encoder reranking using the `fastembed` library. It loads a pre-trained ONNX model to evaluate query-document relevance scores.
+
+### Constructor
+
+```python
+RerankerManager(model_name: str = "Xenova/ms-marco-MiniLM-L-6-v2")
+```
+
+- `model_name`: The name of the cross-encoder model to load. Default is `"Xenova/ms-marco-MiniLM-L-6-v2"`.
+
+### Methods
+
+#### `rerank(query: str, documents: list[str]) -> list[float]`
+
+Predict relevance scores for a list of document strings against a query.
+
+- **Parameters**:
+  - `query` (str): The search query.
+  - `documents` (list of strings): The documents to evaluate.
+- **Returns**: A list of floats representing the predicted relevance score for each document (higher score means more relevant).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,10 @@ nav:
       - Models: api/models.md
       - Parser: api/parser.md
       - Indexer: api/indexer.md
+      - Embeddings: api/embeddings.md
+      - Reranker: api/reranker.md
+      - Query Expansion: api/query_expansion.md
+      - Chunker: api/chunker.md
       - Linter: api/linter.md
       - Healer: api/healer.md
       - Markdown Checks: api/markdown_checks.md


### PR DESCRIPTION
This PR adds mkdocs API documentation pages and index mapping for the newly introduced RAG modules: embeddings, reranker, query_expansion, and chunker.