### PR TITLE
feat: add support for local OpenCode CLI execution

### DIFF
--- a/src/power_framework/core/query_expansion.py
+++ b/src/power_framework/core/query_expansion.py
@@ -8,6 +8,8 @@ import urllib.error
 import urllib.request
 from typing import ClassVar
 
+from .utils import run_opencode_cli
+
 logger = logging.getLogger(__name__)
 
 OPENROUTER_MODELS = [
@@ -74,7 +76,7 @@ class QueryExpander:
         variants: list[str] = [query]
         variants.extend(self._synonym_expand(query))
 
-        if self.use_llm and self.api_key:
+        if self.use_llm and (self.api_key or self.api_base == "opencode"):
             try:
                 llm_variants = self._llm_expand(query)
                 variants.extend(llm_variants)
@@ -101,14 +103,31 @@ class QueryExpander:
         return expanded
 
     def _llm_expand(self, query: str) -> list[str]:
-        if not self.api_key:
-            return []
-
         prompt = (
             f"Generate 2 alternative search queries for a knowledge base. "
             f"Original query: '{query}'. "
             f"Return only a JSON array of 2 strings, no other text."
         )
+
+        if self.api_base == "opencode":
+            res_text = run_opencode_cli(prompt)
+            if not res_text:
+                return []
+            try:
+                cleaned = res_text.strip()
+                if cleaned.startswith("```"):
+                    cleaned = cleaned.split("```")[1]
+                    if cleaned.startswith("json"):
+                        cleaned = cleaned[4:]
+                alternatives = json.loads(cleaned.strip())
+                if isinstance(alternatives, list):
+                    return [str(a) for a in alternatives if a]
+            except json.JSONDecodeError as e:
+                logger.warning("Failed to parse local opencode JSON: %s", e)
+            return []
+
+        if not self.api_key:
+            return []
 
         payload = json.dumps(
             {

--- a/src/power_framework/core/rot_scoring.py
+++ b/src/power_framework/core/rot_scoring.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 from .embeddings import EmbeddingManager
 from .parser import FRONTMATTER_PATTERN, parse_frontmatter, read_file_content
+from .utils import run_opencode_cli
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -213,12 +214,12 @@ class ContradictionDetector:
         vault_dir: Path,
     ) -> str | None:
         """Check if two texts contradict. Returns reason string or None."""
-        if self.api_key:
+        if self.api_key or self.api_base == "opencode":
             return self._llm_contradiction_check(body_a, body_b)
         return self._metadata_contradiction_check(path_a, path_b, vault_dir)
 
     def _llm_contradiction_check(self, body_a: str, body_b: str) -> str | None:
-        """Call LLM via OpenRouter to check for contradictions."""
+        """Call LLM to check for contradictions."""
         prompt = (
             "You are a contradiction detection system. Analyze the following two "
             "texts from a knowledge base and determine if they contain contradictory "
@@ -231,6 +232,18 @@ class ContradictionDetector:
             "Only answer YES if there is a clear factual contradiction. "
             "Differences in wording or complementary information should be marked NO."
         )
+
+        if self.api_base == "opencode":
+            res_text = run_opencode_cli(prompt)
+            if not res_text:
+                return None
+            res_text = res_text.strip()
+            if res_text.upper().startswith("YES"):
+                return res_text
+            return None
+
+        if not self.api_key:
+            return None
 
         payload = json.dumps(
             {

--- a/src/power_framework/core/utils.py
+++ b/src/power_framework/core/utils.py
@@ -191,3 +191,46 @@ try:
     __version__ = _get_version("power-framework")
 except Exception:
     __version__ = "1.8.0"
+
+
+def run_opencode_cli(prompt: str) -> str:
+    """Run local OpenCode agent CLI tool to get LLM completion."""
+    import logging
+    import subprocess
+
+    local_logger = logging.getLogger(__name__)
+
+    # Locate opencode binary
+    binary = "/root/.opencode/bin/opencode"
+    if not os.path.exists(binary):
+        binary = shutil.which("opencode") or "opencode"
+
+    try:
+        res = subprocess.run(  # noqa: S603
+            [binary, "run", prompt, "--auto"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+        stdout = res.stdout
+        lines = stdout.splitlines()
+        content_lines = []
+        started = False
+        for line in lines:
+            if started:
+                content_lines.append(line)
+            elif line.strip().startswith("> "):
+                started = True
+            elif not line.strip():
+                continue
+            else:
+                pass
+
+        if not started:
+            return stdout.strip()
+
+        return "\n".join(content_lines).strip()
+    except Exception as e:
+        local_logger.warning("Failed to run local opencode CLI: %s", e)
+        return ""


### PR DESCRIPTION
Enables P.O.W.E.R. framework to execute LLM tasks (query expansion and contradiction check) directly using the local OpenCode CLI tool ('opencode run [prompt] --auto') when POWER_LLM_API_BASE is set to 'opencode'.