### PR TITLE
fix: resolve CodeQL quality alerts

### DIFF
--- a/benchmarks/power31/scripts/evaluation/validate_dataset.py
+++ b/benchmarks/power31/scripts/evaluation/validate_dataset.py
@@ -395,7 +395,8 @@ def main() -> int:
         answers = load_jsonl(ANSWERS_FILE)
         print(f"  [PASS] Loaded {len(answers)} expected answers")
     except Exception as e:
-        errors.append(f"Answers load failed: {e}")
+        print(f"  [FAIL] Answers load: {e}")
+        return 1
 
     try:
         corpus = {f.name: f.read_text(encoding="utf-8") for f in CORPUS_DIR.glob("*.md")}

--- a/benchmarks/power31/scripts/generate_benchmark.py
+++ b/benchmarks/power31/scripts/generate_benchmark.py
@@ -1184,15 +1184,12 @@ def generate_expected_answers(
                         continue
                     break
                 else:
-                    atomic = q["query"]
                     expected = f"Information about {q['query']} is available."
                     facts = [expected]
             else:
-                atomic = q["query"]
                 expected = f"Information about {q['query']} is available."
                 facts = [expected]
         else:
-            atomic = q["query"]
             expected = f"Information about {q['query']} is available."
             facts = [expected]
 

--- a/scripts/check_search_quality.py
+++ b/scripts/check_search_quality.py
@@ -378,6 +378,7 @@ def load_or_build_qrels(
             if cached.get("vault") == str(Path(vault).resolve()) and "qrels" in cached:
                 return cached["qrels"]
         except (json.JSONDecodeError, OSError):
+            # An unreadable or stale cache is intentionally rebuilt below.
             pass
     qrels = build_qrels(vault, overrides=overrides)
     QRELS_CACHE.write_text(

--- a/src/power_framework/core/embeddings.py
+++ b/src/power_framework/core/embeddings.py
@@ -555,16 +555,10 @@ class BGEM3OnnxManager:
 
 _EMBED_MANAGER_CACHE: dict[str, object] = {}
 
-# Set True when the qwen3 ONNX backend fails to allocate on this host, so we
-# permanently fall back to fastembed for the process (avoids re-probing on
-# every manager fetch and silently producing empty vector indices).
-_QWEN3_DISABLED = False
-
 
 def get_embedding_manager(
     model_name: str | None = None,
 ) -> OllamaEmbeddingManager | FastEmbedManager | Qwen3EmbeddingManager | BGEM3OnnxManager:
-    global _QWEN3_DISABLED
     # Respect the module-level default (POWER 3.0: bge-m3) unless explicitly
     # overridden via the environment variable.
     provider = os.getenv("POWER_EMBED_PROVIDER", EMBED_PROVIDER).lower()

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -352,8 +352,6 @@ def _sync_vault_to_db(
     hosts) and is ~5-10x faster than per-item embedding. Results are streamed to
     the DB with periodic commits so the working set never holds the whole vault.
     """
-    import json
-
     cursor = conn.cursor()
     if force_rebuild and sync_embeddings:
         logger.info("Force rebuild: clearing dense-embedding tables ...")
@@ -781,8 +779,6 @@ def _vector_search(
 
     query_vec = _compute_tf_vector(query_tokens)
     db_path = _db_path()
-
-    import json
 
     try:
         conn = sqlite3.connect(str(db_path), timeout=30)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -8,12 +8,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 import power_framework.core.embeddings as embeddings
-from power_framework.core.embeddings import (
-    BGE_M3_ONNX_REVISION,
-    BGE_M3_PINNED_REPO,
-    configured_embedding_identity,
-    get_embedding_manager,
-)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -24,14 +18,14 @@ class TestEmbeddingManager:
         assert "/root/geminicli/.env" not in inspect.getsource(embeddings)
 
     def test_embed_single_text(self):
-        manager = get_embedding_manager()
+        manager = embeddings.get_embedding_manager()
         vec = manager.embed("Hello world")
         assert isinstance(vec, list)
         assert len(vec) == manager.dimension
         assert all(isinstance(v, float) for v in vec)
 
     def test_embed_batch(self):
-        manager = get_embedding_manager()
+        manager = embeddings.get_embedding_manager()
         texts = ["Hello world", "Second test text", "Third one here"]
         vectors = manager.embed_batch(texts)
         assert len(vectors) == 3
@@ -41,33 +35,33 @@ class TestEmbeddingManager:
             assert all(isinstance(v, float) for v in vec)
 
     def test_embed_empty_string(self):
-        manager = get_embedding_manager()
+        manager = embeddings.get_embedding_manager()
         vec = manager.embed("")
         assert isinstance(vec, list)
         assert len(vec) == manager.dimension
 
     def test_embed_batch_empty(self):
-        manager = get_embedding_manager()
+        manager = embeddings.get_embedding_manager()
         vectors = manager.embed_batch([])
         assert vectors == []
 
     def test_embedding_deterministic(self):
-        manager = get_embedding_manager()
+        manager = embeddings.get_embedding_manager()
         vec1 = manager.embed("Some consistent text")
         vec2 = manager.embed("Some consistent text")
         assert vec1 == vec2
 
     def test_embedding_different_texts(self):
-        manager = get_embedding_manager()
+        manager = embeddings.get_embedding_manager()
         vec1 = manager.embed("Kittens are cute")
         vec2 = manager.embed("Rocket science")
         assert vec1 != vec2
 
     def test_canonical_identity_contains_immutable_revision(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("POWER_EMBED_PROVIDER", "bge-m3")
-        provider, model = configured_embedding_identity()
+        provider, model = embeddings.configured_embedding_identity()
         assert provider == "BGEM3OnnxManager"
-        assert model == f"{BGE_M3_PINNED_REPO}@{BGE_M3_ONNX_REVISION}"
+        assert model == f"{embeddings.BGE_M3_PINNED_REPO}@{embeddings.BGE_M3_ONNX_REVISION}"
 
     def test_sha256_verification_fails_closed(self, tmp_path: Path):
         artifact = tmp_path / "model.onnx"

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -413,7 +413,6 @@ class TestSearchVault:
         assert any("Test Project" in r.title for r in results)
 
     def test_search_vault_fallback_on_sqlite_error(self, sample_vault: Path):
-        import sqlite3
         from unittest.mock import patch
 
         with patch("sqlite3.connect", side_effect=sqlite3.Error("Mocked SQLite Error")):


### PR DESCRIPTION
## Summary
- resolve all 10 open CodeQL quality alerts
- make dataset validation fail safely when expected answers cannot be loaded

## Validation
- `pytest --no-cov tests/test_embeddings.py tests/test_searcher.py -q` (72 passed)
- `pytest --no-cov tests/test_benchmark_integrity.py -q` (50 passed)
- `python3 scripts/evaluation/validate_dataset.py` (passed)
- `ruff check src tests scripts benchmarks/power31/scripts benchmarks/power31/tests` (passed)

MyPy was unavailable in this execution environment.