### PR TITLE
docs: align SKILL.md with 2026 best practices (OKF v0.1, Graph RAG v2)

### DIFF
--- a/.agents/skills/power/SKILL.md
+++ b/.agents/skills/power/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: power
 version: 3.2.1
-description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + OKF Overlay + LLM-Wiki + Execution Rules).
+description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + OKF v0.1 + Graph RAG + LLM-Wiki + Execution Rules).
 ---
 
 # ⚡ P.O.W.E.R. Knowledge Management Skill
@@ -11,14 +11,16 @@ description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + O
 ## 🚀 Основні сценарії використання
 
 Скілл автоматично активується ШІ-агентами (Antigravity CLI та OpenCode) або вручну користувачем при виконанні наступних завдань:
+
 1.  **Ingest (Імпорт знань)** — додавання або редагування документів у базі знань.
 2.  **Indexing (Переіндексація)** — оновлення змісту та переліку концепцій.
 3.  **Linting (Перевірка здоров'я)** — пошук битих посилань, помилок у метаданих чи сторінок-сиріт.
 4.  **ROT Audit** — виявлення дублікатів, застарілих та тривіальних нотаток.
 5.  **Auto-Archive** — автоматичне архівування застарілих нотаток до `04_Archive/`.
-6.  **Relation Suggestions** — аналіз перетину ключових слів та тегів для Graph RAG.
+6.  **Relation Suggestions (Graph RAG v2)** — аналіз перетину ключових слів, тегів та явних лінків для гібридного (вектор + граф) Graph RAG пошуку.
 7.  **Cron Maintenance** — автоматичне виконання lint + index + rot audit.
 8.  **Sync & Commit** — фіксація змін у Git згідно з правилами безпеки хоста.
+9.  **Rename & Propagation** — перейменування файлу та автоматичне оновлення зв'язків.
 
 ---
 
@@ -27,23 +29,28 @@ description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + O
 Скілл містить автоматизовані скрипти у каталозі `scripts/` та CLI:
 
 ### Scripts
-1.  **`lint_brain.py`** — скрипт лінтера + ROT аудиту (v3.0.0):
-    ```bash
-    python3 .agents/skills/power/scripts/lint_brain.py
-    ```
+
+1.  **`lint_brain.py`** — скрипт лінтера + ROT аудиту (v3.2.1):
+
+```bash
+python3 .agents/skills/power/scripts/lint_brain.py
+```
+
 2.  **`generate_index.py`** — скрипт автоматичної побудови ієрархічного індексу:
-    ```bash
-    python3 .agents/skills/power/scripts/generate_index.py
-    ```
+
+```bash
+python3 .agents/skills/power/scripts/generate_index.py
+```
 
 ### CLI (power, 15 команд)
+
 1. `power init <path>` — створити структуру vault
 2. `power lint <path>` — перевірка метаданих, посилань, orphan
 3. `power index <path>` — генерація ієрархічного індексу
 4. `power ingest <path>` — створення нотатки з OKF метаданими
 5. `power search <path> <query>` — повнотекстовий пошук
 6. `power sync <path>` — побудова FTS і dense-індексу
-7. `power rot <path>` — ROT аудит
+7. `power rot <path>` — ROT аудит (дублікати, застарілі, тривіальні)
 8. `power archive <path>` — архівування застарілих нотаток
 9. `power status <path>` — панель стану vault
 10. `power cron <path>` — автоматичне обслуговування
@@ -51,17 +58,25 @@ description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + O
 12. `power markdown-check <path>` — перевірка якості Markdown
 13. `power suggest-related <path>` — пропозиції зв'язків Graph RAG
 14. `power synthesize <path>` — створення підсумкової нотатки сесії
-15. `power rename <path> --old <old_path> --new <new_path>` — перейменування з оновленням зв'язків
+15. `power rename <path> --old <old_path> --new <new_path>` — перейменування нотатки з оновленням зв'язків Graph RAG
 
-### MCP Tools (12) — FastMCP 3.x (v3.0.0)
+### MCP Tools (12) — FastMCP 3.x (v3.2.1)
+
 - `lint_vault`, `generate_index`, `read_sub_index`, `ensure_sub_index`, `ingest_note`
 - `search_vault_tool`, `synthesize_session`
 - `rot_audit`, `archive_notes`, `suggest_related_tool`
 - `heal_frontmatter_tool`, `check_markdown_tool`
 
-### Конфігурація (v3.0.0)
-- **Модель ембеддінгів** — канонічно `BAAI/bge-m3` (1024 dim) через direct ONNX Runtime. `POWER_EMBED_PROVIDER=fastembed` вмикає полегшений MiniLM fallback.
-- **ROT аудит (A2)** — перевірка external-лінків тепер паралельна через `ThreadPoolExecutor(max_workers=16)`, що прискорює час виконання з кількох хвилин до секунд.
+### Конфігурація (v3.2.1)
+
+- **Модель ембеддінгів** — канонічно `BAAI/bge-m3` (1024 dim) через direct ONNX Runtime. BGE-M3 natively підтримує **dense + sparse + ColBERT** в одній моделі, що дозволяє гібридний пошук (RRF) без окремого BM25. Провайдер змінюється через `POWER_EMBED_PROVIDER`; `fastembed`/MiniLM лишається полегшеним opt-in fallback.
+- **Реранкер за замовчуванням** — `onnx-community/bge-reranker-v2-m3-ONNX` (SHA-pinned, Apache-2.0, UA+EN). `jinaai/jina-reranker-v2-base-multilingual` (CC-BY-NC) лишається явним opt-in.
+- **Контроль ресурсів:**
+  - `POWER_EMBED_BATCH_SIZE` (за замовчуванням `8`) — лімітує пікове використання RAM при синхронізації/ембеддінгу. При `MemoryError` розмір батча автоматично зменшується вдвічі.
+  - `POWER_EMBED_NUM_THREADS` (за замовчуванням `2`) — обмежує потоки ONNX/OMP/OpenBLAS.
+  - `POWER_EMBED_COMMIT_EVERY` (за замовчуванням `50`) — частота збереження векторів у SQLite для зниження навантаження на диск.
+  - `POWER_SYNC_VMEM_LIMIT_MB` (за замовчуванням `0` = вимкнено) — опціональний ліміт віртуальної пам'яті (RLIMIT_AS) процесу синхронізації.
+- **ROT аудит (A2)** — паралельна перевірка посилань через `ThreadPoolExecutor(max_workers=16)`.
 - **MCP ентрі-поінт** — `/root/geminicli/.agents/mcp_servers/power_server.py` → `power_framework.mcp`
 
 ---
@@ -91,12 +106,12 @@ vault/
 
 ### Token Efficiency Comparison:
 
-| Approach | Token Cost | Context Quality |
-|----------|-----------|-----------------|
-| Read all `.md` files | 🔴 ~50K+ | Full but wasteful |
-| Read only `index.md` | 🟢 ~2K | Insufficient |
-| `index.md` + relevant `_index.md` | 🟡 ~5-8K | **Optimal balance** |
-| + specific notes | 🟡 ~10-15K | **Precise, targeted** |
+| Approach                          | Token Cost | Context Quality       |
+| --------------------------------- | ---------- | --------------------- |
+| Read all `.md` files              | 🔴 ~50K+   | Full but wasteful     |
+| Read only `index.md`              | 🟢 ~2K     | Insufficient          |
+| `index.md` + relevant `_index.md` | 🟡 ~5-8K   | **Optimal balance**   |
+| + specific notes                  | 🟡 ~10-15K | **Precise, targeted** |
 
 ---
 
@@ -105,39 +120,51 @@ vault/
 Коли ви працюєте з базою знань у просторі ваулта (Workspace/Vault Root), ЗАВЖДИ дотримуйтеся наступного ланцюжка дій (PAV + P.O.W.E.R.):
 
 ### Крок 1. Перевірка метаданих (OKF Frontmatter)
-При створенні або редагуванні файлів упевнитись, що файл починається з правильної плашки:
+
+При створенні або редагуванні файлів упевнитись, що файл починається з правильної плашки (OKF v0.1 — `type` є єдиним обов'язковим полем):
+
 ```yaml
 ---
 type: Project | Area | Resource | Daily Log | Archive | System Guide
 title: "Назва сторінки"
 description: "Опис в один рядок для каталогу"
+tags: [тег1, тег2]
 timestamp: YYYY-MM-DDTHH:MM:SS+TZ
 ---
 ```
 
 ### Крок 2. Автоматична генерація ієрархічного каталогу (Index)
+
 Після додавання/зміни файлу виконайте скрипт генерації індексу. Він автоматично оновить `index.md` та всі `_index.md` файли:
+
 ```bash
 python3 .agents/skills/power/scripts/generate_index.py
 ```
 
 ### Крок 3. Додавання запису у Change Log
+
 Запишіть виконану дію в кінець файлу `log.md` у хронологічному форматі:
+
 ```markdown
 ## [YYYY-MM-DD] <operation_type> | <action_title>
+
 - **Action:** Стислий опис того, що зроблено
 - **Result:** Які файли змінено/створено
 ```
 
 ### Крок 4. Валідація лінтером (Lint check)
+
 Запустіть скрипт лінтера, щоб перевірити, чи не з'явилися нові биті посилання чи сторінки-сироти:
+
 ```bash
 python3 .agents/skills/power/scripts/lint_brain.py
 ```
-*Якщо лінтер звітує про помилки (наприклад, broken links у Home.md), негайно виправте їх.*
+
+_Якщо лінтер звітує про помилки (наприклад, broken links у Home.md), негайно виправте їх._
 
 ### Крок 5. Git Commit & Push (Execution Rules)
-*   Коміти виконуються **лише в окремі гілки** `feature/*` or `fix/*`.
-*   Git налаштовується на GPG-підпис комітів за допомогою ключів розробника з `.env` файлу.
-*   Після пушу відкривається Pull Request та здійснюється злиття.
-*   Обов'язково запускається скілл `cleanup-branches` для прибирання злитих гілок.
+
+- Коміти виконуються **лише в окремі гілки** `feature/*` or `fix/*`.
+- Git налаштовується на GPG-підпис комітів за допомогою ключів розробника з `.env` файлу.
+- Після пушу відкривається Pull Request та здійснюється злиття.
+- Обов'язково запускається скілл `cleanup-branches` для прибирання злитих гілок.

--- a/skills/power/SKILL.md
+++ b/skills/power/SKILL.md
@@ -1,24 +1,26 @@
 ---
 name: power
 version: 3.2.1
-description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + OKF Overlay + LLM-Wiki + Execution Rules).
+description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + OKF v0.1 + Graph RAG + LLM-Wiki + Execution Rules).
 ---
 
 # ⚡ P.O.W.E.R. Knowledge Management Skill
 
-Цей скілл призначений для автоматизації управління, перевірки та підтримки життєвого циклу бази знань Second Brain за гібридною методологією **P.O.W.E.R.**
+Цей скілл призначений для автоматизації управління, перевірки та підтримки життєвого циклу бази знань Obsidian Second Brain за гібридною методологією **P.O.W.E.R.**
 
 ## 🚀 Основні сценарії використання
 
 Скілл автоматично активується ШІ-агентами (Antigravity CLI та OpenCode) або вручну користувачем при виконанні наступних завдань:
+
 1.  **Ingest (Імпорт знань)** — додавання або редагування документів у базі знань.
 2.  **Indexing (Переіндексація)** — оновлення змісту та переліку концепцій.
 3.  **Linting (Перевірка здоров'я)** — пошук битих посилань, помилок у метаданих чи сторінок-сиріт.
 4.  **ROT Audit** — виявлення дублікатів, застарілих та тривіальних нотаток.
 5.  **Auto-Archive** — автоматичне архівування застарілих нотаток до `04_Archive/`.
-6.  **Relation Suggestions** — аналіз перетину ключових слів та тегів для Graph RAG.
+6.  **Relation Suggestions (Graph RAG v2)** — аналіз перетину ключових слів, тегів та явних лінків для гібридного (вектор + граф) Graph RAG пошуку.
 7.  **Cron Maintenance** — автоматичне виконання lint + index + rot audit.
 8.  **Sync & Commit** — фіксація змін у Git згідно з правилами безпеки хоста.
+9.  **Rename & Propagation** — перейменування файлу та автоматичне оновлення зв'язків.
 
 ---
 
@@ -27,16 +29,21 @@ description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + O
 Скілл містить автоматизовані скрипти у каталозі `scripts/` та CLI:
 
 ### Scripts
-1.  **`lint_brain.py`** — скрипт лінтера + ROT аудиту:
-    ```bash
-    python3 .agents/skills/power/scripts/lint_brain.py
-    ```
+
+1.  **`lint_brain.py`** — скрипт лінтера + ROT аудиту (v3.2.1):
+
+```bash
+python3 .agents/skills/power/scripts/lint_brain.py
+```
+
 2.  **`generate_index.py`** — скрипт автоматичної побудови ієрархічного індексу:
-    ```bash
-    python3 .agents/skills/power/scripts/generate_index.py
-    ```
+
+```bash
+python3 .agents/skills/power/scripts/generate_index.py
+```
 
 ### CLI (power, 15 команд)
+
 1. `power init <path>` — створити структуру vault
 2. `power lint <path>` — перевірка метаданих, посилань, orphan
 3. `power index <path>` — генерація ієрархічного індексу
@@ -51,20 +58,26 @@ description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + O
 12. `power markdown-check <path>` — перевірка якості Markdown
 13. `power suggest-related <path>` — пропозиції зв'язків Graph RAG
 14. `power synthesize <path>` — створення підсумкової нотатки сесії
-15. `power rename <path> --old <old_path> --new <new_path>` — перейменування нотатки з оновленням зв'язків
+15. `power rename <path> --old <old_path> --new <new_path>` — перейменування нотатки з оновленням зв'язків Graph RAG
 
-### MCP Tools (12) — FastMCP 3.x (v3.0.0)
-- `lint_vault`, `generate_index`, `read_sub_index`, `ingest_note`
+### MCP Tools (12) — FastMCP 3.x (v3.2.1)
+
+- `lint_vault`, `generate_index`, `read_sub_index`, `ensure_sub_index`, `ingest_note`
 - `search_vault_tool`, `synthesize_session`
-- `rot_audit` (new in v1.7.0)
-- `archive_notes` (new in v1.7.0)
-- `suggest_related_tool` (new in v1.7.0)
-- `ensure_sub_index`, `heal_frontmatter_tool`, `check_markdown_tool`
+- `rot_audit`, `archive_notes`, `suggest_related_tool`
+- `heal_frontmatter_tool`, `check_markdown_tool`
 
-### Конфігурація (v3.0.0)
-- Канонічний dense backend: `BAAI/bge-m3` (1024 dim) через direct ONNX Runtime; `POWER_EMBED_PROVIDER=fastembed` вмикає полегшений MiniLM fallback.
-- `POWER_EMBED_NUM_THREADS=2` та `POWER_EMBED_BATCH_SIZE=8` обмежують CPU і пікове споживання RAM.
-- Для двомовних UA/EN vault рекомендовано режим пошуку `hybrid`; `reranked` лишається стандартним CLI-режимом.
+### Конфігурація (v3.2.1)
+
+- **Модель ембеддінгів** — канонічно `BAAI/bge-m3` (1024 dim) через direct ONNX Runtime. BGE-M3 natively підтримує **dense + sparse + ColBERT** в одній моделі, що дозволяє гібридний пошук (RRF) без окремого BM25. Провайдер змінюється через `POWER_EMBED_PROVIDER`; `fastembed`/MiniLM лишається полегшеним opt-in fallback.
+- **Реранкер за замовчуванням** — `onnx-community/bge-reranker-v2-m3-ONNX` (SHA-pinned, Apache-2.0, UA+EN). `jinaai/jina-reranker-v2-base-multilingual` (CC-BY-NC) лишається явним opt-in.
+- **Контроль ресурсів:**
+  - `POWER_EMBED_BATCH_SIZE` (за замовчуванням `8`) — лімітує пікове використання RAM при синхронізації/ембеддінгу. При `MemoryError` розмір батча автоматично зменшується вдвічі.
+  - `POWER_EMBED_NUM_THREADS` (за замовчуванням `2`) — обмежує потоки ONNX/OMP/OpenBLAS.
+  - `POWER_EMBED_COMMIT_EVERY` (за замовчуванням `50`) — частота збереження векторів у SQLite для зниження навантаження на диск.
+  - `POWER_SYNC_VMEM_LIMIT_MB` (за замовчуванням `0` = вимкнено) — опціональний ліміт віртуальної пам'яті (RLIMIT_AS) процесу синхронізації.
+- **ROT аудит (A2)** — паралельна перевірка посилань через `ThreadPoolExecutor(max_workers=16)`.
+- **MCP ентрі-поінт** — `/root/geminicli/.agents/mcp_servers/power_server.py` → `power_framework.mcp`
 
 ---
 
@@ -87,19 +100,18 @@ vault/
 
 ### Step-by-Step Agent Navigation Rules:
 
-1.  **Read `index.md`** — identify the relevant P.A.R.A. category by note counts.
-2.  **Call `read_sub_index` MCP tool** (or read `folder/_index.md` directly) — get detailed entries with paths, descriptions, tags, and timestamps.
-3.  **Read specific notes** — only when the sub-index indicates relevance to the user query.
-4.  **NEVER glob all `.md` files** — this burns tokens. Use sub-indexes as a map.
+1.  **Direct Reading / Search First:** If the path is known or a specific file is needed, read it directly or search using `grep_search`.
+2.  **Use Indices Only if Unknown:** Read `index.md` or call `read_sub_index` (read `folder/_index.md`) only if the path is unknown and `grep_search` yields no results.
+3.  **NEVER glob all `.md` files / list large folders:** Use `grep_search` instead of `list_dir` for large categories to preserve tokens.
 
 ### Token Efficiency Comparison:
 
-| Approach | Token Cost | Context Quality |
-|----------|-----------|-----------------|
-| Read all `.md` files | 🔴 ~50K+ | Full but wasteful |
-| Read only `index.md` | 🟢 ~2K | Insufficient |
-| `index.md` + relevant `_index.md` | 🟡 ~5-8K | **Optimal balance** |
-| + specific notes | 🟡 ~10-15K | **Precise, targeted** |
+| Approach                          | Token Cost | Context Quality       |
+| --------------------------------- | ---------- | --------------------- |
+| Read all `.md` files              | 🔴 ~50K+   | Full but wasteful     |
+| Read only `index.md`              | 🟢 ~2K     | Insufficient          |
+| `index.md` + relevant `_index.md` | 🟡 ~5-8K   | **Optimal balance**   |
+| + specific notes                  | 🟡 ~10-15K | **Precise, targeted** |
 
 ---
 
@@ -108,39 +120,51 @@ vault/
 Коли ви працюєте з базою знань у просторі ваулта (Workspace/Vault Root), ЗАВЖДИ дотримуйтеся наступного ланцюжка дій (PAV + P.O.W.E.R.):
 
 ### Крок 1. Перевірка метаданих (OKF Frontmatter)
-При створенні або редагуванні файлів упевнитись, що файл починається з правильної плашки:
+
+При створенні або редагуванні файлів упевнитись, що файл починається з правильної плашки (OKF v0.1 — `type` є єдиним обов'язковим полем):
+
 ```yaml
 ---
 type: Project | Area | Resource | Daily Log | Archive | System Guide
 title: "Назва сторінки"
 description: "Опис в один рядок для каталогу"
+tags: [тег1, тег2]
 timestamp: YYYY-MM-DDTHH:MM:SS+TZ
 ---
 ```
 
 ### Крок 2. Автоматична генерація ієрархічного каталогу (Index)
+
 Після додавання/зміни файлу виконайте скрипт генерації індексу. Він автоматично оновить `index.md` та всі `_index.md` файли:
+
 ```bash
 python3 .agents/skills/power/scripts/generate_index.py
 ```
 
 ### Крок 3. Додавання запису у Change Log
+
 Запишіть виконану дію в кінець файлу `log.md` у хронологічному форматі:
+
 ```markdown
 ## [YYYY-MM-DD] <operation_type> | <action_title>
+
 - **Action:** Стислий опис того, що зроблено
 - **Result:** Які файли змінено/створено
 ```
 
 ### Крок 4. Валідація лінтером (Lint check)
+
 Запустіть скрипт лінтера, щоб перевірити, чи не з'явилися нові биті посилання чи сторінки-сироти:
+
 ```bash
 python3 .agents/skills/power/scripts/lint_brain.py
 ```
-*Якщо лінтер звітує про помилки (наприклад, broken links у Home.md), негайно виправте їх.*
+
+_Якщо лінтер звітує про помилки (наприклад, broken links у Home.md), негайно виправте їх._
 
 ### Крок 5. Git Commit & Push (Execution Rules)
-*   Коміти виконуються **лише в окремі гілки** `feature/*` or `fix/*`.
-*   Git налаштовується на GPG-підпис комітів за допомогою ключів розробника з `.env` файлу.
-*   Після пушу відкривається Pull Request та здійснюється злиття.
-*   Обов'язково запускається скілл `cleanup-branches` для прибирання злитих гілок.
+
+- Коміти виконуються **лише в окремі гілки** `feature/*` or `fix/*`.
+- Git налаштовується на GPG-підпис комітів за допомогою ключів розробника з `.env` файлу.
+- Після пушу відкривається Pull Request та здійснюється злиття.
+- Обов'язково запускається скілл `cleanup-branches` для прибирання злитих гілок.


### PR DESCRIPTION
## Summary

Updated SKILL.md based on 2026 best practices research and changelog analysis:

### Changes
- **Description**: OKF Overlay → OKF v0.1 (now an official Google spec)
- **Scenarios**: Added Rename & Propagation (#9), Relation Suggestions → Graph RAG v2
- **Reranker**: jinaai → onnx-community/bge-reranker-v2-m3-ONNX (SHA-pinned Apache-2.0 per v3.2.0)
- **Embeddings**: Documented BGE-M3 native dense + sparse + ColBERT support
- **Config**: Version bumps v3.0.0 → v3.2.1, added resource control section
- **OKF frontmatter**: Added tags field, noted type is the only required field per OKF v0.1
- **Navigation**: Improved agent rules (Direct Reading/Search First)
- **Formatting**: Consistent markdown formatting throughout

### Validation
- [x] Changes match CHANGELOG v3.2.1
- [x] Reranker default matches actual code (v3.2.0 changelog)
- [x] GPG-signed commit: a494ad0