### PR TITLE
docs: expand Windows 11 install guide (merge with #226) + fix vault tree drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,18 +101,56 @@ pip install --user --break-system-packages -e ".[dev]"
 
 ## Windows 11 Installation
 
-P.O.W.E.R. runs natively on Windows 11 (Python 3.11+). The CLI works in
+P.O.W.E.R. runs natively on Windows 11 (Python 3.11+, 64-bit). The CLI works in
 PowerShell 5.1/7 and Windows Terminal; `power rename` uses `os.replace()`, so
 renaming onto an existing destination works on Windows instead of raising
 `FileExistsError`.
 
-```powershell
-# 1. Install Python 3.11+ from python.org (tick "Add python.exe to PATH")
-py -m pip install --user "git+https://github.com/weby-homelab/power-framework.git@v3.3.2"
+### Prerequisites
 
-# 2. Verify — `power` lands in %USERPROFILE%\AppData\Roaming\Python\Scripts
+1. **Python 3.11+** — download the 64-bit installer from
+   [python.org](https://www.python.org/downloads/windows/). On the first setup
+   screen check **"Add python.exe to PATH"**, then click _Install Now_.
+2. **Git for Windows** — from [git-scm.com](https://git-scm.com/download/win)
+   (required for `pip install git+...`).
+3. **Windows Terminal / PowerShell** — built into Windows 11 (Win+X → Terminal).
+
+### Option A: Virtual environment (recommended)
+
+Isolates P.O.W.E.R. and its model dependencies from your global Python:
+
+```powershell
+# 1. Create a tools folder and virtual environment
+mkdir %USERPROFILE%\power-tools
+cd %USERPROFILE%\power-tools
+python -m venv .venv
+
+# 2. Activate it (PowerShell)
+.\.venv\Scripts\Activate.ps1
+
+# 3. Install P.O.W.E.R. 3.3.2
+pip install git+https://github.com/weby-homelab/power-framework.git@v3.3.2
+
+# 4. Verify
 power --version
 ```
+
+> `power` remains available only while the venv is active. Re-activate with
+> `.\.venv\Scripts\Activate.ps1` (or add a shortcut in your PowerShell profile).
+> On first dense search (`power sync`), model assets (BGE-M3 + reranker ONNX,
+> SHA-256 pinned) download automatically into the venv cache.
+
+### Option B: User-site install (global, no venv)
+
+```powershell
+py -m pip install --user "git+https://github.com/weby-homelab/power-framework.git@v3.3.2"
+power --version
+```
+
+Scripts are placed in `%USERPROFILE%\AppData\Roaming\Python\Scripts`. If
+`power` is not recognized, close and reopen the terminal, or add that directory
+to your `PATH` (System Properties → Environment Variables; PowerShell:
+`$env:Path += ";$env:APPDATA\Python\Scripts"` for the session).
 
 For development (editable, easy update):
 
@@ -123,15 +161,54 @@ py -m pip install --user -e ".[dev]"
 git pull origin main   # update anytime
 ```
 
+### Create a vault and run first checks
+
+```powershell
+power init C:\Users\you\my-vault
+power lint C:\Users\you\my-vault
+power index C:\Users\you\my-vault
+power status C:\Users\you\my-vault
+```
+
+### MCP setup on Windows (Claude Desktop)
+
+Edit `%APPDATA%\Claude\claude_desktop_config.json`:
+
+```json
+{
+    "mcpServers": {
+        "power": {
+            "command": "py",
+            "args": ["-m", "power_framework.mcp"],
+            "env": {
+                "POWER_VAULT_DIR": "C:\\Users\\you\\my-vault"
+            }
+        }
+    }
+}
+```
+
 Notes:
 
-- **PATH** — ensure `%USERPROFILE%\AppData\Roaming\Python\Scripts` is on `PATH`
-  (PowerShell: `$env:Path += ";$env:APPDATA\Python\Scripts"` for the session,
-  or set it in System Properties → Environment Variables).
-- **MCP clients** — use `"command": "py", "args": ["-m", "power_framework.mcp"]`
-  in Claude Desktop / OpenCode configs on Windows.
+- **MCP clients** — use `"command": "py"` (the Windows Python launcher; not
+  `python3`) in Claude Desktop / OpenCode configs on Windows.
+- **Escape backslashes** in JSON (`\\`) or use forward slashes: `C:/Users/you/my-vault`.
+- **Venv path** — if you used Option A, point `command` at the full path:
+  `C:\Users\you\power-tools\.venv\Scripts\python.exe`.
 - **POWER_VAULT_DIR** — set the env var via System Properties → Environment
-  Variables when you want the MCP server to skip the interactive vault prompt.
+  Variables (or the `env` block above) when you want the MCP server to skip the
+  interactive vault prompt.
+
+### Troubleshooting on Windows 11
+
+| Symptom                                          | Fix                                                                                                       |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `'power' is not recognized`                      | Reopen the terminal, or add `%USERPROFILE%\AppData\Roaming\Python\Scripts` (or venv `Scripts`) to `PATH`. |
+| `pip install git+...` fails                      | Install [Git for Windows](https://git-scm.com/download/win) and restart the terminal.                     |
+| `python` not found                               | Reinstall Python and check **"Add python.exe to PATH"**; restart the terminal.                            |
+| SmartScreen/Defender warning during `power sync` | Expected on first model download; assets are SHA-256 pinned and validated fail-closed.                    |
+
+## What's Inside
 
 ## What's Inside
 

--- a/README.ua.md
+++ b/README.ua.md
@@ -97,20 +97,58 @@ pip install --user --break-system-packages -e ".[dev]"
 > power --version
 > ```
 
-## Установка на Windows 11
+## Встановлення на Windows 11
 
-P.O.W.E.R. працює нативно на Windows 11 (Python 3.11+). CLI працює в
+P.O.W.E.R. працює нативно на Windows 11 (Python 3.11+, 64-bit). CLI працює в
 PowerShell 5.1/7 та Windows Terminal; `power rename` використовує
 `os.replace()`, тому перейменування поверх наявного файлу працює на Windows
 замість помилки `FileExistsError`.
 
-```powershell
-# 1. Встановіть Python 3.11+ з python.org (позначте "Add python.exe to PATH")
-py -m pip install --user "git+https://github.com/weby-homelab/power-framework.git@v3.3.2"
+### Попередні вимоги
 
-# 2. Перевірка — `power` опиниться у %USERPROFILE%\AppData\Roaming\Python\Scripts
+1. **Python 3.11+** — завантажте 64-bit інсталятор з
+   [python.org](https://www.python.org/downloads/windows/). На першому екрані
+   увімкніть **"Add python.exe to PATH"**, потім _Install Now_.
+2. **Git for Windows** — з [git-scm.com](https://git-scm.com/download/win)
+   (потрібен для `pip install git+...`).
+3. **Windows Terminal / PowerShell** — вбудовані у Windows 11 (Win+X → Terminal).
+
+### Варіант A: Віртуальне середовище (рекомендовано)
+
+Ізолює P.O.W.E.R. та його модельні залежності від глобального Python:
+
+```powershell
+# 1. Створіть папку та віртуальне середовище
+mkdir %USERPROFILE%\power-tools
+cd %USERPROFILE%\power-tools
+python -m venv .venv
+
+# 2. Активуйте його (PowerShell)
+.\.venv\Scripts\Activate.ps1
+
+# 3. Встановіть P.O.W.E.R. 3.3.2
+pip install git+https://github.com/weby-homelab/power-framework.git@v3.3.2
+
+# 4. Перевірка
 power --version
 ```
+
+> `power` доступний лише поки активне venv. Повторно активуйте через
+> `.\.venv\Scripts\Activate.ps1` (або додайте до профілю PowerShell).
+> Під час першого щільного пошуку (`power sync`) модельні файли (BGE-M3 +
+> реранкер ONNX, з перевіркою SHA-256) завантажуються автоматично у кеш venv.
+
+### Варіант B: Встановлення у user-site (глобально, без venv)
+
+```powershell
+py -m pip install --user "git+https://github.com/weby-homelab/power-framework.git@v3.3.2"
+power --version
+```
+
+Скрипти розміщуються у `%USERPROFILE%\AppData\Roaming\Python\Scripts`. Якщо
+`power` не розпізнається — закрийте та відкрийте термінал заново, або додайте
+цю папку до `PATH` (System Properties → Environment Variables; PowerShell:
+`$env:Path += ";$env:APPDATA\Python\Scripts"` на поточну сесію).
 
 Для розробки (editable, легке оновлення):
 
@@ -121,16 +159,54 @@ py -m pip install --user -e ".[dev]"
 git pull origin main   # оновлення будь-коли
 ```
 
+### Створіть vault та виконайте перші перевірки
+
+```powershell
+power init C:\Users\you\my-vault
+power lint C:\Users\you\my-vault
+power index C:\Users\you\my-vault
+power status C:\Users\you\my-vault
+```
+
+### Налаштування MCP на Windows (Claude Desktop)
+
+Відредагуйте `%APPDATA%\Claude\claude_desktop_config.json`:
+
+```json
+{
+    "mcpServers": {
+        "power": {
+            "command": "py",
+            "args": ["-m", "power_framework.mcp"],
+            "env": {
+                "POWER_VAULT_DIR": "C:\\Users\\you\\my-vault"
+            }
+        }
+    }
+}
+```
+
 Примітки:
 
-- **PATH** — додайте `%USERPROFILE%\AppData\Roaming\Python\Scripts` до `PATH`
-  (PowerShell: `$env:Path += ";$env:APPDATA\Python\Scripts"` на поточну сесію,
-  або через System Properties → Environment Variables).
-- **MCP-клієнти** — у конфігах Claude Desktop / OpenCode на Windows
-  використовуйте `"command": "py", "args": ["-m", "power_framework.mcp"]`.
+- **MCP-клієнти** — використовуйте `"command": "py"` (Windows Python launcher;
+  не `python3`) у конфігах Claude Desktop / OpenCode на Windows.
+- **Екранування backslash** у JSON (`\\`) або використовуйте forward slashes: `C:/Users/you/my-vault`.
+- **Шлях до venv** — якщо обрали Варіант A, вкажіть повний шлях у `command`:
+  `C:\Users\you\power-tools\.venv\Scripts\python.exe`.
 - **POWER_VAULT_DIR** — задайте змінну середовища через System Properties →
-  Environment Variables, якщо MCP-сервер не має питати шлях до vault
-  інтерактивно.
+  Environment Variables (або у блоці `env` вище), якщо MCP-сервер не має
+  питати шлях до vault інтерактивно.
+
+### Усунення проблем на Windows 11
+
+| Симптом                                                | Рішення                                                                                                                  |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `'power' is not recognized`                            | Відкрийте термінал заново, або додайте `%USERPROFILE%\AppData\Roaming\Python\Scripts` (чи `Scripts` від venv) до `PATH`. |
+| `pip install git+...` не працює                        | Встановіть [Git for Windows](https://git-scm.com/download/win) і перезапустіть термінал.                                 |
+| `python` не знайдено                                   | Перевстановіть Python з галочкою **"Add python.exe to PATH"**; перезапустіть термінал.                                   |
+| Попередження SmartScreen/Defender під час `power sync` | Очікувано при першому завантаженні моделей; файли перевіряються за SHA-256 та валідуються fail-closed.                   |
+
+## Що всередині
 
 ## Що всередині
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ vault/
 ├── 02_Areas/
 ├── 03_Resources/
 ├── 04_Archive/
-├── 05_Templates/
+├── 05_Templates/       # Note templates (default.md with OKF frontmatter)
 ├── 06_Daily_Logs/
 ├── PROTOCOLS/
 ├── index.md


### PR DESCRIPTION
## Summary
- Merged and expanded the Windows 11 installation guide across `README.md` (ENG) and `README.ua.md` (UKR): prerequisites, venv (recommended) and user-site options, first-check commands, MCP setup for Claude Desktop with `py` launcher, PATH notes, troubleshooting table.
- Harmonized with the guide added in #226 (kept `py -m pip install --user`, `%USERPROFILE%\AppData\Roaming\Python\Scripts` PATH note, `POWER_VAULT_DIR`, dev editable install) instead of duplicating content.
- Fixed minor drift in `docs/getting-started.md`: `power init` also creates `05_Templates/default.md` (vault tree updated).

## Validation
- `git diff --check` — clean
- GPG-signed commit (`git verify-commit` OK)
- All documented commands verified against `power 3.3.2` CLI (init/lint/index/heal/markdown-check/search/rot/archive/suggest-related/cron, MCP transport)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Windows 11 installation guidance, including prerequisites, virtual environments, user-site installs, PATH setup, and verification.
  * Added instructions for vault initialization, first checks, Claude Desktop MCP configuration, Windows path handling, environment variables, and troubleshooting.
  * Updated Ukrainian documentation with the same Windows setup and configuration guidance.
  * Clarified that `05_Templates/` contains note templates, including the default template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->