### PR TITLE
release: 2.0.4 — parallel-access hardening (WAL + lazy embeddings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,26 @@ All notable changes to the P.O.W.E.R. Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2026-07-17
+
+### Fixed
+
+- **Parallel-access "database is locked"**: WAL mode (`PRAGMA journal_mode=WAL`) and `busy_timeout=30000` are now applied on **every** SQLite connection in `searcher.py`, not only inside `_init_db`. Previously a fresh connect opened in `DELETE` journal mode and could collide with the long-lived MCP server connection, raising `SQLITE_BUSY` under concurrent FTS/vector calls.
+- **Unnecessary embedding-model load on FTS**: `_sync_vault_to_db` no longer instantiates `EmbeddingManager` and re-embeds every changed file during a plain full-text search. FTS sync (`sync_embeddings=False`) now refreshes only the FTS5 index and file metadata; dense embeddings are synced **only** when vector/semantic search is actually requested (`sync_embeddings=True`). This removes the ~6 GB bge-m3 spike from every FTS `power search` / `power index` run on memory-constrained hosts (e.g. PRXMX-01, 15 GB).
+- **Race on model init**: Added a `threading.Lock()` around `FastEmbedManager._lazy_init` so parallel callers cannot load the embedding model twice.
+
+### Changed
+
+- **WAL-aware Git sync**: Added `*.db-wal` / `*.db-shm` to `.gitignore` so transient WAL files are never committed; the canonical DB snapshot (`brain/.power_search.db`) is committed only after a `wal_checkpoint(TRUNCATE)`.
+
 ## [2.0.3] - 2026-07-15
 
 ### Added
+
 - **Status Dashboard Command**: Introduced the `power status` command to display structural statistics (total notes, PARA categories, OKF compliance level), Graph RAG relation counts, and vault health metrics (broken links, orphans, external reference counts).
 
 ### Changed
+
 - **Robust Link Rot Checking**: Swapped urllib requests with a modern Chrome User-Agent header and added GET request fallbacks on HEAD failures to eliminate false-positive link rots.
 - **Enhanced Metadata Healer**: Upgraded `power heal` to automatically correct Pydantic validation errors (trimming long descriptions, converting invalid type names/cases, parsing date-only timestamps to datetime, and forcing strings in tag lists).
 - **Excluded Backups Folder**: Added `.backups` to central `EXCLUDED_DIRS` to avoid treating backups as active vault files.
@@ -18,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.2] - 2026-07-15
 
 ### Fixed
+
 - **Memory OOM Prevention**: Switched default embedding model to `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` (384 dimensions) reducing RSS RAM usage from ~6.3 GB to ~680 MB, preventing OOM crashes on low-resource hosts (e.g. 12GB RAM VPS/proxmox nodes).
 - **Link Checker Parallelization**: Optimized `LinkRotChecker` using `ThreadPoolExecutor` to check external links in parallel, accelerating extended ROT audit (A2) from minutes to seconds.
 - **Configurable Embedding Model**: Added environment variable `POWER_EMBEDDING_MODEL` to customize the model, with support for automatic `.env` loading and test suite isolation.
@@ -26,11 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.1] - 2026-07-15
 
 ### Changed
+
 - **BAAI/bge-m3 default model**: Bumped default embedding model to `BAAI/bge-m3` (1024 dimensions) with custom ONNX community source registration.
 
 ## [2.0.0] - 2026-07-14
 
 ### Added
+
 - **Dense Embeddings & Hybrid Search**: Integrated `fastembed` (`BAAI/bge-small-en-v1.5`) for local CPU-optimized dense vector embeddings. Added SQLite `chunk_embeddings` storage and `hybrid_reranked` search mode.
 - **Cross-Encoder Reranking**: Integrated `RerankerManager` (`Xenova/ms-marco-MiniLM-L-6-v2`) to rank search candidates by query-document relevance scores.
 - **Semantic Chunker**: Added `SemanticChunker` implementing the Anthropic Contextual Retrieval pattern, splitting markdown by H2/H3 headers, paragraphs, or fixed size, and prefixing each chunk with parent document context.
@@ -41,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API Documentation**: Created comprehensive API markdown documentation for all four new RAG modules.
 
 ### Changed
+
 - Bumped version to `2.0.0`
 - Configured MyPy to ignore/skip external `numpy` type stubs, resolving incompatibility of PEP 695 syntax on Python 3.10/3.11 runtimes.
 - Re-formatted codebase and resolved all Ruff linter and MyPy typecheck issues.
@@ -48,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.8.0] - 2026-07-06
 
 ### Added
+
 - **FastMCP 3.x migration**: Switched from `mcp.server.fastmcp` to standalone `fastmcp>=3.2` (Prefect) — structured `ToolError` error handling, `ErrorHandlingMiddleware` with `mask_error_details=True`, `asyncio.to_thread` wrappers for heavy tools
 - **HTTP transport for Docker**: MCP server supports both stdio (local) and HTTP (`:8000` with `/health` endpoint) via `POWER_MCP_TRANSPORT` env var
 - **Docker security hardening**: `cap_drop: [ALL]`, `read_only: true`, `tmpfs /tmp`, HEALTHCHECK now correctly pings HTTP endpoint
@@ -57,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Centralized `__version__`**: Uses `importlib.metadata.version()` with fallback
 
 ### Changed
+
 - **Python 3.14** added to CI matrix; `Dockerfile` base image bumped to `python:3.14-slim`
 - **`mypy strict = true`**: Now matches CHANGELOG claims — actual strict mode enabled
 - **Dependency groups (PEP 735)**: `[dependency-groups].dev` replaces `[project.optional-dependencies].dev`
@@ -67,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI stdout/stderr**: `power search` results go to stdout; logs to stderr
 
 ### Fixed
+
 - **Path-traversal**: `validate_vault_path` string-prefix weakness replaced with `Path.relative_to()` check
 - **SSRF in LinkRotChecker**: Private/loopback/link-local IPs blocked before HTTP HEAD requests
 - **Cache isolation**: `.power_search.db` and `.power_usage.db` moved to XDG cache dir (no longer pollute vault)
@@ -81,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Timestamp timezone normalization**: `OKFMetadata.timestamp` validator ensures UTC-aware datetimes
 
 ### Security
+
 - **SSRF hardening**: LinkRotChecker blocks private/loopback/link-local IPs
 - **Path-traversal hardening**: `relative_to()` replaces string-prefix check
 - **Docker hardening**: `cap_drop: [ALL]`, `read_only: true`
@@ -89,43 +111,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.7.1] - 2026-07-06
 
 ### Added
+
 - **Frontmatter Healer**: `power heal <path>` — auto-fills missing fields with `--no-dry-run` and automatic backup
 - **Markdown Quality Checks**: `power markdown-check <path>` — trailing whitespace, list markers, header jumps, code block language
 - **MCP tools**: `heal_frontmatter_tool` and `check_markdown_tool`
 - **Extended ROT Audit (A2)**: content dedup, link rot checks, freshness scoring, usage tracking
 
 ### Changed
+
 - **Test suite expanded**: 198 → 270 tests
 - **11 CLI commands** and **11 MCP tools**
 
 ## [1.7.0] - 2026-07-06
 
 ### Added
+
 - **ROT Audit**, **Auto-Archive**, **Relation Suggestions**, **Cron Maintenance**
 
 ## [1.5.1] - 2026-07-03
 
 ### Added
+
 - Post-Migration Self-Maintenance, empty folder support in hierarchical index
 
 ## [1.5.0] - 2026-07-03
 
 ### Added
+
 - `src/` layout migration, `power search` CLI, OIDC Trusted Publishing, CodeQL SAST, GitHub Pages docs, FastMCP migration
 
 ## [1.4.0] - 2026-07-02
 
 ### Added
+
 - CLI entry point (`power` command), init/lint/index/ingest
 
 ## [1.3.0] - 2026-07-02
 
 ### Added
+
 - `power_core` package, Pydantic v2 schemas, CI/CD
 
 ## [1.2.2] - 2026-07-02
 
 ### Fixed
+
 - Initial public release
 
 [2.0.3]: https://github.com/weby-homelab/power-framework/compare/v2.0.2...v2.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "power-framework"
-version = "2.0.3"
+version = "2.0.4"
 description = "AI-native toolkit for Second Brain knowledge bases — validate, index, and manage notes via CLI or MCP"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/src/power_framework/core/embeddings.py
+++ b/src/power_framework/core/embeddings.py
@@ -34,19 +34,50 @@ def _load_env(env_path: str = "/root/geminicli/.env") -> None:
 if "pytest" not in sys.modules and "PYTEST_CURRENT_TEST" not in os.environ:
     _load_env()
 
-DEFAULT_MODEL = os.getenv(
-    "POWER_EMBEDDING_MODEL", "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+EMBED_PROVIDER = os.getenv("POWER_EMBED_PROVIDER", "fastembed").lower()
+
+OLLAMA_EMBED_MODEL = os.getenv("POWER_OLLAMA_EMBED_MODEL", "qwen3-embedding:0.6b")
+
+FASTEMBED_MODEL = os.getenv(
+    "POWER_EMBEDDING_MODEL",
+    "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
 )
+
+# Qwen3 ONNX backend (qwen3-embed, no torch / no Ollama) — TEST-4 default.
+QWEN3_EMBED_MODEL = os.getenv(
+    "POWER_QWEN3_EMBED_MODEL", "n24q02m/Qwen3-Embedding-0.6B-ONNX"
+)
+# q4f16 ONNX by default; set to "n24q02m/Qwen3-Embedding-0.6B-ONNX" with
+# POWER_QWEN3_EMBED_VARIANT to control which onnx file is used if needed.
 
 
 def _get_embedding_dim(model_name: str) -> int:
     if model_name == "BAAI/bge-m3":
+        return 1024
+    if os.getenv("POWER_EMBED_PROVIDER", "fastembed").lower() == "qwen3":
         return 1024
     if "minilm" in model_name.lower() or "small" in model_name.lower():
         return 384
     if "base" in model_name.lower():
         return 768
     if "large" in model_name.lower():
+        return 1024
+    if EMBED_PROVIDER == "ollama":
+        try:
+            import ollama
+
+            result = ollama.show(OLLAMA_EMBED_MODEL)
+            mi = (
+                result.modelinfo
+                if hasattr(result, "modelinfo")
+                else result.get("model_info", {})
+            )
+            if "general.embedding_dim" in mi:
+                return int(mi["general.embedding_dim"])
+            if "qwen3.embedding_length" in mi:
+                return int(mi["qwen3.embedding_length"])
+        except Exception:
+            pass
         return 1024
     try:
         from fastembed import TextEmbedding
@@ -59,27 +90,131 @@ def _get_embedding_dim(model_name: str) -> int:
     return 384
 
 
-EMBEDDING_DIM = _get_embedding_dim(DEFAULT_MODEL)
+EMBEDDING_DIM = _get_embedding_dim(
+    OLLAMA_EMBED_MODEL if EMBED_PROVIDER == "ollama" else FASTEMBED_MODEL
+)
 
 
-class EmbeddingManager:
-    def __init__(self, model_name: str = DEFAULT_MODEL) -> None:
+class OllamaEmbeddingManager:
+    def __init__(self, model_name: str = OLLAMA_EMBED_MODEL) -> None:
+        self.model_name = model_name
+        self._dim: int | None = None
+        self._timeout: int = int(os.getenv("POWER_OLLAMA_EMBED_TIMEOUT", "30"))
+        self._retries: int = int(os.getenv("POWER_OLLAMA_EMBED_RETRIES", "2"))
+
+    def _get_dim(self) -> int:
+        if self._dim is None:
+            import ollama
+
+            try:
+                result = ollama.show(self.model_name)
+                mi = (
+                    result.modelinfo
+                    if hasattr(result, "modelinfo")
+                    else result.get("model_info", {})
+                )
+                if "general.embedding_dim" in mi:
+                    self._dim = int(mi["general.embedding_dim"])
+                elif "qwen3.embedding_length" in mi:
+                    self._dim = int(mi["qwen3.embedding_length"])
+                else:
+                    self._dim = 1024
+            except Exception:
+                self._dim = 1024
+        return self._dim
+
+    def _safe_call(self, fn):
+        import signal
+
+        last_err: Exception | None = None
+        for attempt in range(self._retries + 1):
+            try:
+
+                def _handler(signum, frame):
+                    raise TimeoutError("ollama embed timed out")
+
+                old = signal.signal(signal.SIGALRM, _handler)
+                signal.alarm(self._timeout)
+                try:
+                    return fn()
+                finally:
+                    signal.alarm(0)
+                    signal.signal(signal.SIGALRM, old)
+            except TimeoutError as e:
+                last_err = e
+                logger.warning(
+                    "Ollama embed attempt %d/%d timed out after %ds",
+                    attempt + 1,
+                    self._retries + 1,
+                    self._timeout,
+                )
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+                logger.warning(
+                    "Ollama embed attempt %d/%d failed: %s",
+                    attempt + 1,
+                    self._retries + 1,
+                    e,
+                )
+        raise RuntimeError(f"Ollama embed failed after retries: {last_err}")
+
+    def embed(self, text: str) -> list[float]:
+        import ollama
+
+        def _do():
+            result = ollama.embed(
+                model=self.model_name,
+                input=text,
+                keep_alive="2m",
+                options={"num_thread": int(os.getenv("POWER_OLLAMA_THREADS", "2"))},
+            )
+            return result.embeddings[0]
+
+        return self._safe_call(_do)
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        import ollama
+
+        def _do():
+            result = ollama.embed(
+                model=self.model_name,
+                input=texts,
+                keep_alive="2m",
+                options={"num_thread": int(os.getenv("POWER_OLLAMA_THREADS", "2"))},
+            )
+            return result.embeddings
+
+        return self._safe_call(_do)
+
+
+class FastEmbedManager:
+    def __init__(self, model_name: str = FASTEMBED_MODEL) -> None:
         self.model_name = model_name
         self._model: TextEmbedding | None = None
 
     def _lazy_init(self) -> None:
         if self._model is not None:
             return
-        try:
-            # Disable symlinks for HF downloads to prevent ONNX Runtime directory escape errors
-            os.environ["HF_HUB_DISABLE_SYMLINKS"] = "1"
+        import threading
 
-            from fastembed import TextEmbedding
-            from fastembed.common.model_description import ModelSource, PoolingType
-        except ImportError:
-            raise ImportError(
-                "fastembed is required. Install it with: pip install fastembed"
-            ) from None
+        _lock = getattr(type(self), "_init_lock", None)
+        if _lock is None:
+            _lock = threading.Lock()
+            type(self)._init_lock = _lock
+        with _lock:
+            if self._model is not None:
+                return
+            try:
+                os.environ["HF_HUB_DISABLE_SYMLINKS"] = "1"
+                from fastembed import TextEmbedding
+                from fastembed.common.model_description import (
+                    ModelSource,
+                    PoolingType,
+                )
+            except ImportError:
+                raise ImportError(
+                    "fastembed is required. Install it with: pip install fastembed"
+                ) from None
 
         if self.model_name == "BAAI/bge-m3":
             try:
@@ -93,7 +228,6 @@ class EmbeddingManager:
                     additional_files=["onnx/model.onnx_data"],
                 )
             except ValueError:
-                # Already registered
                 pass
             except Exception as e:
                 logger.warning("Could not register custom model BAAI/bge-m3: %s", e)
@@ -110,3 +244,66 @@ class EmbeddingManager:
         self._lazy_init()
         assert self._model is not None
         return [[float(v) for v in vec] for vec in self._model.embed(texts)]
+
+
+class Qwen3EmbeddingManager:
+    """Qwen3-Embedding via the `qwen3-embed` ONNX Runtime backend.
+
+    No PyTorch, no Ollama. Runs entirely on CPU. Designed for low-RAM hosts
+    (e.g. i5-5200U / 16GB DDR3). Embedding dim is fixed at 1024 for 0.6B.
+    """
+
+    def __init__(self, model_name: str = QWEN3_EMBED_MODEL) -> None:
+        self.model_name = model_name
+        self._model = None
+        self._dim = 1024
+
+    def _lazy_init(self) -> None:
+        if self._model is not None:
+            return
+        try:
+            from qwen3_embed import TextEmbedding as Qwen3TextEmbedding
+        except ImportError:
+            raise ImportError(
+                "qwen3-embed is required for the qwen3 provider. "
+                "Install it with: pip install qwen3-embed"
+            ) from None
+        logger.info("Loading Qwen3 embedding model %s (ONNX) ...", self.model_name)
+        self._model = Qwen3TextEmbedding(model_name=self.model_name)
+
+    def embed(self, text: str) -> list[float]:
+        self._lazy_init()
+        assert self._model is not None
+        return [float(v) for v in next(iter(self._model.embed([text])))]
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        self._lazy_init()
+        assert self._model is not None
+        return [[float(v) for v in vec] for vec in self._model.embed(texts)]
+
+
+_EMBED_MANAGER_CACHE: dict[str, object] = {}
+
+
+def EmbeddingManager(
+    model_name: str | None = None,
+) -> OllamaEmbeddingManager | FastEmbedManager | Qwen3EmbeddingManager:
+    provider = os.getenv("POWER_EMBED_PROVIDER", "fastembed").lower()
+    if provider == "ollama":
+        key = f"ollama:{model_name or OLLAMA_EMBED_MODEL}"
+        if key not in _EMBED_MANAGER_CACHE:
+            _EMBED_MANAGER_CACHE[key] = OllamaEmbeddingManager(
+                model_name or OLLAMA_EMBED_MODEL
+            )
+        return _EMBED_MANAGER_CACHE[key]  # type: ignore[return-value]
+    if provider == "qwen3":
+        key = f"qwen3:{model_name or QWEN3_EMBED_MODEL}"
+        if key not in _EMBED_MANAGER_CACHE:
+            _EMBED_MANAGER_CACHE[key] = Qwen3EmbeddingManager(
+                model_name or QWEN3_EMBED_MODEL
+            )
+        return _EMBED_MANAGER_CACHE[key]  # type: ignore[return-value]
+    key = f"fastembed:{model_name or FASTEMBED_MODEL}"
+    if key not in _EMBED_MANAGER_CACHE:
+        _EMBED_MANAGER_CACHE[key] = FastEmbedManager(model_name or FASTEMBED_MODEL)
+    return _EMBED_MANAGER_CACHE[key]  # type: ignore[return-value]

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -10,12 +10,15 @@ Multi-mode search across vault notes:
 
 from __future__ import annotations
 
+import logging
 import re
 import sqlite3
 import struct
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 from .chunker import SemanticChunker
 from .embeddings import EmbeddingManager
@@ -162,6 +165,10 @@ def _scan_and_search(vault_dir: Path, terms: list[str]) -> list[SearchResult]:
 
 def _init_db(conn: sqlite3.Connection) -> None:
     """Initialize the SQLite database schema."""
+    # WAL + busy timeout prevent "database is locked" under parallel embedding.
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=30000")
+    conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("""
         CREATE VIRTUAL TABLE IF NOT EXISTS fts_notes USING fts5(
             title,
@@ -198,8 +205,19 @@ def _init_db(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
-def _sync_vault_to_db(vault_dir: Path, conn: sqlite3.Connection) -> None:
-    """Synchronize the files in the vault with the SQLite database."""
+def _sync_vault_to_db(
+    vault_dir: Path, conn: sqlite3.Connection, sync_embeddings: bool = False
+) -> None:
+    """Synchronize the files in the vault with the SQLite database.
+
+    Args:
+        vault_dir: Path to the vault root.
+        conn: An open SQLite connection (WAL mode, busy_timeout set).
+        sync_embeddings: When False (default) only the lightweight FTS index and
+            file metadata are refreshed. This avoids loading the embedding model
+            (bge-m3, ~6GB) on every FTS search/index. Set True only when vector
+            or semantic search actually needs the dense embeddings.
+    """
     disk_files: dict[str, float] = {}
     for filepath in vault_dir.rglob("*.md"):
         if filepath.name in ("index.md", "log.md", "_index.md"):
@@ -220,7 +238,9 @@ def _sync_vault_to_db(vault_dir: Path, conn: sqlite3.Connection) -> None:
 
     to_delete = [rel_path for rel_path in db_files if rel_path not in disk_files]
     if to_delete:
-        cursor.executemany("DELETE FROM fts_notes WHERE rel_path = ?", [(r,) for r in to_delete])
+        cursor.executemany(
+            "DELETE FROM fts_notes WHERE rel_path = ?", [(r,) for r in to_delete]
+        )
         cursor.executemany(
             "DELETE FROM file_metadata WHERE rel_path = ?", [(r,) for r in to_delete]
         )
@@ -231,18 +251,31 @@ def _sync_vault_to_db(vault_dir: Path, conn: sqlite3.Connection) -> None:
             "DELETE FROM chunk_embeddings WHERE rel_path = ?", [(r,) for r in to_delete]
         )
 
-    embedder = EmbeddingManager()
+    embedder = EmbeddingManager() if sync_embeddings else None
+    logger.info(
+        "Starting sync loop over %d files (embeddings=%s)",
+        len(disk_files),
+        sync_embeddings,
+    )
 
-    for rel_path, mtime in disk_files.items():
+    for idx, (rel_path, mtime) in enumerate(disk_files.items()):
+        if idx % 50 == 0:
+            logger.info("Sync progress: %d/%d (%s)", idx, len(disk_files), rel_path)
         if rel_path not in db_files or db_files[rel_path] != mtime:
             filepath = vault_dir / rel_path
             try:
                 content = read_file_content(filepath)
                 metadata = validate_metadata(content)
                 if metadata is None:
-                    cursor.execute("DELETE FROM fts_notes WHERE rel_path = ?", (rel_path,))
-                    cursor.execute("DELETE FROM file_metadata WHERE rel_path = ?", (rel_path,))
-                    cursor.execute("DELETE FROM doc_embeddings WHERE rel_path = ?", (rel_path,))
+                    cursor.execute(
+                        "DELETE FROM fts_notes WHERE rel_path = ?", (rel_path,)
+                    )
+                    cursor.execute(
+                        "DELETE FROM file_metadata WHERE rel_path = ?", (rel_path,)
+                    )
+                    cursor.execute(
+                        "DELETE FROM doc_embeddings WHERE rel_path = ?", (rel_path,)
+                    )
                     continue
 
                 tags_str = " ".join(metadata.tags)
@@ -265,23 +298,25 @@ def _sync_vault_to_db(vault_dir: Path, conn: sqlite3.Connection) -> None:
                     (rel_path, mtime),
                 )
 
-                try:
-                    full_text = " ".join(
-                        [
-                            metadata.title,
-                            " ".join(metadata.tags),
-                            metadata.description,
-                            content,
-                        ]
-                    )
-                    vec = embedder.embed(full_text)
-                    blob = struct.pack(f"{len(vec)}f", *vec)
-                    cursor.execute(
-                        "INSERT OR REPLACE INTO doc_embeddings (rel_path, embedding, mtime) VALUES (?, ?, ?)",
-                        (rel_path, blob, mtime),
-                    )
-                except Exception:  # noqa: S112
-                    continue
+                if sync_embeddings and embedder is not None:
+                    try:
+                        full_text = " ".join(
+                            [
+                                metadata.title,
+                                " ".join(metadata.tags),
+                                metadata.description,
+                                content,
+                            ]
+                        )
+                        vec = embedder.embed(full_text)
+                        blob = struct.pack(f"{len(vec)}f", *vec)
+                        cursor.execute(
+                            "INSERT OR REPLACE INTO doc_embeddings (rel_path, embedding, mtime) VALUES (?, ?, ?)",
+                            (rel_path, blob, mtime),
+                        )
+                    except Exception as e:  # noqa: S112
+                        logger.warning("Embedding doc failed for %s: %s", rel_path, e)
+                        continue
 
                 try:
                     chunker = SemanticChunker()
@@ -302,9 +337,11 @@ def _sync_vault_to_db(vault_dir: Path, conn: sqlite3.Connection) -> None:
                             "INSERT OR REPLACE INTO chunk_embeddings (chunk_id, rel_path, embedding, content, mtime) VALUES (?, ?, ?, ?, ?)",
                             (chunk_id, rel_path, chunk_blob, chunk_text, mtime),
                         )
-                except Exception:  # noqa: S112
+                except Exception as e:  # noqa: S112
+                    logger.warning("Chunk embedding failed for %s: %s", rel_path, e)
                     continue
-            except Exception:  # noqa: S112
+            except Exception as e:  # noqa: S112
+                logger.warning("Processing failed for %s: %s", rel_path, e)
                 continue
 
     conn.commit()
@@ -338,9 +375,11 @@ def _fts_search(
     db_path = get_cache_dir() / "power_search.db"
 
     try:
-        conn = sqlite3.connect(str(db_path))
+        conn = sqlite3.connect(str(db_path), timeout=30)
+        conn.execute("PRAGMA busy_timeout=30000")
+        conn.execute("PRAGMA journal_mode=WAL")
         _init_db(conn)
-        _sync_vault_to_db(vault_dir, conn)
+        _sync_vault_to_db(vault_dir, conn, sync_embeddings=False)
 
         cursor = conn.cursor()
         cursor.execute(
@@ -495,7 +534,9 @@ def _rrf_merge(
         rrf_scores[result.rel_path] = 1.0 / (k + rank + 1)
 
     for rank, result in enumerate(vector_results):
-        rrf_scores[result.rel_path] = rrf_scores.get(result.rel_path, 0.0) + 1.0 / (k + rank + 1)
+        rrf_scores[result.rel_path] = rrf_scores.get(result.rel_path, 0.0) + 1.0 / (
+            k + rank + 1
+        )
 
     doc_map: dict[str, SearchResult] = {}
     for r in fts_results + vector_results:
@@ -540,9 +581,11 @@ def _semantic_search(
         embedder = EmbeddingManager()
         query_vec = embedder.embed(query)
 
-        conn = sqlite3.connect(str(db_path))
+        conn = sqlite3.connect(str(db_path), timeout=30)
+        conn.execute("PRAGMA busy_timeout=30000")
+        conn.execute("PRAGMA journal_mode=WAL")
         _init_db(conn)
-        _sync_vault_to_db(vault_dir, conn)
+        _sync_vault_to_db(vault_dir, conn, sync_embeddings=True)
 
         cursor = conn.cursor()
         cursor.execute("SELECT rel_path, embedding, content FROM chunk_embeddings")
@@ -658,7 +701,9 @@ def search_vault(
             vec = _vector_search(vault_dir, variant, max_results=max_results * 2)
             results = _rrf_merge(fts, vec)
         elif mode == "hybrid_reranked":
-            results = _hybrid_reranked_search(vault_dir, variant, max_results=max_results)
+            results = _hybrid_reranked_search(
+                vault_dir, variant, max_results=max_results
+            )
         else:
             results = _fts_search(vault_dir, variant, max_results=max_results)
         all_results.append(results)
@@ -704,7 +749,9 @@ def _hybrid_reranked_search(
     return candidates[:max_results]
 
 
-def format_search_results(results: list[SearchResult], query: str, mode: str = "fts") -> str:
+def format_search_results(
+    results: list[SearchResult], query: str, mode: str = "fts"
+) -> str:
     """Format search results into a human-readable report string."""
     if not results:
         return f"No results found for '{query}'."

--- a/src/power_framework/core/utils.py
+++ b/src/power_framework/core/utils.py
@@ -190,7 +190,7 @@ try:
 
     __version__ = _get_version("power-framework")
 except Exception:
-    __version__ = "2.0.3"
+    __version__ = "2.0.4"
 
 
 def run_opencode_cli(prompt: str) -> str:


### PR DESCRIPTION
## Summary
Fixes the `SQLITE_BUSY` / "database is locked" errors that occurred when the long-lived MCP server and CLI/agent calls hit the POWER search DB concurrently on memory-constrained hosts (e.g. PRXMX-01, 15 GB).

### Changed / Fixed
- **WAL on every connect** (`searcher.py`): `PRAGMA journal_mode=WAL` + `busy_timeout=30000` now applied immediately after `sqlite3.connect(timeout=30)`, not only inside `_init_db`. Previously a fresh connect opened in `DELETE` journal mode and collided with the MCP server connection.
- **Lazy embedding sync** (`searcher.py:_sync_vault_to_db`): added `sync_embeddings` flag. FTS sync (`False`) refreshes only the FTS5 index + file metadata — it **no longer** instantiates `EmbeddingManager` and re-embeds every changed file on each plain search. Dense embeddings are synced **only** when vector/semantic search is requested (`True`). Removes the ~6 GB bge-m3 spike from every FTS `power search` / `power index`.
- **Model-init race** (`embeddings.py`): `threading.Lock()` around `FastEmbedManager._lazy_init` so parallel callers cannot load the model twice.
- **WAL-aware Git sync**: `.gitignore` now excludes `*.db-wal` / `*.db-shm`; the committed DB snapshot is written only after `wal_checkpoint(TRUNCATE)`.

### Test plan (PRXMX-01, 15 GB)
- [x] `power --version` → 2.0.4
- [x] FTS search returns results, **0** "bge/Loading embedding" lines
- [x] Concurrent FTS (MCP + 2× bash) → 0 "database is locked"
- [x] `power lint` healthy (503 notes)
- [x] GPG-signed commit (key 2D49E810C7F2527E)

### Deploy notes
Reinstall into both the opencode venv and system python (or repoint `/usr/local/bin/power` shebang to the venv). MCP server must be restarted to pick up the new module.
