### PR TITLE
feat: add temporal memory retrieval semantics

### DIFF
--- a/docs/release-3.2.md
+++ b/docs/release-3.2.md
@@ -13,6 +13,19 @@ still require measured evidence.
 | #3 Silent fallback on TF     | **Fixed**     | Unknown `POWER_EMBED_PROVIDER` raises `RuntimeError`. Fallback permitted only with `POWER_ALLOW_DENSE_FALLBACK=1` env gate; contract recorded in `SearchResult.retrieval_contract`.     |
 | #4 OKF description ≤150      | **Fixed**     | `max_length` removed from Pydantic schema. Truncation applied only in catalog render (`index.md`/`_index.md`).                                                                          |
 | #5 Half-manual Graph RAG     | **Foundation only** | Auto-triplet extraction (`graph_extraction.py`) uses a deterministic regex-based extractor. M1.2 stores its output as reviewable SQLite candidates; only explicit approval writes accepted `relations`. Semantic suggest remains available via `suggest_related_semantic`. |
+
+## M1.3 temporal retrieval contract
+
+For notes with optional `memory` metadata, `valid_from` and `valid_until` are
+inclusive date bounds. A valid successor listed in `supersedes` makes the
+prior note historical; Markdown remains the source of truth and neither note
+is overwritten. Competing current successors are surfaced as `conflicted`,
+never selected silently.
+
+`search_vault`, `power search`, and MCP `search_vault_tool` share
+`temporal_view` (`current`, `historical`, or `all`) and an optional inclusive
+`as_of` (`YYYY-MM-DD`) boundary. MCP envelopes return both the requested
+boundary and each result's `temporal_status`.
 | #6 SQLite locks              | **Fixed**     | Single-writer `asyncio.Queue` worker (`write_queue.py`). Write operations serialized; reads parallel.                                                                                   |
 | Memory contract ≤12 GB       | **Pending**   | Model SHA pins and bounded runtime configuration are present; an RSS measurement on the target hardware is still required.                                                                 |
 

--- a/src/power_framework/core/__init__.py
+++ b/src/power_framework/core/__init__.py
@@ -102,6 +102,7 @@ from .searcher import (
     normalize_search_mode,
     search_vault,
 )
+from .temporal import TemporalStatus, TemporalView, normalize_as_of, normalize_temporal_view
 from .utils import (
     RateLimiter,
     __version__,
@@ -150,6 +151,8 @@ __all__ = [
     "SearchResult",
     "SemanticChunker",
     "Sensitivity",
+    "TemporalStatus",
+    "TemporalView",
     "TypedRelation",
     "UsageTracker",
     "WritePolicy",
@@ -183,7 +186,9 @@ __all__ = [
     "has_type_field",
     "heal_frontmatter",
     "heal_vault",
+    "normalize_as_of",
     "normalize_search_mode",
+    "normalize_temporal_view",
     "parse_frontmatter",
     "read_file_content",
     "resolve_path_in_vault",

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -200,7 +200,14 @@ def _cmd_search(args: argparse.Namespace) -> int:
     max_results = args.max_results
     mode = args.mode
 
-    results = search_vault(vault_dir, query, max_results=max_results, mode=mode)
+    results = search_vault(
+        vault_dir,
+        query,
+        max_results=max_results,
+        mode=mode,
+        temporal_view=args.temporal_view,
+        as_of=args.as_of,
+    )
     report = format_search_results(results, query, mode=mode, vault_dir=vault_dir)
     print(report)
     return 0
@@ -534,6 +541,17 @@ def main() -> None:
     p_search.add_argument("path", help="Path to the vault directory")
     p_search.add_argument(
         "query", help='Search query (supports multiple terms and "quoted phrases")'
+    )
+    p_search.add_argument(
+        "--temporal-view",
+        choices=["current", "historical", "all"],
+        default="current",
+        help="Lifecycle projection: current (default), historical, or all including conflicts",
+    )
+    p_search.add_argument(
+        "--as-of",
+        default=None,
+        help="Inclusive lifecycle boundary in ISO date format (YYYY-MM-DD)",
     )
     p_search.add_argument(
         "--max-results",

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -31,9 +31,19 @@ from .ignore import should_skip
 from .models import OKFMetadata  # noqa: TC001
 from .parser import read_file_content, validate_metadata
 from .query_expansion import QueryExpander
+from .temporal import (
+    TemporalStatus,
+    includes_temporal_status,
+    normalize_as_of,
+    normalize_temporal_view,
+    resolve_temporal_statuses,
+    scan_temporal_records,
+)
 from .vault_storage import vault_db_path
 
 if TYPE_CHECKING:
+    from datetime import date
+
     from .reranker import RerankerProtocol
 
 logger = logging.getLogger(__name__)
@@ -132,6 +142,7 @@ class SearchResult:
     match_count: int
     tags: list[str] = field(default_factory=list)
     retrieval_contract: str = "dense"
+    temporal_status: str = TemporalStatus.CURRENT.value
 
 
 def normalize_search_mode(mode: str) -> str:
@@ -1068,6 +1079,8 @@ def search_vault(
     query: str,
     max_results: int = 20,
     mode: str = DEFAULT_SEARCH_MODE,
+    temporal_view: str = "current",
+    as_of: date | str | None = None,
 ) -> list[SearchResult]:
     """
     Search the vault for notes matching the query.
@@ -1081,6 +1094,8 @@ def search_vault(
               index. Other explicit modes are "fts" (BM25), "vector" (TF
               cosine), "hybrid" (RRF of FTS + TF vector), and "reranked".
               ``hybrid_reranked`` is a deprecated alias of ``reranked``.
+        temporal_view: ``current`` (default), ``historical``, or ``all``.
+        as_of: Inclusive ISO-8601 date boundary for temporal evaluation.
 
     Returns:
         List of SearchResult sorted by relevance (highest first).
@@ -1090,6 +1105,8 @@ def search_vault(
     # coerce to a resolved Path once here.
     vault_dir = Path(vault_dir).expanduser().resolve()
     mode = normalize_search_mode(mode)
+    temporal_view = normalize_temporal_view(temporal_view).value
+    boundary = normalize_as_of(as_of)
     mode_spec = get_search_mode_spec(mode)
     retrieval_contract = "dense"
     if mode_spec.requires_dense_index:
@@ -1166,7 +1183,9 @@ def search_vault(
         vec_dedup = sorted(vec_map.values(), key=lambda x: -x.score)
 
         # Single RRF fusion at the end
-        return _rrf_merge(fts_dedup, vec_dedup)[:max_results]
+        return _filter_temporal_results(
+            vault_dir, _rrf_merge(fts_dedup, vec_dedup), temporal_view, boundary, max_results
+        )
 
     # For non-hybrid modes, gather results, dedup by rel_path keeping max score, and sort
     all_results: list[SearchResult] = []
@@ -1195,10 +1214,30 @@ def search_vault(
             res_map[r.rel_path] = r
 
     final_results = sorted(res_map.values(), key=lambda x: (-x.score, x.title))
-    final_results = final_results[:max_results]
+    final_results = _filter_temporal_results(
+        vault_dir, final_results, temporal_view, boundary, max_results
+    )
     for r in final_results:
         r.retrieval_contract = retrieval_contract
     return final_results
+
+
+def _filter_temporal_results(
+    vault_dir: Path,
+    results: list[SearchResult],
+    temporal_view: str,
+    as_of: date,
+    max_results: int,
+) -> list[SearchResult]:
+    """Attach resolved status and filter ranked results at the retrieval boundary."""
+    statuses = resolve_temporal_statuses(scan_temporal_records(vault_dir), as_of)
+    filtered: list[SearchResult] = []
+    for result in results:
+        status = statuses.get(result.rel_path, TemporalStatus.CURRENT)
+        result.temporal_status = status.value
+        if includes_temporal_status(status, temporal_view):
+            filtered.append(result)
+    return filtered[:max_results]
 
 
 def _hybrid_reranked_search(
@@ -1302,6 +1341,7 @@ def format_search_results(
         score_str = f"{r.score:.4f}"
         lines.append(f"{i}. [{r.note_type}] {r.title}  (score: {score_str})")
         lines.append(f"   Path: {r.rel_path}")
+        lines.append(f"   Temporal status: {r.temporal_status}")
         lines.append(f"   {r.description}")
         if r.snippet:
             lines.append(f"   ...{r.snippet}...")
@@ -1328,6 +1368,8 @@ def format_untrusted_search_envelope(
     query: str,
     mode: str,
     vault_dir: Path,
+    temporal_view: str = "current",
+    as_of: str | None = None,
 ) -> str:
     """Serialize MCP retrieval output as untrusted, provenance-bearing data.
 
@@ -1363,6 +1405,7 @@ def format_untrusted_search_envelope(
                     "note_type": result.note_type,
                     "tags": result.tags,
                     "retrieval_contract": result.retrieval_contract,
+                    "temporal_status": result.temporal_status,
                 },
                 "score": result.score,
                 "match_count": result.match_count,
@@ -1380,6 +1423,8 @@ def format_untrusted_search_envelope(
         ),
         "query": query,
         "mode": mode,
+        "temporal_view": temporal_view,
+        "as_of": as_of,
         "result_count": len(envelope_results),
         "results": envelope_results,
     }

--- a/src/power_framework/core/temporal.py
+++ b/src/power_framework/core/temporal.py
@@ -1,0 +1,167 @@
+"""Deterministic temporal and supersession semantics for governed memory."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from .ignore import should_skip
+from .parser import read_file_content, validate_metadata
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .models import MemoryMetadata
+
+
+class TemporalStatus(StrEnum):
+    """Resolved lifecycle state exposed to every retrieval surface."""
+
+    CURRENT = "current"
+    HISTORICAL = "historical"
+    CONFLICTED = "conflicted"
+
+
+class TemporalView(StrEnum):
+    """Selectable retrieval projection over resolved temporal states."""
+
+    CURRENT = "current"
+    HISTORICAL = "historical"
+    ALL = "all"
+
+
+@dataclass(frozen=True)
+class TemporalRecord:
+    """The lifecycle metadata for one Markdown note, keyed by vault-relative path."""
+
+    rel_path: str
+    memory: MemoryMetadata | None
+
+
+def normalize_temporal_view(view: str) -> TemporalView:
+    """Validate one shared library/CLI/MCP temporal-view value."""
+    try:
+        return TemporalView(view.lower())
+    except (AttributeError, ValueError) as exc:
+        supported = ", ".join(member.value for member in TemporalView)
+        raise ValueError(
+            f"Unsupported temporal view '{view}'. Supported views: {supported}"
+        ) from exc
+
+
+def normalize_as_of(as_of: date | str | None) -> date:
+    """Return an ISO-date boundary, defaulting explicitly to today's UTC date."""
+    if as_of is None:
+        return datetime.now(UTC).date()
+    if isinstance(as_of, date):
+        return as_of
+    try:
+        return date.fromisoformat(as_of)
+    except ValueError as exc:
+        raise ValueError("as_of must be an ISO-8601 date (YYYY-MM-DD)") from exc
+
+
+def scan_temporal_records(vault_dir: Path) -> dict[str, TemporalRecord]:
+    """Read valid note metadata without trusting derived index state."""
+    records: dict[str, TemporalRecord] = {}
+    for filepath in vault_dir.rglob("*.md"):
+        rel_path = filepath.relative_to(vault_dir).as_posix()
+        if should_skip(vault_dir, rel_path):
+            continue
+        try:
+            metadata = validate_metadata(read_file_content(filepath))
+        except OSError:
+            continue
+        if metadata is not None:
+            records[rel_path] = TemporalRecord(rel_path, metadata.memory)
+    return records
+
+
+def resolve_temporal_statuses(
+    records: dict[str, TemporalRecord], as_of: date | str | None = None
+) -> dict[str, TemporalStatus]:
+    """Resolve validity and supersession without silently overwriting conflicts.
+
+    Validity bounds are inclusive. A valid successor makes its ancestors historical.
+    When independent current heads supersede the same ancestor, all affected heads
+    and their shared ancestry are marked ``conflicted`` rather than choosing one.
+    """
+    boundary = normalize_as_of(as_of)
+    active: set[str] = {
+        path
+        for path, record in records.items()
+        if record.memory is None
+        or (
+            (record.memory.valid_from is None or record.memory.valid_from <= boundary)
+            and (record.memory.valid_until is None or boundary <= record.memory.valid_until)
+        )
+    }
+    statuses = {
+        path: TemporalStatus.CURRENT if path in active else TemporalStatus.HISTORICAL
+        for path in records
+    }
+
+    edges: dict[str, set[str]] = defaultdict(set)
+    incoming: set[str] = set()
+    for path in active:
+        memory = records[path].memory
+        if memory is None:
+            continue
+        for target in memory.supersedes:
+            if target in records:
+                edges[path].add(target)
+                incoming.add(target)
+
+    heads = active - incoming
+    reached_by: dict[str, set[str]] = defaultdict(set)
+    for head in heads:
+        queue = deque(edges.get(head, set()))
+        seen: set[str] = set()
+        while queue:
+            target = queue.popleft()
+            if target in seen:
+                continue
+            seen.add(target)
+            reached_by[target].add(head)
+            queue.extend(edges.get(target, set()))
+
+    conflicted: set[str] = set()
+    for target, competing_heads in reached_by.items():
+        if len(competing_heads) > 1:
+            conflicted.add(target)
+            conflicted.update(competing_heads)
+
+    # Detect actual cycles; a non-head is normal in a linear supersession chain.
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(path: str, trail: list[str]) -> None:
+        if path in visiting:
+            conflicted.update(trail[trail.index(path) :])
+            return
+        if path in visited:
+            return
+        visiting.add(path)
+        for target in edges.get(path, set()):
+            visit(target, [*trail, target])
+        visiting.remove(path)
+        visited.add(path)
+
+    for path in active:
+        visit(path, [path])
+
+    for target, source_heads in reached_by.items():
+        if len(source_heads) == 1 and target not in conflicted:
+            statuses[target] = TemporalStatus.HISTORICAL
+    for path in conflicted:
+        statuses[path] = TemporalStatus.CONFLICTED
+    return statuses
+
+
+def includes_temporal_status(status: TemporalStatus, view: str) -> bool:
+    """Apply the same projection contract used by library, CLI, and MCP."""
+    normalized = normalize_temporal_view(view)
+    return normalized is TemporalView.ALL or status.value == normalized.value

--- a/src/power_framework/mcp/power_server.py
+++ b/src/power_framework/mcp/power_server.py
@@ -294,6 +294,8 @@ async def search_vault_tool(
     query: str,
     max_results: int = 20,
     search_mode: str = DEFAULT_SEARCH_MODE,
+    temporal_view: str = "current",
+    as_of: str | None = None,
     vault_path: str | None = None,
 ) -> str:
     """Search vault notes and return provenance-bearing untrusted data only.
@@ -309,12 +311,30 @@ async def search_vault_tool(
         raise ToolError(f"max_results must be between 1 and {_MAX_MCP_SEARCH_RESULTS}")
     try:
         search_mode = normalize_search_mode(search_mode)
+        from power_framework.core.temporal import normalize_as_of, normalize_temporal_view
+
+        temporal_view = normalize_temporal_view(temporal_view).value
+        normalized_as_of = normalize_as_of(as_of).isoformat()
     except ValueError as exc:
         raise ToolError(str(exc)) from exc
 
     def _do_search() -> str:
-        results = search_vault(path, query, max_results=max_results, mode=search_mode)
-        return format_untrusted_search_envelope(results, query, mode=search_mode, vault_dir=path)
+        results = search_vault(
+            path,
+            query,
+            max_results=max_results,
+            mode=search_mode,
+            temporal_view=temporal_view,
+            as_of=normalized_as_of,
+        )
+        return format_untrusted_search_envelope(
+            results,
+            query,
+            mode=search_mode,
+            vault_dir=path,
+            temporal_view=temporal_view,
+            as_of=normalized_as_of,
+        )
 
     return await run_blocking(_do_search)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,6 +193,33 @@ def test_search_uses_canonical_default_mode(sample_vault: Path) -> None:
     assert search.call_args.kwargs["mode"] == DEFAULT_SEARCH_MODE
 
 
+def test_search_passes_shared_temporal_contract(sample_vault: Path) -> None:
+    with (
+        patch("power_framework.core.cli.format_search_results", return_value="No results"),
+        patch("power_framework.core.cli.search_vault", return_value=[]) as search,
+        patch.object(
+            sys,
+            "argv",
+            [
+                "power",
+                "search",
+                str(sample_vault),
+                "Test",
+                "--temporal-view",
+                "historical",
+                "--as-of",
+                "2026-07-10",
+            ],
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+
+    assert exc.value.code == 0
+    assert search.call_args.kwargs["temporal_view"] == "historical"
+    assert search.call_args.kwargs["as_of"] == "2026-07-10"
+
+
 def test_search_no_results(sample_vault: Path) -> None:
     with (
         patch.object(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -54,6 +54,8 @@ async def test_search_vault_finds_notes(sample_vault: Path) -> None:
     assert envelope["trust"] == "untrusted"
     assert envelope["data_only"] is True
     assert envelope["result_count"] > 0
+    assert envelope["temporal_view"] == "current"
+    assert envelope["as_of"]
     assert envelope["results"][0]["source"]["content_sha256"]
 
 
@@ -67,8 +69,8 @@ async def test_search_vault_uses_canonical_default_mode(
 ) -> None:
     captured: dict[str, str] = {}
 
-    def fake_search(_path: Path, _query: str, *, max_results: int, mode: str):
-        captured["mode"] = mode
+    def fake_search(_path: Path, _query: str, **kwargs: object):
+        captured["mode"] = str(kwargs["mode"])
         return []
 
     monkeypatch.setattr(power_server, "search_vault", fake_search)
@@ -84,8 +86,8 @@ async def test_search_vault_keeps_explicit_fts_mode_compatible(
 ) -> None:
     captured: dict[str, str] = {}
 
-    def fake_search(_path: Path, _query: str, *, max_results: int, mode: str):
-        captured["mode"] = mode
+    def fake_search(_path: Path, _query: str, **kwargs: object):
+        captured["mode"] = str(kwargs["mode"])
         return []
 
     monkeypatch.setattr(power_server, "search_vault", fake_search)
@@ -96,6 +98,32 @@ async def test_search_vault_keeps_explicit_fts_mode_compatible(
 
     assert captured["mode"] == "fts"
     assert envelope["mode"] == "fts"
+
+
+async def test_search_vault_uses_shared_temporal_contract(
+    sample_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_search(_path: Path, _query: str, **kwargs: object):
+        captured["temporal_view"] = str(kwargs["temporal_view"])
+        captured["as_of"] = str(kwargs["as_of"])
+        return []
+
+    monkeypatch.setattr(power_server, "search_vault", fake_search)
+    envelope = json.loads(
+        await search_vault_tool(
+            query="Test",
+            search_mode="fts",
+            temporal_view="historical",
+            as_of="2026-07-10",
+            vault_path=str(sample_vault),
+        )
+    )
+
+    assert captured == {"temporal_view": "historical", "as_of": "2026-07-10"}
+    assert envelope["temporal_view"] == "historical"
+    assert envelope["as_of"] == "2026-07-10"
 
 
 async def test_search_vault_rejects_unknown_mode(sample_vault: Path) -> None:

--- a/tests/test_memory_contract.py
+++ b/tests/test_memory_contract.py
@@ -10,6 +10,11 @@ from pydantic import ValidationError
 from power_framework.core.healer import heal_frontmatter
 from power_framework.core.models import MemoryMetadata, OKFMetadata
 from power_framework.core.parser import build_frontmatter, validate_metadata
+from power_framework.core.temporal import (
+    TemporalRecord,
+    TemporalStatus,
+    resolve_temporal_statuses,
+)
 
 
 def _memory(**overrides: object) -> MemoryMetadata:
@@ -92,3 +97,37 @@ Body used to infer a description.
     assert parsed.related[0].relation == "depends_on"
     assert parsed.related[0].confidence == 0.42
     assert parsed.related[0].model_extra == {"evidence": {"source": "human-review"}}
+
+
+def test_temporal_chain_uses_inclusive_dates_and_preserves_history() -> None:
+    records = {
+        "03_Resources/old.md": TemporalRecord("03_Resources/old.md", _memory()),
+        "03_Resources/new.md": TemporalRecord(
+            "03_Resources/new.md",
+            _memory(valid_from=date(2026, 7, 10), supersedes=["03_Resources/old.md"]),
+        ),
+    }
+
+    before = resolve_temporal_statuses(records, date(2026, 7, 9))
+    boundary = resolve_temporal_statuses(records, date(2026, 7, 10))
+
+    assert before["03_Resources/old.md"] == TemporalStatus.CURRENT
+    assert before["03_Resources/new.md"] == TemporalStatus.HISTORICAL
+    assert boundary["03_Resources/old.md"] == TemporalStatus.HISTORICAL
+    assert boundary["03_Resources/new.md"] == TemporalStatus.CURRENT
+
+
+def test_competing_supersession_is_explicitly_conflicted() -> None:
+    records = {
+        "03_Resources/old.md": TemporalRecord("03_Resources/old.md", _memory()),
+        "03_Resources/a.md": TemporalRecord(
+            "03_Resources/a.md", _memory(supersedes=["03_Resources/old.md"])
+        ),
+        "03_Resources/b.md": TemporalRecord(
+            "03_Resources/b.md", _memory(supersedes=["03_Resources/old.md"])
+        ),
+    }
+
+    statuses = resolve_temporal_statuses(records, date(2026, 7, 10))
+
+    assert set(statuses.values()) == {TemporalStatus.CONFLICTED}

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import sqlite3
 from contextlib import closing
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path  # noqa: TC003
 
 import pytest
@@ -35,6 +35,60 @@ from power_framework.core.searcher import (
     search_vault,
     validate_dense_index,
 )
+
+
+def test_search_temporal_views_filter_one_shared_corpus(sample_vault: Path) -> None:
+    old = sample_vault / "03_Resources" / "old-fact.md"
+    new = sample_vault / "03_Resources" / "new-fact.md"
+    old.write_text(
+        """---
+type: Resource
+title: "Old fact"
+description: "temporal-token historical fact"
+okf_version: "0.2"
+memory:
+  kind: semantic
+  valid_from: 2026-01-01
+timestamp: 2026-01-01T00:00:00
+---
+
+temporal-token historical fact
+""",
+        encoding="utf-8",
+    )
+    new.write_text(
+        """---
+type: Resource
+title: "New fact"
+description: "temporal-token current fact"
+okf_version: "0.2"
+memory:
+  kind: semantic
+  valid_from: 2026-07-10
+  supersedes: [03_Resources/old-fact.md]
+timestamp: 2026-07-10T00:00:00
+---
+
+temporal-token current fact
+""",
+        encoding="utf-8",
+    )
+
+    current = search_vault(
+        sample_vault, "temporal-token", mode="fts", temporal_view="current", as_of=date(2026, 7, 10)
+    )
+    historical = search_vault(
+        sample_vault,
+        "temporal-token",
+        mode="fts",
+        temporal_view="historical",
+        as_of="2026-07-10",
+    )
+
+    assert {result.rel_path for result in current} == {"03_Resources/new-fact.md"}
+    assert {result.rel_path for result in historical} == {"03_Resources/old-fact.md"}
+    assert current[0].temporal_status == "current"
+    assert historical[0].temporal_status == "historical"
 
 
 class TestTokenize:


### PR DESCRIPTION
## What changed

Implements POWER M1.3 temporal and supersession retrieval semantics.

- resolves inclusive validity windows and transitive supersession
- reports competing successors as explicit conflicted state
- applies current/historical/all filters consistently in library, CLI, and MCP
- records the temporal boundary and result status in MCP envelopes

## Validation

- 635 passed; coverage gate passed
- Ruff, format, MyPy, strict MkDocs, and workspace verify.sh passed

Stacked on #211; kept draft until the dependency chain is reviewable.