### PR TITLE
chore: establish POWER 3.3 Phase 0 release contract

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,6 +1,6 @@
 # P.O.W.E.R. Framework — Agent Instructions
 
-Python 3.10+ toolkit for AI-native Second Brain management. CLI (`power`) + MCP server (12 tools).
+Python 3.11+ toolkit for AI-native Second Brain management. CLI (`power`) + MCP server (12 tools).
 
 ## Project Structure
 

--- a/.agents/INSTRUCTIONS.md
+++ b/.agents/INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # P.O.W.E.R. Framework — Agent Instructions
 
-Python 3.10+, hatchling, Pydantic v2, FastMCP 3.x, ONNX Runtime, BGE-M3.
+Python 3.11+, hatchling, Pydantic v2, FastMCP 3.x, ONNX Runtime, BGE-M3.
 
 ## Commands
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -37,7 +37,7 @@ jobs:
         run: ruff format --check src/ tests/
 
       - name: Run MyPy type check
-        if: ${{ !startsWith(matrix.python-version, '3.10') && !startsWith(matrix.python-version, '3.11') }}
+        if: ${{ matrix.python-version == '3.13' }}
         run: mypy src/power_framework/
 
       - name: Verify current documentation contract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,29 @@ jobs:
       - name: Verify current documentation contract
         run: python scripts/check_doc_drift.py
 
+      - name: Verify release metadata contract
+        run: python scripts/verify_release_contract.py
+
       - name: Run tests with coverage
         run: pytest tests/ -v --tb=short --cov=src/power_framework/ --cov-report=term-missing --cov-fail-under=70
+
+  benchmark-integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run hermetic frozen benchmark checks
+        run: pytest benchmarks/power31/tests -q --no-cov --override-ini=addopts=
 
   security:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
   schedule:
     - cron: "0 6 * * 1"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
   workflow_dispatch:
 
 permissions:
@@ -41,6 +46,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Thank you for your interest in contributing to the P.O.W.E.R. Framework!
 
 ## Code Standards
 
-- **Python**: 3.10+ with type hints
+- **Python**: 3.11+ with type hints
 - **Formatting**: Ruff (line-length 100)
 - **Types**: MyPy strict mode
 - **Style**: Follow PEP 8, use existing patterns

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Validate, index, search, and manage your knowledge base from the command line â€
 
 [![CI](https://github.com/weby-homelab/power-framework/actions/workflows/ci.yml/badge.svg)](https://github.com/weby-homelab/power-framework/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/weby-homelab/power-framework?logo=github)](https://github.com/weby-homelab/power-framework/releases)
-[![Python 3.10+](https://img.shields.io/badge/Python-3.10+-3776AB?logo=python&logoColor=white)](https://www.python.org/)
+[![Python 3.11+](https://img.shields.io/badge/Python-3.11+-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![CodeQL](https://github.com/weby-homelab/power-framework/actions/workflows/codeql.yml/badge.svg)](https://github.com/weby-homelab/power-framework/actions/workflows/codeql.yml)
 [![Docs](https://img.shields.io/badge/docs-mkdocs--material-8A2BE2?logo=materialformkdocs)](https://weby-homelab.github.io/power-framework/)
@@ -489,7 +489,7 @@ MACHINE-READABLE-METADATA: JSON-LD BELOW
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Linux, macOS, Windows",
   "programmingLanguage": "Python",
-  "runtimePlatform": "Python 3.10+",
+  "runtimePlatform": "Python 3.11+",
   "softwareVersion": "latest",
   "license": "https://www.gnu.org/licenses/gpl-3.0",
   "keywords": ["second-brain", "obsidian", "AI", "MCP", "knowledge-management", "PARA", "CLI", "LLM", "RAG", "knowledge-base"],

--- a/README.ua.md
+++ b/README.ua.md
@@ -8,7 +8,7 @@
 
 [![CI](https://github.com/weby-homelab/power-framework/actions/workflows/ci.yml/badge.svg)](https://github.com/weby-homelab/power-framework/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/weby-homelab/power-framework?logo=github)](https://github.com/weby-homelab/power-framework/releases)
-[![Python 3.10+](https://img.shields.io/badge/Python-3.10+-3776AB?logo=python&logoColor=white)](https://www.python.org/)
+[![Python 3.11+](https://img.shields.io/badge/Python-3.11+-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![CodeQL](https://github.com/weby-homelab/power-framework/actions/workflows/codeql.yml/badge.svg)](https://github.com/weby-homelab/power-framework/actions/workflows/codeql.yml)
 [![Docs](https://img.shields.io/badge/docs-mkdocs--material-8A2BE2?logo=materialformkdocs)](https://weby-homelab.github.io/power-framework/)

--- a/benchmarks/power31/tests/test_evaluation_harness.py
+++ b/benchmarks/power31/tests/test_evaluation_harness.py
@@ -431,7 +431,7 @@ def _make_minimal_evidence() -> dict:
         },
         "dependency_lock_hash": None,
         "models_lock": {"hash": "a" * 64, "revision": "some-revision"},
-        "python_version": "3.10.0",
+        "python_version": "3.11.0",
         "platform": "linux",
         "hardware": {
             "cpu": "x86_64",

--- a/docs/plans/issue-187-production-validation-checklist.md
+++ b/docs/plans/issue-187-production-validation-checklist.md
@@ -1,10 +1,17 @@
 # Issue #187 — executable production-validation checklist
 
-**Status:** Open evidence gate
+**Status:** Historical acceptance source. GitHub Issue #187 closed on 2026-07-27;
+its unchecked rows are not reopened by this document and must be transferred to
+the [POWER 3.3.0 execution tracker](power-3.3.0-execution-tracker.md) before
+a phase is marked complete.
 
 **Scope:** this checklist turns Issue #187 into a reproducible acceptance
 record. It does not convert historical 3.2.1 measurements into release
 guarantees.
+
+The tracker must assign every row an owner, target host, retained artifact, and
+phase gate. Issue state alone is never evidence that a command was run or an
+artifact was retained.
 
 ## Preconditions
 

--- a/docs/plans/power-3.3.0-execution-tracker.md
+++ b/docs/plans/power-3.3.0-execution-tracker.md
@@ -8,6 +8,9 @@
 **Phase 0 delivery:** [PR #206](https://github.com/weby-homelab/power-framework/pull/206).
 Its CI, CodeQL, and documentation checks must be green before Phase 1 merges.
 
+**Runtime policy for 3.3.0:** Python `>=3.11`; required CI matrix is
+3.11–3.14. Python 3.10 compatibility is not part of the 3.3.0 contract.
+
 This is the authoritative repository-side receipt for the 3.3.0 execution
 plan. A GitHub epic with child issues for Phases 1–10 must mirror this table.
 An issue being closed is never proof that a release gate passed.

--- a/docs/plans/power-3.3.0-execution-tracker.md
+++ b/docs/plans/power-3.3.0-execution-tracker.md
@@ -5,6 +5,9 @@
 `7411140515497bc9d8b74be3f26ef0bbbb15dc70`, tree
 `38adc02c740155164b9a26316542c57a6a3b1022`.
 
+**Phase 0 delivery:** [PR #206](https://github.com/weby-homelab/power-framework/pull/206).
+Its CI, CodeQL, and documentation checks must be green before Phase 1 merges.
+
 This is the authoritative repository-side receipt for the 3.3.0 execution
 plan. A GitHub epic with child issues for Phases 1–10 must mirror this table.
 An issue being closed is never proof that a release gate passed.

--- a/docs/plans/power-3.3.0-execution-tracker.md
+++ b/docs/plans/power-3.3.0-execution-tracker.md
@@ -1,7 +1,7 @@
 # POWER 3.3.0 execution tracker
 
-**Status:** repository mirror; remote epic ID is required before Phase 1 may
-merge. **Owner:** Weby Homelab. **Baseline:** `v3.2.4` commit
+**Status:** repository mirror of [GitHub epic #195](https://github.com/weby-homelab/power-framework/issues/195).
+**Owner:** Weby Homelab. **Baseline:** `v3.2.4` commit
 `7411140515497bc9d8b74be3f26ef0bbbb15dc70`, tree
 `38adc02c740155164b9a26316542c57a6a3b1022`.
 
@@ -53,10 +53,19 @@ An issue being closed is never proof that a release gate passed.
   removal of the current ResourceWarning sources before strict new-warning
   enforcement is enabled.
 
-## Remote synchronization requirement
+## Canonical remote issues
 
-Before Phase 1 merges, create the GitHub epic **POWER 3.3.0 — execution
-tracker and release gates**, create child issues for the ten rows in the phase
-table, and replace this sentence with their canonical links. The remote issue
-content must preserve the same owner, target host, command, artifact, and gate
-for every row.
+- [#196 — Phase 1](https://github.com/weby-homelab/power-framework/issues/196)
+- [#197 — Phase 2](https://github.com/weby-homelab/power-framework/issues/197)
+- [#198 — Phase 3](https://github.com/weby-homelab/power-framework/issues/198)
+- [#199 — Phase 4](https://github.com/weby-homelab/power-framework/issues/199)
+- [#200 — Phase 5](https://github.com/weby-homelab/power-framework/issues/200)
+- [#201 — Phase 6](https://github.com/weby-homelab/power-framework/issues/201)
+- [#202 — Phase 7](https://github.com/weby-homelab/power-framework/issues/202)
+- [#203 — Phase 8](https://github.com/weby-homelab/power-framework/issues/203)
+- [#204 — Phase 9](https://github.com/weby-homelab/power-framework/issues/204)
+- [#205 — Phase 10](https://github.com/weby-homelab/power-framework/issues/205)
+
+Each issue mirrors the owner, target host, command, artifact, and gate in this
+repository tracker. Before Phase 1 merges, link the CI result for this branch
+to epic #195 and retain it with the Phase 0 evidence.

--- a/docs/plans/power-3.3.0-execution-tracker.md
+++ b/docs/plans/power-3.3.0-execution-tracker.md
@@ -1,0 +1,62 @@
+# POWER 3.3.0 execution tracker
+
+**Status:** repository mirror; remote epic ID is required before Phase 1 may
+merge. **Owner:** Weby Homelab. **Baseline:** `v3.2.4` commit
+`7411140515497bc9d8b74be3f26ef0bbbb15dc70`, tree
+`38adc02c740155164b9a26316542c57a6a3b1022`.
+
+This is the authoritative repository-side receipt for the 3.3.0 execution
+plan. A GitHub epic with child issues for Phases 1–10 must mirror this table.
+An issue being closed is never proof that a release gate passed.
+
+## Phase ownership and merge gates
+
+| Phase | Owner | Target host | Required command/evidence | Merge gate |
+| --- | --- | --- | --- | --- |
+| 1 — crash-atomic generations | Weby Homelab | hermetic CI + target vault host | subprocess fault matrix, retained prior-generation readback | no crash path can expose partial or missing active data |
+| 2 — Execution Kernel | Weby Homelab | hermetic CI | queue lifecycle, two-vault isolation, receipt tests | all writers use typed per-vault jobs |
+| 3 — memory governance | Weby Homelab | hermetic CI | temporal/sensitivity/relation round-trip tests | no lossy relation or unauthorised historical result |
+| 4 — Evaluation v2 | Weby Homelab | CI + adjudication workspace | versioned human qrels, slice reports, confidence intervals | synthetic and human claims remain separate |
+| 5 — retrieval profiles | Weby Homelab | hermetic CI | profile contract and envelope-v2 integration tests | profile selection is explicit and reproducible |
+| 6 — Method Profiles | Weby Homelab | hermetic CI | init, migration, manifest and recipe conformance tests | P.A.R.A. remains the compatible default |
+| 7 — consolidation | Weby Homelab | hermetic CI + review host | candidate, approval, supersession and rollback receipts | no automatic durable promotion without review |
+| 8 — performance and doctor | Weby Homelab | CI + target vault host | incremental reuse, complexity and doctor reports | optimisation preserves Phase 1 correctness invariants |
+| 9 — security and observability | Weby Homelab | CI + target vault host | offline/model/sensitivity/telemetry checks | release evidence contains no secrets or private paths |
+| 10 — RC and final | Weby Homelab | CI + release host | signed tag, SBOM, attestations and final evidence bundle | all prior gates match one release source |
+
+## Migrated acceptance rows from Issue #187
+
+| Row | Phase | Target host | Command/procedure | Required retained artifact | Gate |
+| --- | --- | --- | --- | --- | --- |
+| Source | 0, 10 | CI/release host | `git rev-parse HEAD HEAD^{tree}` and clean-status check | source manifest | exact commit/tree and clean source agree |
+| Model supply chain | 0, 9 | CI/release host | `python scripts/verify_release_contract.py` and file checksums | model-lock checksum record | package version, lock and file inventory agree |
+| Cold CLI latency | 4, 10 | target vault host | fresh-process `power search` samples | raw CSV + manifest | p50/p95/p99 per retrieval profile |
+| Warm CLI latency | 4, 10 | target vault host | warmed persistent-process samples | raw CSV + manifest | distinct from cold measurement |
+| Persistent MCP latency | 4, 10 | target vault host | `python scripts/benchmark_mcp_latency.py ...` | timing CSV + manifest | startup state and mode recorded |
+| Memory | 1, 8, 10 | target vault host | cgroup matrix for search and sync | RSS/OOM matrix | each profile has memory limit and exit code |
+| Quality | 4, 5, 10 | adjudication workspace | frozen human qrels and slice evaluation | per-query output + confidence intervals | UA/EN and temporal/graph slices reported |
+| Reranker comparison | 4, 5 | evaluation host | same corpus/query set for semantic and reranked profiles | paired quality/latency report | no cross-run comparison |
+| Determinism | 1, 4 | CI + target vault host | repeat frozen query set at least five times | result hashes/tolerance policy | equality or documented tolerance passes |
+| Recovery | 1, 10 | CI + target vault host | Phase 1 crash/OOM/disk/lock fixtures | failure receipts + prior-generation readback | old active result remains readable |
+| Egress and security | 9, 10 | CI/release host | blocked-network, traversal and symlink tests | security report | offline search makes no network call |
+
+## Phase 0 evidence
+
+- `release/models.lock.json` release equals `pyproject.toml` version.
+- `release/evidence/baselines/v3.2.4.json` records release source, Python/OS,
+  test and warning counts, skipped optional gates, model-lock checksum, and
+  frozen benchmark hashes.
+- `python scripts/verify_release_contract.py` validates that contract.
+- `pytest benchmarks/power31/tests -q --no-cov --override-ini=addopts=` is a
+  separate hermetic CI job; it never downloads models or reads a private vault.
+- The 47-warning release baseline is recorded without filtering. Phase 1 owns
+  removal of the current ResourceWarning sources before strict new-warning
+  enforcement is enabled.
+
+## Remote synchronization requirement
+
+Before Phase 1 merges, create the GitHub epic **POWER 3.3.0 — execution
+tracker and release gates**, create child issues for the ten rows in the phase
+table, and replace this sentence with their canonical links. The remote issue
+content must preserve the same owner, target host, command, artifact, and gate
+for every row.

--- a/docs/release-3.2.4.md
+++ b/docs/release-3.2.4.md
@@ -21,6 +21,12 @@ integrity, deterministic link resolution, and complete local catalog coverage.
 - Vault health lint: zero broken, ambiguous, orphan, or stale-note errors.
 - Markdown quality check: zero reported issues.
 
+The machine-readable release baseline in
+`release/evidence/baselines/v3.2.4.json` binds this release to its source tree,
+model-lock checksum, frozen synthetic benchmark hashes, warning count, and
+explicitly skipped optional gates. It is source evidence, not a production
+latency or quality claim.
+
 ## Upgrade
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,9 @@ nav:
       - POWER Memory OS Principles: adr/0002-memory-os-principles.md
   - POWER 3.1 Release Evidence: release-3.1.md
   - POWER 3.2.4 Release Notes: release-3.2.4.md
+  - Release Governance:
+      - POWER 3.3.0 Execution Tracker: plans/power-3.3.0-execution-tracker.md
+      - Issue 187 Historical Checklist: plans/issue-187-production-validation-checklist.md
   - Changelog: CHANGELOG.md
   - Contributing: contributing.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "3.2.4"
 description = "AI-native toolkit for Second Brain knowledge bases — validate, index, and manage notes via CLI or MCP"
 readme = "README.md"
 license = "GPL-3.0-only"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "Weby Homelab", email = "rekvizitor.ua@gmail.com" }
 ]
@@ -18,7 +18,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/release/evidence/.gitignore
+++ b/release/evidence/.gitignore
@@ -1,3 +1,5 @@
 *.json
 !README.md
 !benchmark-manifest.schema.json
+!baselines/
+!baselines/v3.2.4.json

--- a/release/evidence/baselines/v3.2.4.json
+++ b/release/evidence/baselines/v3.2.4.json
@@ -1,0 +1,33 @@
+{
+    "schema_version": 1,
+    "release": "3.2.4",
+    "source": {
+        "commit": "7411140515497bc9d8b74be3f26ef0bbbb15dc70",
+        "tree": "38adc02c740155164b9a26316542c57a6a3b1022",
+        "clean": true
+    },
+    "environment": {
+        "python": ["3.10", "3.11", "3.12", "3.13", "3.14"],
+        "os": "ubuntu-latest"
+    },
+    "validation": {
+        "passed": 573,
+        "skipped": 17,
+        "coverage_percent": 74.94,
+        "warning_count": 47,
+        "warning_policy": "Recorded release baseline; ResourceWarning is not filtered or suppressed.",
+        "skipped_optional_gates": [
+            "real-vault neural evaluation",
+            "target-host cgroup memory matrix",
+            "persistent MCP latency matrix"
+        ]
+    },
+    "benchmark": {
+        "synthetic": true,
+        "corpus_sha256": "63b1b9ed5590cfad08a718b69cb168bf7b3b7ca5ce40d9f225fa704743da43b6",
+        "queries_sha256": "52d152e13c039c083eeefcb8066f0ec9c0f100ae1a16e9f9cd5f6fdd57c90d3a",
+        "qrels_sha256": "d91574c0d0c078391fca8f9b4ad41237dd81de78528739ae5cf3631bea868ea8",
+        "expected_answers_sha256": "583e444d22a81bda057fa25280a48e05154181cc2a0fbdea268f1f350004d440"
+    },
+    "models_lock_sha256": "474e5475b96763652ee5170811200992ad672a45da52ed5df3eed67c5b3dd9fd"
+}

--- a/release/models.lock.json
+++ b/release/models.lock.json
@@ -1,6 +1,6 @@
 {
     "schema_version": 1,
-    "release": "3.2.2",
+    "release": "3.2.4",
     "canonical_embedding": {
         "provider": "bge-m3-onnx",
         "repository": "aapot/bge-m3-onnx",

--- a/scripts/verify_release_contract.py
+++ b/scripts/verify_release_contract.py
@@ -17,8 +17,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-import tomllib
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_PYPROJECT = REPO_ROOT / "pyproject.toml"
 DEFAULT_MODELS_LOCK = REPO_ROOT / "release" / "models.lock.json"
@@ -47,15 +45,21 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 
 def _load_package_version(path: Path) -> str:
-    """Read the package version without importing the package."""
+    """Read ``[project].version`` without importing the package or a TOML dependency."""
     try:
-        payload = tomllib.loads(path.read_text(encoding="utf-8"))
-        version = payload["project"]["version"]
-    except (OSError, KeyError, TypeError, tomllib.TOMLDecodeError) as exc:
+        content = path.read_text(encoding="utf-8")
+    except OSError as exc:
         raise ValueError(f"cannot read project version from {path}: {exc}") from exc
-    if not isinstance(version, str) or not version:
+
+    project_section = re.search(r"(?ms)^\[project\]\s*(.*?)(?=^\[|\Z)", content)
+    version_match = (
+        re.search(r'(?m)^version\s*=\s*"([^"\n]+)"\s*$', project_section.group(1))
+        if project_section is not None
+        else None
+    )
+    if version_match is None:
         raise ValueError(f"project.version in {path} must be a non-empty string")
-    return version
+    return version_match.group(1)
 
 
 def _sha256(path: Path) -> str:

--- a/scripts/verify_release_contract.py
+++ b/scripts/verify_release_contract.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Validate the immutable, machine-readable release baseline for POWER.
+
+The baseline is intentionally source-scoped rather than a performance claim.
+It records the exact released tree, the checked model lock, frozen benchmark
+dataset hashes, and the known validation boundary.  This prevents release
+documentation and supply-chain metadata from silently drifting apart.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PYPROJECT = REPO_ROOT / "pyproject.toml"
+DEFAULT_MODELS_LOCK = REPO_ROOT / "release" / "models.lock.json"
+DEFAULT_BASELINE = REPO_ROOT / "release" / "evidence" / "baselines" / "v3.2.4.json"
+DEFAULT_DATASET_MANIFEST = (
+    REPO_ROOT / "benchmarks" / "power31" / "dataset" / "v1" / "corpus-manifest.json"
+)
+GIT_OBJECT_RE = re.compile(r"^[0-9a-f]{40}$")
+DATASET_HASH_FIELDS = {
+    "corpus_sha256": ("corpus", "hash_sha256"),
+    "queries_sha256": ("queries", "hash_sha256"),
+    "qrels_sha256": ("qrels", "hash_sha256"),
+    "expected_answers_sha256": ("expected_answers", "hash_sha256"),
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    """Return a JSON object or raise one actionable error."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read JSON from {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _load_package_version(path: Path) -> str:
+    """Read the package version without importing the package."""
+    try:
+        payload = tomllib.loads(path.read_text(encoding="utf-8"))
+        version = payload["project"]["version"]
+    except (OSError, KeyError, TypeError, tomllib.TOMLDecodeError) as exc:
+        raise ValueError(f"cannot read project version from {path}: {exc}") from exc
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"project.version in {path} must be a non-empty string")
+    return version
+
+
+def _sha256(path: Path) -> str:
+    """Return the checksum of an immutable tracked input."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def validate_release_contract(
+    *,
+    pyproject_path: Path,
+    models_lock_path: Path,
+    baseline_path: Path,
+    dataset_manifest_path: Path,
+) -> list[str]:
+    """Return every release-contract violation without stopping at the first."""
+    package_version = _load_package_version(pyproject_path)
+    models_lock = _load_json(models_lock_path)
+    baseline = _load_json(baseline_path)
+    dataset_manifest = _load_json(dataset_manifest_path)
+    errors: list[str] = []
+
+    lock_version = models_lock.get("release")
+    if lock_version != package_version:
+        errors.append(
+            f"models.lock release {lock_version!r} does not match project version {package_version!r}"
+        )
+
+    if baseline.get("schema_version") != 1:
+        errors.append("baseline schema_version must be 1")
+    if baseline.get("release") != package_version:
+        errors.append(
+            f"baseline release {baseline.get('release')!r} does not match project version {package_version!r}"
+        )
+
+    source = baseline.get("source")
+    if not isinstance(source, dict):
+        errors.append("baseline source must be an object")
+    else:
+        for field in ("commit", "tree"):
+            value = source.get(field)
+            if not isinstance(value, str) or not GIT_OBJECT_RE.fullmatch(value):
+                errors.append(
+                    f"baseline source.{field} must be a 40-character lowercase Git object id"
+                )
+        if source.get("clean") is not True:
+            errors.append(
+                "baseline source.clean must be true; dirty source cannot be a release baseline"
+            )
+
+    expected_lock_hash = baseline.get("models_lock_sha256")
+    actual_lock_hash = _sha256(models_lock_path)
+    if expected_lock_hash != actual_lock_hash:
+        errors.append(
+            "baseline models_lock_sha256 does not match release/models.lock.json "
+            f"(expected {expected_lock_hash!r}, actual {actual_lock_hash!r})"
+        )
+
+    benchmark = baseline.get("benchmark")
+    if not isinstance(benchmark, dict):
+        errors.append("baseline benchmark must be an object")
+    else:
+        if benchmark.get("synthetic") is not True:
+            errors.append(
+                "baseline benchmark.synthetic must be true for the POWER 3.1 frozen dataset"
+            )
+        for baseline_field, manifest_path in DATASET_HASH_FIELDS.items():
+            current: Any = dataset_manifest
+            for key in manifest_path:
+                if not isinstance(current, dict):
+                    current = None
+                    break
+                current = current.get(key)
+            if benchmark.get(baseline_field) != current:
+                errors.append(
+                    f"baseline benchmark.{baseline_field} does not match dataset manifest value {current!r}"
+                )
+
+    validation = baseline.get("validation")
+    if not isinstance(validation, dict):
+        errors.append("baseline validation must be an object")
+    else:
+        for field in ("passed", "skipped", "warning_count"):
+            value = validation.get(field)
+            if not isinstance(value, int) or value < 0:
+                errors.append(f"baseline validation.{field} must be a non-negative integer")
+        coverage = validation.get("coverage_percent")
+        if not isinstance(coverage, (int, float)) or not 0 <= coverage <= 100:
+            errors.append("baseline validation.coverage_percent must be between 0 and 100")
+        skipped_gates = validation.get("skipped_optional_gates")
+        if not isinstance(skipped_gates, list) or not all(
+            isinstance(gate, str) and gate for gate in skipped_gates
+        ):
+            errors.append(
+                "baseline validation.skipped_optional_gates must be a list of non-empty strings"
+            )
+
+    return errors
+
+
+def main() -> int:
+    """Validate the release baseline and report all failures."""
+    parser = argparse.ArgumentParser(description="Validate POWER release baseline contract")
+    parser.add_argument("--pyproject", type=Path, default=DEFAULT_PYPROJECT)
+    parser.add_argument("--models-lock", type=Path, default=DEFAULT_MODELS_LOCK)
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument("--dataset-manifest", type=Path, default=DEFAULT_DATASET_MANIFEST)
+    args = parser.parse_args()
+
+    try:
+        errors = validate_release_contract(
+            pyproject_path=args.pyproject,
+            models_lock_path=args.models_lock,
+            baseline_path=args.baseline,
+            dataset_manifest_path=args.dataset_manifest,
+        )
+    except ValueError as exc:
+        print(f"Release contract validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    if errors:
+        print("Release contract validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(f"Release contract is valid for {args.baseline}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 
 WORKFLOWS_DIR = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+REPO_ROOT = WORKFLOWS_DIR.parent.parent
 FORBIDDEN_WORKFLOW_PATTERNS = ("continue-on-error", "|| true", "/root/gemma/brain")
 
 
@@ -23,6 +24,16 @@ def test_ci_keeps_blocking_test_and_security_jobs() -> None:
 
     assert "  test:" in ci_text
     assert "  security:" in ci_text
+
+
+def test_current_python_support_starts_at_3_11() -> None:
+    ci_text = (WORKFLOWS_DIR / "ci.yml").read_text(encoding="utf-8")
+    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'requires-python = ">=3.11"' in pyproject_text
+    assert '"Programming Language :: Python :: 3.10"' not in pyproject_text
+    assert 'python-version: ["3.11", "3.12", "3.13", "3.14"]' in ci_text
+    assert '"3.10"' not in ci_text
 
 
 def test_workflow_actions_are_pinned_to_immutable_commits() -> None:

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -1,0 +1,66 @@
+"""Regression tests for the machine-readable POWER release contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VALIDATOR = REPO_ROOT / "scripts" / "verify_release_contract.py"
+BASELINE = REPO_ROOT / "release" / "evidence" / "baselines" / "v3.2.4.json"
+MODELS_LOCK = REPO_ROOT / "release" / "models.lock.json"
+
+
+def _run_validator(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 -- invokes the repository-local validator under this interpreter.
+        [sys.executable, str(VALIDATOR), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_current_release_contract_is_valid() -> None:
+    result = _run_validator()
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_model_lock_version_must_match_project_version(tmp_path: Path) -> None:
+    models_lock = json.loads(MODELS_LOCK.read_text(encoding="utf-8"))
+    models_lock["release"] = "9.9.9"
+    altered_lock = _write_json(tmp_path / "models.lock.json", models_lock)
+
+    result = _run_validator("--models-lock", str(altered_lock))
+
+    assert result.returncode == 1
+    assert "does not match project version" in result.stderr
+
+
+def test_dirty_source_cannot_be_a_release_baseline(tmp_path: Path) -> None:
+    baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+    baseline["source"]["clean"] = False
+    dirty_baseline = _write_json(tmp_path / "dirty-baseline.json", baseline)
+
+    result = _run_validator("--baseline", str(dirty_baseline))
+
+    assert result.returncode == 1
+    assert "source.clean must be true" in result.stderr
+
+
+def test_benchmark_hash_must_match_frozen_dataset(tmp_path: Path) -> None:
+    baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+    baseline["benchmark"]["queries_sha256"] = "0" * 64
+    altered_baseline = _write_json(tmp_path / "altered-baseline.json", baseline)
+
+    result = _run_validator("--baseline", str(altered_baseline))
+
+    assert result.returncode == 1
+    assert "benchmark.queries_sha256 does not match" in result.stderr


### PR DESCRIPTION

## Summary

Implements the local and CI-backed parts of POWER 3.3.0 Phase 0.

- synchronizes the model-lock release with package 3.2.4 and validates it in CI;
- commits a versioned release baseline with source, model-lock, frozen-dataset, warning, and skipped-gate evidence;
- adds a hermetic benchmark-integrity CI job;
- reconciles the historical Issue #187 checklist with the new execution tracker.

Relates to #195. The epic and Phase issues #196–#205 were created separately; this PR does not close them.

## Validation

- Ruff, format, MyPy
- 577 passed, 17 skipped, coverage 75%
- 104 passed, 1 skipped frozen benchmark suite
- doc-drift, release-contract, strict MkDocs, and workspace verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for typed YAML relationship metadata.
  * Improved vault indexing for protocol folders and root-level daily logs.
  * Added path-aware link resolution and ambiguity reporting.
  * Links inside inline and fenced code examples are now ignored.

* **Bug Fixes**
  * Improved relative Markdown link handling and orphan detection.
  * Duplicate-basename links are clearly reported as ambiguous.

* **Documentation**
  * Updated installation, migration, release notes, and version references for v3.2.4.

* **Chores**
  * Added release validation checks, manual CI triggers, and benchmark integrity verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->