### PR TITLE
fix(ci): resolve mypy type check error

### DIFF
--- a/src/power_framework/core/embeddings.py
+++ b/src/power_framework/core/embeddings.py
@@ -53,7 +53,7 @@ def _get_embedding_dim(model_name: str) -> int:
 
         for m in TextEmbedding.list_supported_models():
             if m["model"] == model_name:
-                return m["dim"]
+                return int(m["dim"])
     except Exception as e:
         logger.debug("Failed to list fastembed models: %s", e)
     return 384


### PR DESCRIPTION
Casts TextEmbedding model dimension to int to satisfy MyPy's no-any-return check.