### PR TITLE
feat: establish M2 human retrieval evidence contract

### DIFF
--- a/benchmarks/human_retrieval/README.md
+++ b/benchmarks/human_retrieval/README.md
@@ -1,0 +1,23 @@
+# POWER M2 Human Retrieval Evidence
+
+This directory is the evidence contract for M2. It is deliberately separate
+from `benchmarks/power31`: the latter is a synthetic CI regression benchmark
+and cannot be used as human-quality or production evidence.
+
+M2 evaluates five real knowledge-worker journeys:
+
+1. locate a current operational fact;
+2. recover an historical or superseded fact as of a stated date;
+3. trace a claim to its cited source and provenance;
+4. decide that a question has no supported answer and abstain; and
+5. retrieve a cross-note relationship without treating candidates as authority.
+
+The corpus owner must create `dataset/v1/manifest.json` from
+`manifest.template.json`, retain raw annotations outside the development
+working copy, and publish only de-identified, review-approved material.
+`scripts/validate_human_evidence.py` validates the manifest contract. It
+refuses to validate the sealed holdout unless `--allow-sealed` is explicitly
+supplied.
+
+No human qrels, metrics, thresholds, or release-quality claim are present yet.
+Until independent annotators complete the protocol, M2 remains **in progress**.

--- a/benchmarks/human_retrieval/annotation_protocol.md
+++ b/benchmarks/human_retrieval/annotation_protocol.md
@@ -16,6 +16,8 @@ and the candidate documents; they must not receive a retrieval-mode label.
   not cross the split boundary.
 - A run may score the sealed split only with an explicit release-review action
   (`--allow-sealed`) and must emit a fresh manifest with hashes.
+- Use a pooled candidate set from every compared mode, plus random negatives;
+  never grade only a system's own top-ranked documents.
 
 ## Judgments
 
@@ -41,6 +43,22 @@ and temporal status, go to a third adjudicator who records a reason code:
 `scope`, `temporal`, `provenance`, `partial`, `conflict`, or `other`.
 The final qrel keeps both original judgments and the adjudicated decision;
 adjudication never overwrites raw judgments.
+
+## Reproducibility and reporting
+
+Bind every result to exact corpus, queries, raw judgments and adjudicated qrels
+SHA-256 values. Keep raw judgments and the agreement receipt, including the
+chosen agreement statistic, with the final qrels. The corpus and qrels must be
+evaluated together; do not reuse judgments after a content or de-identification
+change. Report per-query results, confidence intervals and a paired comparison,
+not only an aggregate winner.
+
+These rules follow established TREC practice: human judgments are tied to the
+specific document collection and qrels, graded relevance is valid for ranking,
+and independent assessments surface disagreements for adjudication. See the
+[TREC relevance-judgment guidance](https://trec.nist.gov/data/reljudge_eng.html),
+[TREC Legal Track dual assessment](https://trec.nist.gov/pubs/trec19/papers/LEGAL10.OVERVIEW.pdf),
+and [TREC 2024 RAG citation assessment](https://trec.nist.gov/data/rag2024.html).
 
 ## Pre-registered M2 gate
 

--- a/benchmarks/human_retrieval/annotation_protocol.md
+++ b/benchmarks/human_retrieval/annotation_protocol.md
@@ -1,0 +1,51 @@
+# M2 annotation and adjudication protocol
+
+## Scope and privacy
+
+Each corpus item must be de-identified before annotation. Do not include
+credentials, personal data, private URLs, hostnames, or note content classified
+as `sensitive`. Annotators receive a stable document identifier, the question,
+and the candidate documents; they must not receive a retrieval-mode label.
+
+## Splits and blinding
+
+- **Development**: used to improve or configure a mode.
+- **Sealed holdout**: its queries, judgments, and per-query results are not
+  available to implementers until the release candidate is frozen.
+- An item belongs to exactly one split. A document family or paraphrase must
+  not cross the split boundary.
+- A run may score the sealed split only with an explicit release-review action
+  (`--allow-sealed`) and must emit a fresh manifest with hashes.
+
+## Judgments
+
+Two independent human annotators judge each `(query, document)` pair without
+seeing each other's assessment. Relevance is ordinal:
+
+- `2`: directly supports a correct answer;
+- `1`: useful but incomplete context;
+- `0`: does not support the answer;
+- `-1`: misleading, stale for the requested time, or contradicts the evidence.
+
+For every query, annotators also record:
+
+- whether abstention is correct;
+- which document IDs are acceptable citations;
+- whether a cited fact is current, historical, or conflicted;
+- the journey and question-taxonomy class.
+
+## Adjudication
+
+Compute agreement before reconciliation. Disagreements, including abstention
+and temporal status, go to a third adjudicator who records a reason code:
+`scope`, `temporal`, `provenance`, `partial`, `conflict`, or `other`.
+The final qrel keeps both original judgments and the adjudicated decision;
+adjudication never overwrites raw judgments.
+
+## Pre-registered M2 gate
+
+Before evaluating the sealed holdout, record thresholds for Recall@K, nDCG@K,
+MRR, citation/provenance accuracy, stale-answer rate, abstention quality, and
+latency. Report confidence intervals and every failed threshold. Compare
+lexical, semantic, hybrid, reranked, and graph-assisted modes under the same
+corpus hash and runtime manifest. Synthetic `power31` results remain CI-only.

--- a/benchmarks/human_retrieval/manifest.template.json
+++ b/benchmarks/human_retrieval/manifest.template.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0",
+  "status": "pending_human_annotation",
+  "split": "development",
+  "corpus_sha256": "REPLACE_WITH_SHA256",
+  "queries_sha256": "REPLACE_WITH_SHA256",
+  "raw_judgments_sha256": "REPLACE_WITH_SHA256",
+  "adjudicated_qrels_sha256": "REPLACE_WITH_SHA256",
+  "annotation_protocol": "annotation_protocol.md",
+  "journeys": [
+    "current_fact",
+    "historical_fact",
+    "provenance_trace",
+    "abstention",
+    "candidate_boundary"
+  ],
+  "thresholds": null
+}

--- a/benchmarks/human_retrieval/manifest.template.json
+++ b/benchmarks/human_retrieval/manifest.template.json
@@ -6,6 +6,12 @@
   "queries_sha256": "REPLACE_WITH_SHA256",
   "raw_judgments_sha256": "REPLACE_WITH_SHA256",
   "adjudicated_qrels_sha256": "REPLACE_WITH_SHA256",
+  "artifacts": {
+    "corpus": "corpus.jsonl",
+    "queries": "queries.jsonl",
+    "raw_judgments": "raw-judgments.jsonl",
+    "adjudicated_qrels": "adjudicated-qrels.jsonl"
+  },
   "annotation_protocol": "annotation_protocol.md",
   "journeys": [
     "current_fact",

--- a/benchmarks/human_retrieval/scripts/validate_human_evidence.py
+++ b/benchmarks/human_retrieval/scripts/validate_human_evidence.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
+import math
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +24,21 @@ REQUIRED_HASHES = {
     "adjudicated_qrels_sha256",
 }
 VALID_SPLITS = {"development", "sealed_holdout"}
+ARTIFACTS = {
+    "corpus": "corpus_sha256",
+    "queries": "queries_sha256",
+    "raw_judgments": "raw_judgments_sha256",
+    "adjudicated_qrels": "adjudicated_qrels_sha256",
+}
+REQUIRED_THRESHOLDS = {
+    "recall_at_10",
+    "ndcg_at_10",
+    "mrr_at_10",
+    "citation_provenance_accuracy",
+    "stale_answer_rate_max",
+    "abstention_quality",
+    "p95_latency_ms",
+}
 logger = logging.getLogger(__name__)
 
 
@@ -47,8 +64,54 @@ def validate_manifest(manifest: dict[str, Any], *, allow_sealed: bool) -> list[s
             or any(c not in "0123456789abcdef" for c in value)
         ):
             errors.append(f"{key} must be a lowercase SHA-256 hex digest")
-    if manifest.get("status") == "adjudicated" and not isinstance(manifest.get("thresholds"), dict):
-        errors.append("adjudicated evidence requires pre-registered thresholds")
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict) or set(artifacts) != set(ARTIFACTS):
+        errors.append("artifacts must name corpus, queries, raw_judgments, and adjudicated_qrels")
+    elif not all(isinstance(path, str) and path for path in artifacts.values()):
+        errors.append("artifact paths must be non-empty strings")
+    if manifest.get("status") == "adjudicated":
+        thresholds = manifest.get("thresholds")
+        if not isinstance(thresholds, dict) or set(thresholds) != REQUIRED_THRESHOLDS:
+            errors.append("adjudicated evidence requires complete pre-registered thresholds")
+        elif not all(
+            isinstance(value, (int, float)) and math.isfinite(value)
+            for value in thresholds.values()
+        ):
+            errors.append("pre-registered thresholds must be finite numbers")
+        if not isinstance(manifest.get("annotator_count"), int) or manifest["annotator_count"] < 2:
+            errors.append("adjudicated evidence requires at least two independent annotators")
+        if not isinstance(manifest.get("agreement"), dict):
+            errors.append("adjudicated evidence requires an agreement receipt")
+    return errors
+
+
+def _artifact_path(root: Path, value: str) -> Path | None:
+    candidate = (root / value).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError:
+        return None
+    return candidate
+
+
+def validate_evidence_file(manifest_path: Path, *, allow_sealed: bool) -> list[str]:
+    """Validate the manifest plus the exact bytes it claims to govern."""
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    errors = validate_manifest(manifest, allow_sealed=allow_sealed)
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return errors
+    for artifact_key, digest_key in ARTIFACTS.items():
+        relative_path = artifacts.get(artifact_key)
+        if not isinstance(relative_path, str):
+            continue
+        artifact_path = _artifact_path(manifest_path.parent, relative_path)
+        if artifact_path is None:
+            errors.append(f"{artifact_key} path must stay under the manifest directory")
+        elif not artifact_path.is_file():
+            errors.append(f"{artifact_key} artifact is missing")
+        elif hashlib.sha256(artifact_path.read_bytes()).hexdigest() != manifest.get(digest_key):
+            errors.append(f"{artifact_key} SHA-256 does not match {digest_key}")
     return errors
 
 
@@ -57,16 +120,13 @@ def main() -> int:
     parser.add_argument("manifest", type=Path)
     parser.add_argument("--allow-sealed", action="store_true")
     args = parser.parse_args()
-    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
-    errors = validate_manifest(manifest, allow_sealed=args.allow_sealed)
+    errors = validate_evidence_file(args.manifest, allow_sealed=args.allow_sealed)
     if errors:
         logger.error(
             "M2 evidence contract failed:\n%s", "\n".join(f"- {error}" for error in errors)
         )
         return 1
-    logger.info(
-        "M2 evidence manifest valid: split=%s status=%s", manifest["split"], manifest["status"]
-    )
+    logger.info("M2 evidence manifest valid: %s", args.manifest)
     return 0
 
 

--- a/benchmarks/human_retrieval/scripts/validate_human_evidence.py
+++ b/benchmarks/human_retrieval/scripts/validate_human_evidence.py
@@ -1,0 +1,74 @@
+"""Validate the M2 human-retrieval evidence boundary without scoring it."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+REQUIRED_JOURNEYS = {
+    "current_fact",
+    "historical_fact",
+    "provenance_trace",
+    "abstention",
+    "candidate_boundary",
+}
+REQUIRED_HASHES = {
+    "corpus_sha256",
+    "queries_sha256",
+    "raw_judgments_sha256",
+    "adjudicated_qrels_sha256",
+}
+VALID_SPLITS = {"development", "sealed_holdout"}
+logger = logging.getLogger(__name__)
+
+
+def validate_manifest(manifest: dict[str, Any], *, allow_sealed: bool) -> list[str]:
+    """Return contract violations; never silently treats a holdout as development."""
+    errors: list[str] = []
+    if manifest.get("schema_version") != "1.0":
+        errors.append("schema_version must be '1.0'")
+    if manifest.get("status") not in {"pending_human_annotation", "adjudicated"}:
+        errors.append("status must be pending_human_annotation or adjudicated")
+    split = manifest.get("split")
+    if split not in VALID_SPLITS:
+        errors.append("split must be development or sealed_holdout")
+    elif split == "sealed_holdout" and not allow_sealed:
+        errors.append("sealed_holdout requires --allow-sealed")
+    if set(manifest.get("journeys", [])) != REQUIRED_JOURNEYS:
+        errors.append("journeys must contain each required M2 journey exactly once")
+    for key in REQUIRED_HASHES:
+        value = manifest.get(key)
+        if (
+            not isinstance(value, str)
+            or len(value) != 64
+            or any(c not in "0123456789abcdef" for c in value)
+        ):
+            errors.append(f"{key} must be a lowercase SHA-256 hex digest")
+    if manifest.get("status") == "adjudicated" and not isinstance(manifest.get("thresholds"), dict):
+        errors.append("adjudicated evidence requires pre-registered thresholds")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--allow-sealed", action="store_true")
+    args = parser.parse_args()
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    errors = validate_manifest(manifest, allow_sealed=args.allow_sealed)
+    if errors:
+        logger.error(
+            "M2 evidence contract failed:\n%s", "\n".join(f"- {error}" for error in errors)
+        )
+        return 1
+    logger.info(
+        "M2 evidence manifest valid: split=%s status=%s", manifest["split"], manifest["status"]
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_human_retrieval_evidence.py
+++ b/tests/test_human_retrieval_evidence.py
@@ -1,0 +1,52 @@
+"""Contract tests for the M2 human-evidence boundary."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "benchmarks"
+    / "human_retrieval"
+    / "scripts"
+    / "validate_human_evidence.py"
+)
+SPEC = importlib.util.spec_from_file_location("m2_evidence", SCRIPT)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def _manifest(**overrides: object) -> dict[str, object]:
+    manifest: dict[str, object] = {
+        "schema_version": "1.0",
+        "status": "pending_human_annotation",
+        "split": "development",
+        "corpus_sha256": "a" * 64,
+        "queries_sha256": "b" * 64,
+        "raw_judgments_sha256": "c" * 64,
+        "adjudicated_qrels_sha256": "d" * 64,
+        "journeys": sorted(MODULE.REQUIRED_JOURNEYS),
+        "thresholds": None,
+    }
+    manifest.update(overrides)
+    return manifest
+
+
+def test_development_manifest_is_valid_before_annotation() -> None:
+    assert MODULE.validate_manifest(_manifest(), allow_sealed=False) == []
+
+
+def test_sealed_holdout_requires_explicit_release_review() -> None:
+    manifest = _manifest(split="sealed_holdout")
+    assert "sealed_holdout requires --allow-sealed" in MODULE.validate_manifest(
+        manifest, allow_sealed=False
+    )
+    assert MODULE.validate_manifest(manifest, allow_sealed=True) == []
+
+
+def test_adjudicated_manifest_requires_preregistered_thresholds() -> None:
+    errors = MODULE.validate_manifest(_manifest(status="adjudicated"), allow_sealed=False)
+    assert "adjudicated evidence requires pre-registered thresholds" in errors

--- a/tests/test_human_retrieval_evidence.py
+++ b/tests/test_human_retrieval_evidence.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
+import json
 from pathlib import Path
 
 SCRIPT = (
@@ -28,6 +30,12 @@ def _manifest(**overrides: object) -> dict[str, object]:
         "queries_sha256": "b" * 64,
         "raw_judgments_sha256": "c" * 64,
         "adjudicated_qrels_sha256": "d" * 64,
+        "artifacts": {
+            "corpus": "corpus.jsonl",
+            "queries": "queries.jsonl",
+            "raw_judgments": "raw-judgments.jsonl",
+            "adjudicated_qrels": "adjudicated-qrels.jsonl",
+        },
         "journeys": sorted(MODULE.REQUIRED_JOURNEYS),
         "thresholds": None,
     }
@@ -49,4 +57,26 @@ def test_sealed_holdout_requires_explicit_release_review() -> None:
 
 def test_adjudicated_manifest_requires_preregistered_thresholds() -> None:
     errors = MODULE.validate_manifest(_manifest(status="adjudicated"), allow_sealed=False)
-    assert "adjudicated evidence requires pre-registered thresholds" in errors
+    assert "adjudicated evidence requires complete pre-registered thresholds" in errors
+
+
+def test_evidence_file_binds_each_artifact_to_its_declared_hash(tmp_path: Path) -> None:
+    artifacts = _manifest()["artifacts"]
+    assert isinstance(artifacts, dict)
+    manifest = _manifest()
+    for key, filename in artifacts.items():
+        content = f"{key}\n"
+        (tmp_path / filename).write_text(content, encoding="utf-8")
+        manifest[f"{key}_sha256" if key != "raw_judgments" else "raw_judgments_sha256"] = (
+            hashlib.sha256(content.encode()).hexdigest()
+        )
+    manifest["adjudicated_qrels_sha256"] = hashlib.sha256(
+        (tmp_path / artifacts["adjudicated_qrels"]).read_bytes()
+    ).hexdigest()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    assert MODULE.validate_evidence_file(manifest_path, allow_sealed=False) == []
+    (tmp_path / artifacts["queries"]).write_text("tampered\n", encoding="utf-8")
+    assert "queries SHA-256 does not match queries_sha256" in MODULE.validate_evidence_file(
+        manifest_path, allow_sealed=False
+    )


### PR DESCRIPTION
## What changed

Adds an M2 human-retrieval evidence contract: blinded pooled judging, development/sealed-holdout separation, provenance-safe de-identification, SHA-256-bound artifacts, preregistered thresholds, and a fail-closed validator.

## Why

The existing power31 benchmark is synthetic CI regression evidence and cannot establish human retrieval quality.

## Validation

- 633 passed, 17 skipped; coverage 76.86%
- Ruff, formatting, and MyPy passed
- M2 contract tests: 4 passed

## Scope

This does not claim human-quality results or change retrieval defaults. Human corpus, independent judgments, adjudication, and sealed evaluation remain required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation and an annotation protocol for human retrieval evaluation.
  * Added a manifest template covering development data, required journeys, artifacts, and integrity hashes.
  * Added validation for manifest structure, artifact paths, file availability, and SHA-256 integrity.
  * Added explicit safeguards for sealed holdout validation and adjudicated evidence requirements.

* **Tests**
  * Added coverage for valid manifests, sealed holdout restrictions, threshold requirements, and artifact hash mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->