### PR TITLE
docs(plan): add multi-methodology expansion architecture roadmap

### DIFF
--- a/docs/plans/2026-07-24-multi-methodology-expansion-plan.md
+++ b/docs/plans/2026-07-24-multi-methodology-expansion-plan.md
@@ -1,0 +1,73 @@
+---
+type: Resource
+title: "P.O.W.E.R. Roadmap: Multi-Methodology Knowledge Framework Engine (P.A.R.A., C.O.D.E., GTD, Zettelkasten, LYT, Johnny.Decimal)"
+description: "Architectural blueprint for pluggable methodology templates, linter schemas, and CLI/MCP preset engine in P.O.W.E.R."
+tags: [power, architecture, roadmap, gtd, zettelkasten, lyt, johnny-decimal, code, mcp]
+timestamp: 2026-07-24T17:28:00
+---
+
+# 🚀 P.O.W.E.R. Architecture Expansion: Multi-Methodology Engine
+
+## 🎯 Vision
+
+Expand P.O.W.E.R. from a single P.A.R.A.-centric framework into a **Pluggable Multi-Methodology Knowledge Engine for AI Agents and Humans**. 
+
+Out-of-the-box, users and AI agents can choose, initialize, validate, and search knowledge bases built on any popular knowledge organization system:
+
+1. **P.A.R.A.** (Projects, Areas, Resources, Archive) — *Default Task-Driven Focus*
+2. **C.O.D.E.** (Capture, Organize, Distill, Express) — *Content Lifecycle & Synthesis*
+3. **GTD** (Getting Things Done) — *Inbox, Next Actions, Waiting For, Someday/Maybe*
+4. **Zettelkasten** (Atomic Notes, UID Timestamps, Dense Fleeting/Permanent Links) — *Idea Graph*
+5. **LYT** (Linking Your Thinking) — *Maps of Content (MOCs), Home, Hubs*
+6. **Johnny.Decimal** (10-49 Category & Area Numbering System) — *Strict Decimal Hierarchy*
+
+---
+
+## 🛠️ Proposed Architecture & Features
+
+### 1. Preset Initializer (`power init --template <name>`)
+
+```bash
+# Initialize a GTD-oriented vault
+power init /path/to/vault --template gtd
+
+# Initialize a Zettelkasten atomic vault
+power init /path/to/vault --template zettelkasten
+
+# Initialize a Johnny.Decimal vault
+power init /path/to/vault --template johnny-decimal
+```
+
+### 2. Pluggable OKF Frontmatter & Linter Schemas
+
+- **Pydantic v2 Taxonomy Providers**: Dynamic schema validation tailored to the active methodology.
+- **`power lint --methodology <name>`**: Custom rule enforcement (e.g. Zettelkasten requires UID timestamps & atomic links; GTD enforces actionability fields; Johnny.Decimal enforces `XX.YY` category codes).
+
+### 3. Pluggable MCP Tool Engine
+
+MCP tools automatically inspect the active vault's methodology in `.power.json` / `OKF` metadata:
+- `ingest_note(..., methodology="zettelkasten")` auto-generates atomic UIDs.
+- `search_vault_tool` filtering by methodology-specific facets (e.g. `MOCs`, `Next Actions`).
+
+### 4. Cross-Methodology Converter (`power convert`)
+
+Seamlessly transform or overlay notes across methodologies without data loss.
+
+---
+
+## 📋 Comparison of Supported Methodologies
+
+| Methodology | Core Focus | Vault Skeleton | Primary Metric |
+| :--- | :--- | :--- | :--- |
+| **P.A.R.A.** | Actionability & Deadlines | `01_Projects`, `02_Areas`, `03_Resources`, `04_Archive` | Project completion rate |
+| **C.O.D.E.** | Knowledge Distillation | `01_Capture`, `02_Organize`, `03_Distill`, `04_Express` | Synthesis output |
+| **GTD** | Task Processing | `00_Inbox`, `01_Next_Actions`, `02_Waiting_For`, `03_Someday` | Inbox Zero & Flow |
+| **Zettelkasten** | Atomic Connection | `fleeting/`, `literature/`, `permanent/`, `index/` | Graph density & UID links |
+| **LYT** | MOC Navigation | `Home.md`, `MOCs/`, `Notes/`, `Archives/` | MOC coverage |
+| **Johnny.Decimal** | Strict Indexing | `10-19_Admin/`, `20-29_Engineering/`, `30-39_Ops/` | Decimal addressability |
+
+---
+
+<p align="center">
+  <b>P.O.W.E.R. Framework Roadmap 2026</b> ⚡
+</p>


### PR DESCRIPTION
## Description

- Adds `docs/plans/2026-07-24-multi-methodology-expansion-plan.md` outlining the architectural roadmap for pluggable multi-methodology support:
  - P.A.R.A. (Actionability focus)
  - C.O.D.E. (Content synthesis)
  - GTD (Task flow & processing)
  - Zettelkasten (Atomic UID idea graph)
  - LYT (Map of Content MOCs)
  - Johnny.Decimal (Strict 10-49 index numbering)
- Details CLI flag `power init --template <name>`, pluggable Pydantic v2 OKF schema rules, and MCP tool facets.

## Verification
- `./verify.sh` passed 100% cleanly.