### PR TITLE
feat: fail closed remote egress

### DIFF
--- a/docs/release-3.2.md
+++ b/docs/release-3.2.md
@@ -26,6 +26,15 @@ never selected silently.
 `temporal_view` (`current`, `historical`, or `all`) and an optional inclusive
 `as_of` (`YYYY-MM-DD`) boundary. MCP envelopes return both the requested
 boundary and each result's `temporal_status`.
+
+## M1.4 fail-closed egress contract
+
+`POWER_EGRESS_POLICY` defaults to `deny`. Remote paths must pass the shared
+policy before sending any vault-derived value: `allow-public`,
+`allow-internal`, and `allow-sensitive` are the only explicit opt-ins. The
+policy guards OpenRouter query expansion, ROT contradiction analysis, HTTP
+link-ROT, and a non-loopback Ollama embedding endpoint. Local ONNX/fastembed/
+Qwen and local rerankers do not send note content off-host.
 | #6 SQLite locks              | **Fixed**     | Single-writer `asyncio.Queue` worker (`write_queue.py`). Write operations serialized; reads parallel.                                                                                   |
 | Memory contract ≤12 GB       | **Pending**   | Model SHA pins and bounded runtime configuration are present; an RSS measurement on the target hardware is still required.                                                                 |
 

--- a/src/power_framework/core/egress.py
+++ b/src/power_framework/core/egress.py
@@ -1,0 +1,70 @@
+"""Central fail-closed policy for sending vault-derived data off-host."""
+
+from __future__ import annotations
+
+import os
+from enum import IntEnum, StrEnum
+from urllib.parse import urlparse
+
+from .models import Sensitivity
+
+
+class EgressOperation(StrEnum):
+    """Every POWER path that can contact a non-local service."""
+
+    EMBEDDINGS = "embeddings"
+    RERANKING = "reranking"
+    QUERY_EXPANSION = "query_expansion"
+    ROT = "rot"
+
+
+class EgressDeniedError(PermissionError):
+    """Raised before sensitive vault content can leave the local host."""
+
+
+class _PolicyLevel(IntEnum):
+    DENY = 0
+    PUBLIC = 1
+    INTERNAL = 2
+    SENSITIVE = 3
+
+
+_LEVELS = {
+    "deny": _PolicyLevel.DENY,
+    "allow-public": _PolicyLevel.PUBLIC,
+    "allow-internal": _PolicyLevel.INTERNAL,
+    "allow-sensitive": _PolicyLevel.SENSITIVE,
+}
+_SENSITIVITY_LEVELS = {
+    Sensitivity.PUBLIC.value: _PolicyLevel.PUBLIC,
+    Sensitivity.INTERNAL.value: _PolicyLevel.INTERNAL,
+    Sensitivity.SENSITIVE.value: _PolicyLevel.SENSITIVE,
+}
+
+
+def configured_egress_policy() -> str:
+    """Return the explicit policy name; absent configuration always denies."""
+    return os.getenv("POWER_EGRESS_POLICY", "deny").lower()
+
+
+def require_remote_egress(operation: EgressOperation, sensitivity: str = "internal") -> None:
+    """Permit a remote call only under a policy explicit enough for its data."""
+    policy = configured_egress_policy()
+    allowed = _LEVELS.get(policy)
+    level = _SENSITIVITY_LEVELS.get(sensitivity.lower())
+    if allowed is None:
+        raise EgressDeniedError(
+            "POWER_EGRESS_POLICY must be deny, allow-public, allow-internal, or allow-sensitive"
+        )
+    if level is None:
+        raise EgressDeniedError(f"Unknown sensitivity '{sensitivity}' for {operation.value}")
+    if allowed < level:
+        raise EgressDeniedError(
+            f"remote {operation.value} denied for {sensitivity} content by POWER_EGRESS_POLICY={policy}"
+        )
+
+
+def is_remote_endpoint(url: str) -> bool:
+    """Treat only non-loopback HTTP endpoints as remote content egress."""
+    host = urlparse(url).hostname
+    return bool(host and host not in {"localhost", "127.0.0.1", "::1"})

--- a/src/power_framework/core/embeddings.py
+++ b/src/power_framework/core/embeddings.py
@@ -6,6 +6,8 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from .egress import EgressOperation, is_remote_endpoint, require_remote_egress
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
@@ -225,6 +227,9 @@ class OllamaEmbeddingManager:
     def embed(self, text: str) -> list[float]:
         import ollama
 
+        if is_remote_endpoint(os.getenv("OLLAMA_HOST", "http://127.0.0.1:11434")):
+            require_remote_egress(EgressOperation.EMBEDDINGS)
+
         def _do():
             result = ollama.embed(
                 model=self.model_name,
@@ -238,6 +243,9 @@ class OllamaEmbeddingManager:
 
     def embed_batch(self, texts: list[str]) -> list[list[float]]:
         import ollama
+
+        if is_remote_endpoint(os.getenv("OLLAMA_HOST", "http://127.0.0.1:11434")):
+            require_remote_egress(EgressOperation.EMBEDDINGS)
 
         def _do():
             result = ollama.embed(

--- a/src/power_framework/core/query_expansion.py
+++ b/src/power_framework/core/query_expansion.py
@@ -8,6 +8,7 @@ import urllib.error
 import urllib.request
 from typing import ClassVar
 
+from .egress import EgressOperation, require_remote_egress
 from .utils import run_opencode_cli
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,9 @@ class QueryExpander:
         "помилка": ["error"],
     }
 
-    def __init__(self, use_llm: bool = False, api_key: str | None = None) -> None:
+    def __init__(
+        self, use_llm: bool = False, api_key: str | None = None, sensitivity: str = "internal"
+    ) -> None:
         self.use_llm = use_llm
         if api_key is not None:
             self.api_key = api_key
@@ -69,6 +72,7 @@ class QueryExpander:
             "/"
         )
         self.model = os.environ.get("POWER_LLM_MODEL", OPENROUTER_MODELS[0])
+        self.sensitivity = sensitivity
 
     def expand(self, query: str) -> list[str]:
         if not query or not query.strip():
@@ -129,6 +133,8 @@ class QueryExpander:
 
         if not self.api_key:
             return []
+
+        require_remote_egress(EgressOperation.QUERY_EXPANSION, self.sensitivity)
 
         payload = json.dumps(
             {

--- a/src/power_framework/core/rot_scoring.py
+++ b/src/power_framework/core/rot_scoring.py
@@ -21,14 +21,14 @@ import urllib.request
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from .egress import EgressDeniedError, EgressOperation, require_remote_egress
 from .embeddings import get_embedding_manager
+from .ignore import should_skip
 from .parser import FRONTMATTER_PATTERN, parse_frontmatter, read_file_content
 from .utils import run_opencode_cli
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-from .ignore import should_skip
 
 logger = logging.getLogger(__name__)
 
@@ -245,6 +245,8 @@ class ContradictionDetector:
         if not self.api_key:
             return None
 
+        require_remote_egress(EgressOperation.ROT, "internal")
+
         payload = json.dumps(
             {
                 "model": self.model,
@@ -445,6 +447,10 @@ class LinkRotChecker:
     def _head_status(self, url: str) -> int:
         """Perform HTTP HEAD request and return status code. Returns -1 on error."""
         if not url.startswith(("http://", "https://")):
+            return -1
+        try:
+            require_remote_egress(EgressOperation.ROT, "public")
+        except EgressDeniedError:
             return -1
         try:
             from urllib.parse import urlparse

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -1,0 +1,41 @@
+"""Negative regression coverage for the fail-closed remote-egress contract."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from power_framework.core.egress import EgressDeniedError, EgressOperation, require_remote_egress
+from power_framework.core.query_expansion import QueryExpander
+from power_framework.core.rot_scoring import LinkRotChecker
+
+
+@pytest.mark.parametrize("operation", list(EgressOperation))
+def test_remote_egress_denies_all_operations_by_default(operation: EgressOperation) -> None:
+    with pytest.raises(EgressDeniedError, match="POWER_EGRESS_POLICY=deny"):
+        require_remote_egress(operation, "internal")
+
+
+def test_sensitive_egress_requires_the_explicit_sensitive_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-internal")
+    with pytest.raises(EgressDeniedError):
+        require_remote_egress(EgressOperation.RERANKING, "sensitive")
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-sensitive")
+    require_remote_egress(EgressOperation.RERANKING, "sensitive")
+
+
+def test_query_expansion_does_not_open_network_when_policy_denies() -> None:
+    expander = QueryExpander(use_llm=True, api_key="test-key")
+    with patch("urllib.request.urlopen") as request:
+        variants = expander.expand("internal deployment credential")
+    request.assert_not_called()
+    assert "internal deployment credential" in variants
+
+
+def test_link_rot_does_not_open_network_when_policy_denies() -> None:
+    with patch("urllib.request.urlopen") as request:
+        assert LinkRotChecker()._head_status("https://example.com") == -1
+    request.assert_not_called()

--- a/tests/test_memory_contract.py
+++ b/tests/test_memory_contract.py
@@ -97,6 +97,7 @@ Body used to infer a description.
     assert parsed.related[0].relation == "depends_on"
     assert parsed.related[0].confidence == 0.42
     assert parsed.related[0].model_extra == {"evidence": {"source": "human-review"}}
+<<<<<<< HEAD
 
 
 def test_temporal_chain_uses_inclusive_dates_and_preserves_history() -> None:
@@ -131,3 +132,5 @@ def test_competing_supersession_is_explicitly_conflicted() -> None:
     statuses = resolve_temporal_statuses(records, date(2026, 7, 10))
 
     assert set(statuses.values()) == {TemporalStatus.CONFLICTED}
+=======
+>>>>>>> 6fee2bc (fix: preserve typed relation semantics)

--- a/tests/test_memory_contract.py
+++ b/tests/test_memory_contract.py
@@ -97,7 +97,6 @@ Body used to infer a description.
     assert parsed.related[0].relation == "depends_on"
     assert parsed.related[0].confidence == 0.42
     assert parsed.related[0].model_extra == {"evidence": {"source": "human-review"}}
-<<<<<<< HEAD
 
 
 def test_temporal_chain_uses_inclusive_dates_and_preserves_history() -> None:
@@ -132,5 +131,3 @@ def test_competing_supersession_is_explicitly_conflicted() -> None:
     statuses = resolve_temporal_statuses(records, date(2026, 7, 10))
 
     assert set(statuses.values()) == {TemporalStatus.CONFLICTED}
-=======
->>>>>>> 6fee2bc (fix: preserve typed relation semantics)

--- a/tests/test_query_expansion.py
+++ b/tests/test_query_expansion.py
@@ -96,7 +96,8 @@ class TestQueryExpanderLLM:
             variants = expander.expand("docker")
         assert "docker" in variants
 
-    def test_llm_adds_variants_on_success(self):
+    def test_llm_adds_variants_on_success(self, monkeypatch):
+        monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-internal")
         expander = QueryExpander(use_llm=True, api_key="sk-test-key")
         mock_resp = MagicMock()
         mock_resp.read.return_value = b'{"choices":[{"message":{"content":"[\\"docker orchestration\\",\\"container management\\"]"}}]}'

--- a/tests/test_semantic_rot.py
+++ b/tests/test_semantic_rot.py
@@ -242,6 +242,7 @@ class TestContradictionDetectorLLM:
 
     def test_llm_detects_contradiction(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-key")
+        monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-internal")
         vault = self._make_simple_vault(tmp_path, self.LLM_BODY_A, self.LLM_BODY_B)
 
         detector = ContradictionDetector(similarity_threshold=0.5)
@@ -284,6 +285,7 @@ class TestContradictionDetectorLLM:
 
     def test_llm_no_contradiction(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-key")
+        monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-internal")
         vault = self._make_simple_vault(tmp_path, self.LLM_COMPAT_A, self.LLM_COMPAT_B)
 
         detector = ContradictionDetector(similarity_threshold=0.5)


### PR DESCRIPTION
Implements POWER M1.4: centralized explicit egress policy, deny-by-default guards, and negative regressions for remote paths.

Validation: 642 passed; coverage gate, Ruff, format, MyPy, strict MkDocs, and verify.sh passed.

Stacked on #212.