### PR TITLE
fix: resolve ruff linter and formatter issues on Python 3.14

### DIFF
--- a/src/power_framework/core/embeddings.py
+++ b/src/power_framework/core/embeddings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -29,7 +30,6 @@ def _load_env(env_path: str = "/root/geminicli/.env") -> None:
 
 
 # Load env variables before setting up default model
-import sys
 if "pytest" not in sys.modules and "PYTEST_CURRENT_TEST" not in os.environ:
     _load_env()
 
@@ -49,11 +49,12 @@ def _get_embedding_dim(model_name: str) -> int:
         return 1024
     try:
         from fastembed import TextEmbedding
+
         for m in TextEmbedding.list_supported_models():
             if m["model"] == model_name:
                 return m["dim"]
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Failed to get embedding dim for model %s: %s", model_name, e)
     return 384
 
 
@@ -108,4 +109,3 @@ class EmbeddingManager:
         self._lazy_init()
         assert self._model is not None
         return [[float(v) for v in vec] for vec in self._model.embed(texts)]
-

--- a/src/power_framework/core/query_expansion.py
+++ b/src/power_framework/core/query_expansion.py
@@ -62,9 +62,8 @@ class QueryExpander:
         if api_key is not None:
             self.api_key = api_key
         else:
-            self.api_key = (
-                os.environ.get("POWER_LLM_API_KEY")
-                or os.environ.get("OPENROUTER_API_KEY", "")
+            self.api_key = os.environ.get("POWER_LLM_API_KEY") or os.environ.get(
+                "OPENROUTER_API_KEY", ""
             )
         self.api_base = os.environ.get("POWER_LLM_API_BASE", "https://openrouter.ai/api/v1").rstrip(
             "/"

--- a/src/power_framework/core/rot_scoring.py
+++ b/src/power_framework/core/rot_scoring.py
@@ -419,8 +419,7 @@ class LinkRotChecker:
                 continue
 
             urls = self.EXTERNAL_LINK_PATTERN.findall(content)
-            for url in urls:
-                to_check.append((str(rel), url))
+            to_check.extend((str(rel), url) for url in urls)
 
         if not to_check:
             return results


### PR DESCRIPTION
This PR fixes Ruff E402, I001, S110, and PERF401 errors highlighted by CI build on Python 3.14.