### PR TITLE
docs: move Why P.O.W.E.R. 3.2.1 links up to ## Why P.O.W.E.R.? section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Unlike generic knowledge management tools, P.O.W.E.R. is designed from the groun
 - **MCP-native** — expose all 12 tools to any MCP-compatible AI client (Claude, OpenCode, Cursor) with zero glue code, powered by FastMCP 3.x
 - **Beta with explicit release gates** — hermetic tests and security checks are tracked in CI; the [P.O.W.E.R. 3.1 trust-release baseline](docs/adr/0001-power-3.1-trust-release-baseline.md) records the remaining gates.
 
+Detailed breakdown and technical comparison matrix with competing frameworks:
+
+- **[English: Why P.O.W.E.R. 3.2.1](https://github.com/weby-homelab/power-framework/blob/main/WHY_POWER_3.2.1.en.md)** — comparison matrix, 5 super features, token economy, P.A.R.A. flexibility FAQ
+- **[Українська: Чому P.O.W.E.R. 3.2.1](https://github.com/weby-homelab/power-framework/blob/main/WHY_POWER_3.2.1.md)** — огляд, порівняльна таблиця, 5 супер фішок, економія токенів
+
 ## Quick Start
 
 ```bash
@@ -127,13 +132,6 @@ Step-by-step protocol for any AI agent (Antigravity, OpenCode, Claude Code CLI, 
 
 - **[English: AI Agent Migration Guide](https://github.com/weby-homelab/power-framework/blob/main/docs/migration-guide.md)** — 5-phase protocol with MCP tools, classification heuristics, and troubleshooting
 - **[Українська: Ґайд міграції для AI-агента](https://github.com/weby-homelab/power-framework/blob/main/docs/migration-guide.ua.md)** — покроковий протокол для будь-якого AI-агента
-
-### Why P.O.W.E.R. 3.2.1
-
-Detailed breakdown and technical comparison matrix with competing frameworks:
-
-- **[English: Why P.O.W.E.R. 3.2.1](https://github.com/weby-homelab/power-framework/blob/main/WHY_POWER_3.2.1.en.md)** — comparison matrix, 5 super features, token economy, P.A.R.A. flexibility FAQ
-- **[Українська: Чому P.O.W.E.R. 3.2.1](https://github.com/weby-homelab/power-framework/blob/main/WHY_POWER_3.2.1.md)** — огляд, порівняльна таблиця, 5 супер фішок, економія токенів
 
 ## 🗂️ Methodology Support: Choose What Works for You
 


### PR DESCRIPTION
Moves the 'Why P.O.W.E.R. 3.2.1' document links directly under the `## Why P.O.W.E.R.?` heading at the top of README.md, and removes the orphaned `### Why P.O.W.E.R. 3.2.1` subsection that was buried below the AI Agent Migration Guide section.