### PR TITLE
docs(readme): add WS development install (editable + power-update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,47 @@ power heal ~/my-vault          # Auto-fix missing/invalid frontmatter
 power markdown-check ~/my-vault  # Check markdown quality issues
 ```
 
+## Development Install (editable + easy update)
+
+For a **permanent, always-updatable** CLI on your workstation (WS), install in
+_editable_ mode from a local clone. This binds `power` to the repo so code
+changes take effect immediately — no reinstall needed.
+
+```bash
+# 1. Clone once
+git clone https://github.com/weby-homelab/power-framework.git /tmp/power-framework
+cd /tmp/power-framework
+
+# 2. Editable install into user-site (survives reboots, no venv required)
+pip install --user --break-system-packages -e ".[dev]"
+
+# 3. Verify — `power` is now on PATH (via ~/.local/bin)
+power --version
+```
+
+Update to the latest code anytime with:
+
+```bash
+cd /tmp/power-framework && git pull origin main && power --version
+# If pyproject.toml changed (new deps/version), reinstall:
+pip install --user --break-system-packages -e ".[dev]"
+```
+
+> 💡 **One-liner updater.** Save this as `/root/.local/bin/power-update` and
+> `chmod +x` it, then just run `power-update` to pull + reinstall automatically:
+>
+> ```bash
+> #!/usr/bin/env bash
+> set -euo pipefail
+> REPO="/tmp/power-framework"
+> cd "$REPO"
+> git fetch origin main && git reset --hard origin/main
+> if git diff --name-only HEAD@{1} HEAD | grep -q pyproject.toml; then
+>   pip install --user --break-system-packages -e ".[dev]" >/dev/null 2>&1
+> fi
+> power --version
+> ```
+
 ## What's Inside
 
 | Feature                         | What it does                                                                                                                                                                                                                                                                                                                                                                                                                   |

--- a/README.ua.md
+++ b/README.ua.md
@@ -42,6 +42,47 @@ power heal ~/my-vault      # Автовиправлення відсутньог
 power markdown-check ~/my-vault  # Перевірка якості Markdown
 ```
 
+## Розробницька установка (editable + легке оновлення)
+
+Для **постійного, завжди оновлюваного** CLI на робочій станції (WS) встановіть
+у _editable_ режимі з локальної копії. Це прив'язує `power` до репо, тож зміни
+коду набирають чинності одразу — перевстановлення не потрібне.
+
+```bash
+# 1. Клонуйте одного разу
+git clone https://github.com/weby-homelab/power-framework.git /tmp/power-framework
+cd /tmp/power-framework
+
+# 2. Editable-встановлення у user-site (переживає reboot, без venv)
+pip install --user --break-system-packages -e ".[dev]"
+
+# 3. Перевірка — `power` тепер у PATH (через ~/.local/bin)
+power --version
+```
+
+Оновити до останнього коду будь-коли:
+
+```bash
+cd /tmp/power-framework && git pull origin main && power --version
+# Якщо змінився pyproject.toml (нові залежності/версія) — перевстановіть:
+pip install --user --break-system-packages -e ".[dev]"
+```
+
+> 💡 **Оновлювач в один рядок.** Збережіть це як `/root/.local/bin/power-update`,
+> зробіть `chmod +x`, і просто запускайте `power-update` для авто-pull + reinstall:
+>
+> ```bash
+> #!/usr/bin/env bash
+> set -euo pipefail
+> REPO="/tmp/power-framework"
+> cd "$REPO"
+> git fetch origin main && git reset --hard origin/main
+> if git diff --name-only HEAD@{1} HEAD | grep -q pyproject.toml; then
+>   pip install --user --break-system-packages -e ".[dev]" >/dev/null 2>&1
+> fi
+> power --version
+> ```
+
 ## Що всередині
 
 | Функція                         | Що робить                                                                                                                                                                                                                                                                                                                                                                                                                   |


### PR DESCRIPTION
Додає розділ про постійну, легко оновлювану установку CLI на робочій станції (WS) у README.md та README.ua.md.

## Що додано
- **Development Install (editable + easy update)** — клон репо + `pip install --user --break-system-packages -e ".[dev]"`, що прив'язує `power` до репо (зміни коду набирають чинності без перевстановлення).
- Команда оновлення: `git pull origin main && power --version` (з перевстановленням, якщо змінився pyproject.toml).
- 💡 One-liner `/root/.local/bin/power-update` — автоматичний pull + reinstall за потреби.

Це відображає реально застосований на WS спосіб установки (див. сесію: `power` глобально доступний, оновлюється скриптом `power-update`).