### PR TITLE
feat: make LLM endpoint and model configurable via env variables

### DIFF
--- a/src/power_framework/core/query_expansion.py
+++ b/src/power_framework/core/query_expansion.py
@@ -57,7 +57,15 @@ class QueryExpander:
 
     def __init__(self, use_llm: bool = False, api_key: str | None = None) -> None:
         self.use_llm = use_llm
-        self.api_key = api_key or os.environ.get("OPENROUTER_API_KEY", "")
+        self.api_key = (
+            api_key
+            or os.environ.get("POWER_LLM_API_KEY")
+            or os.environ.get("OPENROUTER_API_KEY", "")
+        )
+        self.api_base = os.environ.get("POWER_LLM_API_BASE", "https://openrouter.ai/api/v1").rstrip(
+            "/"
+        )
+        self.model = os.environ.get("POWER_LLM_MODEL", OPENROUTER_MODELS[0])
 
     def expand(self, query: str) -> list[str]:
         if not query or not query.strip():
@@ -104,15 +112,15 @@ class QueryExpander:
 
         payload = json.dumps(
             {
-                "model": OPENROUTER_MODELS[0],
+                "model": self.model,
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": 150,
                 "temperature": 0.7,
             }
         ).encode("utf-8")
 
-        req = urllib.request.Request(
-            "https://openrouter.ai/api/v1/chat/completions",
+        req = urllib.request.Request(  # noqa: S310
+            f"{self.api_base}/chat/completions",
             data=payload,
             headers={
                 "Content-Type": "application/json",

--- a/src/power_framework/core/rot_scoring.py
+++ b/src/power_framework/core/rot_scoring.py
@@ -140,7 +140,15 @@ class ContradictionDetector:
         api_key: str | None = None,
     ):
         self.similarity_threshold = similarity_threshold
-        self.api_key = api_key or os.environ.get("OPENROUTER_API_KEY", "")
+        self.api_key = (
+            api_key
+            or os.environ.get("POWER_LLM_API_KEY")
+            or os.environ.get("OPENROUTER_API_KEY", "")
+        )
+        self.api_base = os.environ.get("POWER_LLM_API_BASE", "https://openrouter.ai/api/v1").rstrip(
+            "/"
+        )
+        self.model = os.environ.get("POWER_LLM_MODEL", OPENROUTER_MODELS[0])
         self.embedder = EmbeddingManager()
 
     def detect(self, vault_dir: Path) -> list[tuple[str, str, str]]:
@@ -226,15 +234,15 @@ class ContradictionDetector:
 
         payload = json.dumps(
             {
-                "model": OPENROUTER_MODELS[0],
+                "model": self.model,
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": 100,
                 "temperature": 0.1,
             }
         ).encode("utf-8")
 
-        req = urllib.request.Request(
-            "https://openrouter.ai/api/v1/chat/completions",
+        req = urllib.request.Request(  # noqa: S310
+            f"{self.api_base}/chat/completions",
             data=payload,
             headers={
                 "Content-Type": "application/json",


### PR DESCRIPTION
Decouples the framework from OpenRouter by introducing POWER_LLM_API_BASE, POWER_LLM_API_KEY, and POWER_LLM_MODEL environment variables, enabling users to use local LLM instances (like Ollama, llama.cpp, OpenCode) for query expansion and contradiction checks.