### PR TITLE
docs: add AI-agent guides and Windows 11 install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Unlike generic knowledge management tools, P.O.W.E.R. is designed from the groun
   provenance are verified; human-quality certification, sealed-holdout access,
   and production claims remain incomplete
 
+## For AI Agents
+
+P.O.W.E.R. is designed to be operated by human workflows and AI agents alike.
+Agents (Antigravity, OpenCode, Claude Code, Gemini, Devin, DeepSeek) should read
+the role-specific guides before touching a vault:
+
+- **[Getting Started](https://github.com/weby-homelab/power-framework/blob/main/docs/getting-started.md)** — first install, first vault, first query
+- **[CLI Reference](https://github.com/weby-homelab/power-framework/blob/main/docs/cli.md)** — every command, flag, and exit code
+- **[MCP Server](https://github.com/weby-homelab/power-framework/blob/main/docs/mcp-server.md)** — the 17 governed MCP tools for MCP-compatible clients
+- **[AI Agent Migration Guide](https://github.com/weby-homelab/power-framework/blob/main/docs/migration-guide.md)** — 5-phase protocol for adopting an existing vault
+
 ## Quick Start
 
 ```bash
@@ -87,6 +98,40 @@ pip install --user --break-system-packages -e ".[dev]"
 > fi
 > power --version
 > ```
+
+## Windows 11 Installation
+
+P.O.W.E.R. runs natively on Windows 11 (Python 3.11+). The CLI works in
+PowerShell 5.1/7 and Windows Terminal; `power rename` uses `os.replace()`, so
+renaming onto an existing destination works on Windows instead of raising
+`FileExistsError`.
+
+```powershell
+# 1. Install Python 3.11+ from python.org (tick "Add python.exe to PATH")
+py -m pip install --user "git+https://github.com/weby-homelab/power-framework.git@v3.3.2"
+
+# 2. Verify — `power` lands in %USERPROFILE%\AppData\Roaming\Python\Scripts
+power --version
+```
+
+For development (editable, easy update):
+
+```powershell
+git clone https://github.com/weby-homelab/power-framework.git C:\dev\power-framework
+cd C:\dev\power-framework
+py -m pip install --user -e ".[dev]"
+git pull origin main   # update anytime
+```
+
+Notes:
+
+- **PATH** — ensure `%USERPROFILE%\AppData\Roaming\Python\Scripts` is on `PATH`
+  (PowerShell: `$env:Path += ";$env:APPDATA\Python\Scripts"` for the session,
+  or set it in System Properties → Environment Variables).
+- **MCP clients** — use `"command": "py", "args": ["-m", "power_framework.mcp"]`
+  in Claude Desktop / OpenCode configs on Windows.
+- **POWER_VAULT_DIR** — set the env var via System Properties → Environment
+  Variables when you want the MCP server to skip the interactive vault prompt.
 
 ## What's Inside
 
@@ -192,7 +237,7 @@ power archive <path>           Auto-archive stale notes to 04_Archive/
 power suggest-related <path>   Suggest cross-note relations for Graph RAG
 power cron <path>              Run automated maintenance (lint + index + rot)
 power synthesize <path>        Auto-ingest a session synthesis note
-power rename <path> <name>     Rename a note and update related paths
+power rename <path> --old OLD --new NEW   Rename a note and update related paths
 ```
 
 ### Ingest Examples

--- a/README.ua.md
+++ b/README.ua.md
@@ -33,6 +33,17 @@ P.O.W.E.R. — це гібридна система, створена для п�
   замість помилки `FileExistsError`
 - **Технічний реліз 3.3.2** — machine-only M2–M5 gates, package та CI provenance перевірені; сертифікація human-quality, доступ до sealed holdout і production claims залишаються закритими.
 
+## Для AI-агентів
+
+P.O.W.E.R. створений для роботи як людьми, так і AI-агентами. Агентам
+(Antigravity, OpenCode, Claude Code, Gemini, Devin, DeepSeek) варто прочитати
+рольові ґайди перед роботою з vault:
+
+- **[Getting Started](https://github.com/weby-homelab/power-framework/blob/main/docs/getting-started.md)** — перша установка, перший vault, перший запит
+- **[CLI Reference](https://github.com/weby-homelab/power-framework/blob/main/docs/cli.md)** — усі команди, прапорці та коди виходу
+- **[MCP Server](https://github.com/weby-homelab/power-framework/blob/main/docs/mcp-server.md)** — 17 керованих MCP-інструментів для MCP-сумісних клієнтів
+- **[Ґайд міграції для AI-агента](https://github.com/weby-homelab/power-framework/blob/main/docs/migration-guide.ua.md)** — 5-фазний протокол адаптації наявного vault
+
 ## Швидкий старт
 
 ```bash
@@ -85,6 +96,41 @@ pip install --user --break-system-packages -e ".[dev]"
 > fi
 > power --version
 > ```
+
+## Установка на Windows 11
+
+P.O.W.E.R. працює нативно на Windows 11 (Python 3.11+). CLI працює в
+PowerShell 5.1/7 та Windows Terminal; `power rename` використовує
+`os.replace()`, тому перейменування поверх наявного файлу працює на Windows
+замість помилки `FileExistsError`.
+
+```powershell
+# 1. Встановіть Python 3.11+ з python.org (позначте "Add python.exe to PATH")
+py -m pip install --user "git+https://github.com/weby-homelab/power-framework.git@v3.3.2"
+
+# 2. Перевірка — `power` опиниться у %USERPROFILE%\AppData\Roaming\Python\Scripts
+power --version
+```
+
+Для розробки (editable, легке оновлення):
+
+```powershell
+git clone https://github.com/weby-homelab/power-framework.git C:\dev\power-framework
+cd C:\dev\power-framework
+py -m pip install --user -e ".[dev]"
+git pull origin main   # оновлення будь-коли
+```
+
+Примітки:
+
+- **PATH** — додайте `%USERPROFILE%\AppData\Roaming\Python\Scripts` до `PATH`
+  (PowerShell: `$env:Path += ";$env:APPDATA\Python\Scripts"` на поточну сесію,
+  або через System Properties → Environment Variables).
+- **MCP-клієнти** — у конфігах Claude Desktop / OpenCode на Windows
+  використовуйте `"command": "py", "args": ["-m", "power_framework.mcp"]`.
+- **POWER_VAULT_DIR** — задайте змінну середовища через System Properties →
+  Environment Variables, якщо MCP-сервер не має питати шлях до vault
+  інтерактивно.
 
 ## Що всередині
 
@@ -191,7 +237,7 @@ power archive <path>           Автоматично архівувати за�
 power suggest-related <path>   Запропонувати Graph RAG зв'язки між нотатками
 power cron <path>              Автоматичне обслуговування (lint + index + rot)
 power synthesize <path>        Автоматично додати нотатку з підсумком сесії
-power rename <path> <name>     Перейменувати нотатку й оновити пов'язані шляхи
+power rename <path> --old OLD --new NEW   Перейменувати нотатку й оновити пов'язані шляхи
 ```
 
 ### Приклади ingest


### PR DESCRIPTION
## What
- Add **For AI Agents** section linking role-specific guides (`getting-started.md`, `cli.md`, `mcp-server.md`, `migration-guide.md`) so agents find them directly from the README.
- Add **Windows 11 Installation** section: PowerShell install (pinned v3.3.2), editable dev install, PATH/`py launcher` notes, MCP `command: py` config, `POWER_VAULT_DIR`.
- Fix `power rename` signature in the Commands table: `power rename <path> --old OLD --new NEW` (matches the real CLI; verified via `power rename --help`).

## Validation
- `scripts/check_doc_drift.py` → **passed**
- `pytest tests/test_doc_drift.py` → **2 passed**
- CLI signature cross-checked against installed `power rename --help` on `origin/main`
- Both README.md and README.ua.md updated in sync

## Related
Closes #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AI-agent guidance with links to installation, CLI, MCP, and migration resources.
  * Added Windows 11 installation and configuration instructions, including PowerShell, PATH, MCP, and vault directory setup.
  * Updated `power rename` examples to use explicit `--old` and `--new` options.
  * Added equivalent guidance in Ukrainian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->