### PR TITLE
fix: improve Windows portability and validation

### DIFF
--- a/docs/documentation-inventory.ua.md
+++ b/docs/documentation-inventory.ua.md
@@ -53,11 +53,10 @@
 ## Межі перевірки
 
 Локальний smoke test підтверджує створення чистої бази, ingest, strict index, lint,
-Markdown-перевірку, FTS sync/search і status. Windows-команди звірено з PowerShell,
-офіційними prerequisites і шляхами venv; прямий запуск на Windows 11 25H2 має
-виконати цільовий хост після публікації змін. Доданий `windows-latest` CI smoke
-перевіряє загальний Windows runtime, але не є доказом саме Windows 11 25H2.
-Це обмеження не можна підмінювати Linux-успіхом.
+Markdown-перевірку, FTS sync/search і status. Фізичну перевірку Windows 11 25H2
+виконано для follow-up revision `4e5b2b9`; результати наведено у [звіті
+перевірки](tests/windows-11-25h2-validation.md). `windows-latest` CI smoke
+перевіряє загальний Windows runtime, але не замінює доказ цільового хоста.
 
 Автоматичний gate `scripts/check_doc_drift.py` перевіряє поточні кількості CLI/MCP,
 пошуковий контракт, заборонені застарілі шаблони та всі локальні Markdown-посилання

--- a/docs/tests/windows-11-25h2-validation.md
+++ b/docs/tests/windows-11-25h2-validation.md
@@ -1,0 +1,40 @@
+# Windows 11 25H2 validation
+
+Validation date: 2026-08-08  
+Validation target: physical Windows 11 Home 25H2, OS build `26200.8973`, x64  
+Python: CPython `3.13.14`  
+P.O.W.E.R. version: `3.3.2`  
+Source revision: `4e5b2b9`
+
+This report records the Windows portability validation for the follow-up source
+revision. It is intentionally limited to reproducible results and contains no
+machine-specific paths, addresses, credentials, or private configuration.
+
+## Results
+
+| Gate | Result |
+| --- | --- |
+| Full test suite with coverage and warnings-as-errors | `739 passed, 21 skipped`; coverage `78.21%` |
+| Ruff format and lint | Passed |
+| MyPy | Passed; 39 source files checked |
+| Documentation drift | Passed |
+| Release contract | Passed |
+| Markdown checks | Passed; 0 issues |
+| Wheel and sdist package smoke | Passed; 16 queries |
+| Clean vault: init, ingest, strict index, lint, Markdown, FTS, status | Passed |
+| Dense semantic search | Passed |
+| Reranked search | Passed |
+| MCP preflight | Passed |
+
+The dense and reranked checks used the pinned model contract and CPU runtime.
+The FTS checks were also run independently of model-backed retrieval.
+
+## Scope boundary
+
+This is a source and build validation record for revision `4e5b2b9`. The
+immutable public `v3.3.2` release tag and artifacts are not moved, replaced, or
+reissued by this change. The report does not claim certification for an
+unchanged artifact that was not rebuilt from this revision.
+
+The Microsoft Visual C++ runtime was present on the validation host. CUDA was
+not required because the acceptance run used the CPU ONNX Runtime backend.

--- a/docs/windows-11-installation.md
+++ b/docs/windows-11-installation.md
@@ -12,9 +12,10 @@ MCP client. It uses PowerShell syntax throughout.
   Microsoft Visual C++ runtime.
 - P.O.W.E.R. `v3.3.2` includes an automated cross-platform regression for the
   Windows rename-overwrite behavior.
-- The `v3.3.2` release was not executed on a physical Windows 11 25H2 host by
-  the release pipeline. Follow the acceptance checks below on the target
-  machine; do not interpret Linux CI as direct Windows certification.
+- Physical Windows 11 25H2 validation was completed on 2026-08-08 for follow-up
+  revision `4e5b2b9`; see the [validation report](tests/windows-11-25h2-validation.md).
+  This validates the follow-up source/build and does not move or reissue the
+  immutable `v3.3.2` release artifacts.
 
 Official prerequisites:
 

--- a/docs/windows-11-installation.ua.md
+++ b/docs/windows-11-installation.ua.md
@@ -12,9 +12,10 @@ MCP-клієнт. Усі команди наведено для PowerShell.
   актуального Microsoft Visual C++ Runtime.
 - P.O.W.E.R. `v3.3.2` має автоматизований кросплатформний regression-тест
   поведінки rename-overwrite у Windows.
-- Release pipeline `v3.3.2` не запускався на фізичному хості Windows 11 25H2.
-  Виконайте acceptance-перевірки нижче на цільовій машині; Linux CI не є
-  прямою сертифікацією Windows.
+- Фізичну перевірку Windows 11 25H2 завершено 2026-08-08 для follow-up revision
+  `4e5b2b9`; див. [звіт перевірки](tests/windows-11-25h2-validation.md).
+  Це підтверджує follow-up source/build і не переміщує та не перевидає
+  незмінні release-артефакти `v3.3.2`.
 
 Офіційні передумови:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
   - Release Governance:
       - M2 Human Evaluation: m2-human-evaluation.md
       - Issue 187 Historical Checklist: plans/issue-187-production-validation-checklist.md
+      - Windows 11 25H2 Validation: tests/windows-11-25h2-validation.md
   - Changelog: CHANGELOG.md
   - Contributing: contributing.md
 

--- a/scripts/smoke_package.py
+++ b/scripts/smoke_package.py
@@ -29,7 +29,11 @@ def smoke_artifact(artifact: Path, root: Path) -> None:
     name = artifact.stem.replace("-", "_")
     venv_dir = root / f"venv-{name}"
     _run([sys.executable, "-m", "venv", "--system-site-packages", str(venv_dir)], cwd=root)
-    python = venv_dir / "bin" / "python"
+    python = (
+        venv_dir
+        / ("Scripts" if sys.platform == "win32" else "bin")
+        / ("python.exe" if sys.platform == "win32" else "python")
+    )
     _run(
         [str(python), "-m", "pip", "install", "--force-reinstall", str(artifact)],
         cwd=root,

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -307,11 +307,13 @@ def _cmd_sync(args: argparse.Namespace) -> int:
         and hasattr(resource, "RLIMIT_AS")
     ):
         try:
-            _, hard = resource.getrlimit(resource.RLIMIT_AS)
+            getrlimit = getattr(resource, "getrlimit")  # noqa: B009 - optional POSIX module.
+            setrlimit = getattr(resource, "setrlimit")  # noqa: B009 - optional POSIX module.
+            _, hard = getrlimit(resource.RLIMIT_AS)
             new_soft = (
                 min(vmem_limit_mb * 1024 * 1024, hard) if hard > 0 else vmem_limit_mb * 1024 * 1024
             )
-            resource.setrlimit(resource.RLIMIT_AS, (new_soft, hard))
+            setrlimit(resource.RLIMIT_AS, (new_soft, hard))
             logger.info("Applied virtual-memory cap: %d MB", vmem_limit_mb)
         except (ValueError, OSError) as e:  # pragma: no cover
             logger.warning("Could not apply vmem cap: %s", e)
@@ -493,7 +495,7 @@ def _cmd_markdown_check(args: argparse.Namespace) -> int:
     total_issues = 0
     for filepath in vault_dir.rglob("*.md"):
         rel = filepath.relative_to(vault_dir)
-        if should_skip(vault_dir, str(rel)):
+        if should_skip(vault_dir, rel.as_posix()):
             continue
         if filepath.name in SKIP_FILES:
             continue

--- a/src/power_framework/core/coverage.py
+++ b/src/power_framework/core/coverage.py
@@ -26,7 +26,7 @@ def get_index_coverage(vault_dir: Path) -> tuple[int, int]:
         for filepath in root.rglob("*.md"):
             if filepath.name in ("index.md", "log.md", "_index.md"):
                 continue
-            if should_skip(root, str(filepath.relative_to(root))):
+            if should_skip(root, filepath.relative_to(root).as_posix()):
                 continue
             total += 1
     except OSError:

--- a/src/power_framework/core/generation_index.py
+++ b/src/power_framework/core/generation_index.py
@@ -139,7 +139,7 @@ def _source_inventory(vault_dir: Path) -> SourceInventory:
     for path in sorted(vault_dir.rglob("*.md")):
         if path.name in {"index.md", "log.md", "_index.md"}:
             continue
-        rel_path = str(path.relative_to(vault_dir))
+        rel_path = path.relative_to(vault_dir).as_posix()
         if should_skip(vault_dir, rel_path):
             continue
         total_scanned += 1

--- a/src/power_framework/core/healer.py
+++ b/src/power_framework/core/healer.py
@@ -283,7 +283,7 @@ def heal_vault(vault_dir: Path, dry_run: bool = True, limit: int | None = None) 
 
     for filepath in vault_dir.rglob("*.md"):
         rel = filepath.relative_to(vault_dir)
-        if should_skip(vault_dir, str(rel)):
+        if should_skip(vault_dir, rel.as_posix()):
             continue
         if any(part in DEFAULT_EXCLUDED for part in rel.parts):
             continue

--- a/src/power_framework/core/ignore.py
+++ b/src/power_framework/core/ignore.py
@@ -113,7 +113,7 @@ def should_skip(vault_dir: Path, rel_path: str) -> bool:
 def iter_markdown(vault_dir: Path) -> Iterator[tuple[Path, str]]:
     """Yield ``(filepath, rel_path)`` for every in-scope, non-ignored ``.md`` file."""
     for filepath in vault_dir.rglob("*.md"):
-        rel_path = str(filepath.relative_to(vault_dir))
+        rel_path = filepath.relative_to(vault_dir).as_posix()
         if should_skip(vault_dir, rel_path):
             continue
         yield filepath, rel_path

--- a/src/power_framework/core/indexer.py
+++ b/src/power_framework/core/indexer.py
@@ -48,7 +48,7 @@ def scan_vault_notes(vault_dir: Path) -> dict[str, list[tuple[str, str, str]]]:
     for filepath in vault_dir.rglob("*.md"):
         if filepath.name in ("index.md", "log.md"):
             continue
-        if should_skip(vault_dir, str(filepath.relative_to(vault_dir))):
+        if should_skip(vault_dir, filepath.relative_to(vault_dir).as_posix()):
             continue
 
         try:
@@ -57,7 +57,7 @@ def scan_vault_notes(vault_dir: Path) -> dict[str, list[tuple[str, str, str]]]:
             if metadata is None:
                 continue
 
-            rel_path = str(filepath.relative_to(vault_dir))
+            rel_path = filepath.relative_to(vault_dir).as_posix()
             note_type = metadata.type
             title = metadata.title
             desc = metadata.description
@@ -89,7 +89,7 @@ def scan_folder_notes(
             continue
 
         rel_path = filepath.relative_to(vault_dir)
-        if should_skip(vault_dir, str(rel_path)):
+        if should_skip(vault_dir, rel_path.as_posix()):
             continue
 
         top_folder = rel_path.parts[0]
@@ -101,7 +101,7 @@ def scan_folder_notes(
             metadata: OKFMetadata | None = validate_metadata(content)
             if metadata is None:
                 if invalid_notes is not None:
-                    invalid_notes.append((str(rel_path), "Invalid OKF metadata"))
+                    invalid_notes.append((rel_path.as_posix(), "Invalid OKF metadata"))
                 continue
 
             tags = metadata.tags if metadata.tags else []
@@ -112,7 +112,7 @@ def scan_folder_notes(
             related = metadata.related if metadata.related else []
 
             note_info = {
-                "rel_path": str(rel_path),
+                "rel_path": rel_path.as_posix(),
                 "title": metadata.title,
                 "description": metadata.description,
                 "note_type": metadata.type,
@@ -208,12 +208,12 @@ def _scan_folder_notes_incremental(
         if filepath.name in {"index.md", "log.md", "_index.md"}:
             continue
         rel_path = filepath.relative_to(vault_dir)
-        if should_skip(vault_dir, str(rel_path)) or not rel_path.parts:
+        if should_skip(vault_dir, rel_path.as_posix()) or not rel_path.parts:
             continue
         top_folder = rel_path.parts[0]
         if top_folder not in INDEX_FOLDERS:
             continue
-        rel_path_str = str(rel_path)
+        rel_path_str = rel_path.as_posix()
         seen_paths.add(rel_path_str)
 
         try:
@@ -221,7 +221,7 @@ def _scan_folder_notes_incremental(
             signature = {"mtime_ns": stat.st_mtime_ns, "size": stat.st_size}
         except OSError:
             changed_folders.add(top_folder)
-            invalid_notes.append((str(rel_path), "read_error"))
+            invalid_notes.append((rel_path.as_posix(), "read_error"))
             continue
 
         cached_entry = cached_entries.get(rel_path_str)
@@ -235,9 +235,9 @@ def _scan_folder_notes_incremental(
                 folder_notes.setdefault(top_folder, []).append(note_info)
             else:
                 invalid_notes.append(
-                    (str(rel_path), str(cached_entry.get("reason", "invalid_metadata")))
+                    (rel_path.as_posix(), str(cached_entry.get("reason", "invalid_metadata")))
                 )
-            next_entries[str(rel_path)] = cached_entry
+            next_entries[rel_path.as_posix()] = cached_entry
             continue
 
         changed_folders.add(top_folder)
@@ -248,8 +248,8 @@ def _scan_folder_notes_incremental(
             metadata = None
         if metadata is None:
             reason = "Invalid OKF metadata"
-            invalid_notes.append((str(rel_path), reason))
-            next_entries[str(rel_path)] = {
+            invalid_notes.append((rel_path.as_posix(), reason))
+            next_entries[rel_path.as_posix()] = {
                 "signature": signature,
                 "valid": False,
                 "reason": reason,
@@ -259,7 +259,7 @@ def _scan_folder_notes_incremental(
 
         note_info = _note_info_from_metadata(filepath, vault_dir, metadata)
         folder_notes.setdefault(top_folder, []).append(note_info)
-        next_entries[str(rel_path)] = {
+        next_entries[rel_path.as_posix()] = {
             "signature": signature,
             "valid": True,
             "note": _serialise_note_info(note_info),
@@ -310,7 +310,7 @@ def scan_root_daily_logs(vault_dir: Path) -> list[dict]:
         rel_path = filepath.relative_to(vault_dir)
         if filepath.name in {"index.md", "log.md", "_index.md"}:
             continue
-        if len(rel_path.parts) != 1 or should_skip(vault_dir, str(rel_path)):
+        if len(rel_path.parts) != 1 or should_skip(vault_dir, rel_path.as_posix()):
             continue
 
         try:
@@ -320,7 +320,7 @@ def scan_root_daily_logs(vault_dir: Path) -> list[dict]:
                 continue
             root_logs.append(
                 {
-                    "rel_path": str(rel_path),
+                    "rel_path": rel_path.as_posix(),
                     "title": metadata.title,
                     "description": metadata.description,
                 }

--- a/src/power_framework/core/linter.py
+++ b/src/power_framework/core/linter.py
@@ -456,7 +456,7 @@ def run_rot_audit(vault_dir: Path, extended: bool = False) -> ROTResult:
 
     for filepath in vault_dir.rglob("*.md"):
         rel = filepath.relative_to(vault_dir)
-        if should_skip(vault_dir, str(rel)):
+        if should_skip(vault_dir, rel.as_posix()):
             continue
         if filepath.name in ("index.md", "log.md", "_index.md"):
             continue
@@ -471,7 +471,7 @@ def run_rot_audit(vault_dir: Path, extended: bool = False) -> ROTResult:
             continue
 
         title = str(fm.get("title", ""))
-        rel_path = str(rel)
+        rel_path = rel.as_posix()
 
         # Track titles for redundancy check
         if title:
@@ -580,12 +580,12 @@ def archive_stale_notes(vault_dir: Path, dry_run: bool = True) -> str:
 
     for filepath in vault_dir.rglob("*.md"):
         rel = filepath.relative_to(vault_dir)
-        if should_skip(vault_dir, str(rel)):
+        if should_skip(vault_dir, rel.as_posix()):
             continue
         if filepath.name in ("index.md", "log.md", "_index.md"):
             continue
         # Skip notes already in archive
-        rel_str = str(rel)
+        rel_str = rel.as_posix()
         if rel_str.startswith("04_Archive/"):
             continue
 
@@ -622,11 +622,11 @@ def archive_stale_notes(vault_dir: Path, dry_run: bool = True) -> str:
             continue
 
         if dry_run:
-            moved.append(f"  {rel_str} -> {archive_target.relative_to(vault_dir)}")
+            moved.append(f"  {rel_str} -> {archive_target.relative_to(vault_dir).as_posix()}")
         else:
             archive_dir.mkdir(parents=True, exist_ok=True)
             shutil.move(str(filepath), str(archive_target))
-            moved.append(f"  {rel_str} -> {archive_target.relative_to(vault_dir)}")
+            moved.append(f"  {rel_str} -> {archive_target.relative_to(vault_dir).as_posix()}")
 
     lines = [
         "=== Archive Stale Notes ===",
@@ -686,7 +686,7 @@ def run_status_report(vault_dir: Path) -> str:
             continue
 
         rel_path = filepath.relative_to(vault_dir)
-        rel_path_str = str(rel_path)
+        rel_path_str = rel_path.as_posix()
 
         if should_skip(vault_dir, rel_path_str):
             continue

--- a/src/power_framework/core/mutation.py
+++ b/src/power_framework/core/mutation.py
@@ -39,7 +39,9 @@ _compatibility_lock = threading.RLock()
 def _lock_descriptor(descriptor: int) -> None:
     """Acquire an exclusive advisory lock on one byte of the lock file."""
     if fcntl is not None:
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        flock = getattr(fcntl, "flock")  # noqa: B009 - optional POSIX module.
+        lock_ex = getattr(fcntl, "LOCK_EX")  # noqa: B009 - optional POSIX module.
+        flock(descriptor, lock_ex)
         return
     if msvcrt is not None:  # pragma: no cover - Windows-only branch
         # ``msvcrt.locking`` locks bytes, so make the lock file non-empty
@@ -55,7 +57,9 @@ def _lock_descriptor(descriptor: int) -> None:
 def _unlock_descriptor(descriptor: int) -> None:
     """Release a lock acquired by :func:`_lock_descriptor`."""
     if fcntl is not None:
-        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        flock = getattr(fcntl, "flock")  # noqa: B009 - optional POSIX module.
+        lock_un = getattr(fcntl, "LOCK_UN")  # noqa: B009 - optional POSIX module.
+        flock(descriptor, lock_un)
         return
     if msvcrt is not None:  # pragma: no cover - Windows-only branch
         os.lseek(descriptor, 0, os.SEEK_SET)

--- a/src/power_framework/core/relations.py
+++ b/src/power_framework/core/relations.py
@@ -148,7 +148,7 @@ def suggest_related(
 
     for filepath in vault_dir.rglob("*.md"):
         rel = filepath.relative_to(vault_dir)
-        if should_skip(vault_dir, str(rel)):
+        if should_skip(vault_dir, rel.as_posix()):
             continue
         if filepath.name in ("index.md", "log.md", "_index.md"):
             continue
@@ -162,7 +162,7 @@ def suggest_related(
         if metadata is None:
             continue
 
-        rel_path = str(rel)
+        rel_path = rel.as_posix()
         kw_text = f"{metadata.title} {metadata.description} {content}"
         keywords = _extract_keywords(kw_text)
         tags = metadata.tags or []
@@ -445,7 +445,7 @@ def suggest_related_v2(
 
     for filepath in vault_dir.rglob("*.md"):
         rel = filepath.relative_to(vault_dir)
-        if should_skip(vault_dir, str(rel)):
+        if should_skip(vault_dir, rel.as_posix()):
             continue
         if filepath.name in ("index.md", "log.md", "_index.md"):
             continue
@@ -457,7 +457,7 @@ def suggest_related_v2(
         if metadata is None:
             continue
 
-        rel_path = str(rel)
+        rel_path = rel.as_posix()
         kw_text = f"{metadata.title} {metadata.description} {content}"
         keywords = _extract_keywords(kw_text)
         tags = metadata.tags or []
@@ -616,7 +616,7 @@ def suggest_related_semantic(
     notes: dict[str, str] = {}
     for filepath in vault_dir.rglob("*.md"):
         rel = filepath.relative_to(vault_dir)
-        if should_skip(vault_dir, str(rel)):
+        if should_skip(vault_dir, rel.as_posix()):
             continue
         if filepath.name in ("index.md", "log.md", "_index.md"):
             continue
@@ -624,7 +624,7 @@ def suggest_related_semantic(
             content = read_file_content(filepath)
         except Exception:  # noqa: S112
             continue
-        rel_path = str(rel)
+        rel_path = rel.as_posix()
         if rel_path == target_path:
             target_text = content
             continue

--- a/src/power_framework/core/rot_scoring.py
+++ b/src/power_framework/core/rot_scoring.py
@@ -84,7 +84,7 @@ class ContentDedupDetector:
 
         for filepath in vault_dir.rglob("*.md"):
             rel = filepath.relative_to(vault_dir)
-            if should_skip(vault_dir, str(rel)):
+            if should_skip(vault_dir, rel.as_posix()):
                 continue
             if filepath.name in ("index.md", "log.md", "_index.md"):
                 continue
@@ -99,7 +99,7 @@ class ContentDedupDetector:
             if len(body) < 50:
                 continue
 
-            rel_path = str(rel)
+            rel_path = rel.as_posix()
             try:
                 vec = self.embedder.embed(body)
             except Exception as exc:
@@ -166,7 +166,7 @@ class ContradictionDetector:
 
         for filepath in vault_dir.rglob("*.md"):
             rel = filepath.relative_to(vault_dir)
-            if should_skip(vault_dir, str(rel)):
+            if should_skip(vault_dir, rel.as_posix()):
                 continue
             if filepath.name in ("index.md", "log.md", "_index.md"):
                 continue
@@ -181,7 +181,7 @@ class ContradictionDetector:
             if len(body) < 50:
                 continue
 
-            rel_path = str(rel)
+            rel_path = rel.as_posix()
             notes[rel_path] = body
             try:
                 embeddings[rel_path] = self.embedder.embed(body)
@@ -356,7 +356,7 @@ class FreshnessScorer:
 
         for filepath in vault_dir.rglob("*.md"):
             rel = filepath.relative_to(vault_dir)
-            if should_skip(vault_dir, str(rel)):
+            if should_skip(vault_dir, rel.as_posix()):
                 continue
             if filepath.name in ("index.md", "log.md", "_index.md"):
                 continue
@@ -383,7 +383,7 @@ class FreshnessScorer:
 
             half_life = TYPE_HALF_LIFE_DAYS.get(note_type, DEFAULT_HALF_LIFE_DAYS)
             score = 2.0 ** (-age / half_life) if half_life > 0 else 1.0
-            scores[str(rel)] = round(min(1.0, max(0.0, score)), 4)
+            scores[rel.as_posix()] = round(min(1.0, max(0.0, score)), 4)
 
         return scores
 
@@ -410,7 +410,7 @@ class LinkRotChecker:
 
         for filepath in vault_dir.rglob("*.md"):
             rel = filepath.relative_to(vault_dir)
-            if should_skip(vault_dir, str(rel)):
+            if should_skip(vault_dir, rel.as_posix()):
                 continue
             if filepath.name in ("index.md", "log.md", "_index.md"):
                 continue
@@ -422,7 +422,7 @@ class LinkRotChecker:
                 continue
 
             urls = self.EXTERNAL_LINK_PATTERN.findall(content)
-            to_check.extend((str(rel), url) for url in urls)
+            to_check.extend((rel.as_posix(), url) for url in urls)
 
         if not to_check:
             return results

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -359,7 +359,7 @@ def _scan_and_search(vault_dir: Path, terms: list[str]) -> list[SearchResult]:
     for filepath in vault_dir.rglob("*.md"):
         if filepath.name in ("index.md", "log.md", "_index.md"):
             continue
-        if should_skip(vault_dir, str(filepath.relative_to(vault_dir))):
+        if should_skip(vault_dir, filepath.relative_to(vault_dir).as_posix()):
             continue
 
         try:
@@ -372,7 +372,7 @@ def _scan_and_search(vault_dir: Path, terms: list[str]) -> list[SearchResult]:
             if score == 0:
                 continue
 
-            rel_path = str(filepath.relative_to(vault_dir))
+            rel_path = filepath.relative_to(vault_dir).as_posix()
             results.append(
                 SearchResult(
                     rel_path=rel_path,
@@ -436,11 +436,11 @@ def _sync_vault_to_db(
     for filepath in vault_dir.rglob("*.md"):
         if filepath.name in ("index.md", "log.md", "_index.md"):
             continue
-        if should_skip(vault_dir, str(filepath.relative_to(vault_dir))):
+        if should_skip(vault_dir, filepath.relative_to(vault_dir).as_posix()):
             continue
 
         try:
-            rel_path = str(filepath.relative_to(vault_dir))
+            rel_path = filepath.relative_to(vault_dir).as_posix()
             mtime = filepath.stat().st_mtime
             disk_files[rel_path] = mtime
         except Exception:  # noqa: S112

--- a/src/power_framework/core/utils.py
+++ b/src/power_framework/core/utils.py
@@ -87,10 +87,14 @@ def atomic_write(filepath: Path, content: str, encoding: str = "utf-8") -> None:
         suffix=".tmp",
     )
     try:
-        with os.fdopen(fd, "w", encoding=encoding) as f:
+        file_obj = os.fdopen(fd, "w", encoding=encoding)
+        fd = -1
+        with file_obj as f:
             f.write(content)
         os.replace(tmp_path, filepath)
     except Exception:
+        if fd >= 0:
+            os.close(fd)
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
         raise
@@ -114,13 +118,12 @@ def resolve_path_in_vault(
 
     if not raw_path or any(ord(char) < 32 or ord(char) == 127 for char in decoded_path):
         raise ValueError("Invalid vault-relative path")
-    if "\\" in decoded_path:
-        raise ValueError("Windows path separators are not allowed")
-
     windows_path = PureWindowsPath(decoded_path)
     posix_path = Path(decoded_path)
     if posix_path.is_absolute() or windows_path.is_absolute() or windows_path.drive:
         raise ValueError("Absolute paths are not allowed")
+    if "\\" in decoded_path:
+        raise ValueError("Windows path separators are not allowed")
 
     path_parts = Path(decoded_path).parts
     if not path_parts or any(part in {".", ".."} for part in path_parts):

--- a/tests/test_human_retrieval_evidence.py
+++ b/tests/test_human_retrieval_evidence.py
@@ -139,7 +139,7 @@ def test_evidence_file_binds_each_artifact_to_its_declared_hash(tmp_path: Path) 
         content = f"{key}\n"
         (tmp_path / filename).write_text(content, encoding="utf-8")
         manifest[f"{key}_sha256" if key != "raw_judgments" else "raw_judgments_sha256"] = (
-            hashlib.sha256(content.encode()).hexdigest()
+            hashlib.sha256((tmp_path / filename).read_bytes()).hexdigest()
         )
     manifest["adjudicated_qrels_sha256"] = hashlib.sha256(
         (tmp_path / artifacts["adjudicated_qrels"]).read_bytes()

--- a/tests/test_m2_candidate_pool.py
+++ b/tests/test_m2_candidate_pool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import stat
 from pathlib import Path
 
@@ -76,7 +77,8 @@ def test_pool_is_deterministic_and_hash_bound(tmp_path: Path) -> None:
     assert first["policy_sha256"] == MODULE.sha256_file(inputs[0])
     assert first["source_receipt_sha256"] == MODULE.sha256_file(inputs[3])
     assert all(len(row["random_negative_ids"]) == 2 for row in first["queries"])
-    assert stat.S_IMODE(first_path.stat().st_mode) == 0o600
+    if os.name != "nt":
+        assert stat.S_IMODE(first_path.stat().st_mode) == 0o600
 
 
 def test_pending_policy_is_fail_closed(tmp_path: Path) -> None:

--- a/tests/test_memory_benchmarks.py
+++ b/tests/test_memory_benchmarks.py
@@ -429,8 +429,8 @@ Preferred text editor is Neovim.
         scorer = FreshnessScorer()
         scores = scorer.score_all(vault)
 
-        old_rel = str(old_pref.relative_to(vault))
-        new_rel = str(new_pref.relative_to(vault))
+        old_rel = old_pref.relative_to(vault).as_posix()
+        new_rel = new_pref.relative_to(vault).as_posix()
 
         # Newer preferences must have higher freshness score than the stale ones
         assert scores[new_rel] > scores[old_rel]

--- a/tests/test_rot_scoring.py
+++ b/tests/test_rot_scoring.py
@@ -89,7 +89,7 @@ class TestFreshnessScorer:
         scorer = FreshnessScorer()
         scores = scorer.score_all(vault)
         assert len(scores) == 1
-        rel_path = str(note.relative_to(vault))
+        rel_path = note.relative_to(vault).as_posix()
         assert scores[rel_path] > 0.8  # freshly created, should be very fresh
 
     def test_old_daily_log_is_stale(self, tmp_path: Path):
@@ -106,7 +106,7 @@ class TestFreshnessScorer:
 
         scorer = FreshnessScorer()
         scores = scorer.score_all(vault)
-        rel_path = str(note.relative_to(vault))
+        rel_path = note.relative_to(vault).as_posix()
         assert scores[rel_path] < 0.3  # >18 months old, daily log half-life 30d
 
     def test_resource_ages_slower(self, tmp_path: Path):
@@ -123,7 +123,7 @@ class TestFreshnessScorer:
 
         scorer = FreshnessScorer()
         scores = scorer.score_all(vault)
-        rel_path = str(note.relative_to(vault))
+        rel_path = note.relative_to(vault).as_posix()
         # Resource half-life is 365d, ~13 months old
         assert 0.3 < scores[rel_path] < 1.0
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -109,6 +109,10 @@ class TestVaultRelativeWritePaths:
     """Tests for centralized validation of untrusted note paths."""
 
     _allowed_directories = ("01_Projects", "06_Daily_Logs")
+    _requires_windows_symlink_privilege = pytest.mark.skipif(
+        os.name == "nt",
+        reason="Windows symlink creation requires SeCreateSymbolicLinkPrivilege",
+    )
 
     def test_allows_existing_nested_markdown_path(self, sample_vault: Path):
         target = resolve_path_in_vault(
@@ -139,6 +143,7 @@ class TestVaultRelativeWritePaths:
         with pytest.raises(ValueError, match="Absolute"):
             resolve_path_in_vault(sample_vault, str(outside_path), self._allowed_directories)
 
+    @_requires_windows_symlink_privilege
     def test_rejects_symlinked_parent_that_escapes_vault(self, sample_vault: Path, tmp_path: Path):
         outside_directory = tmp_path / "outside"
         outside_directory.mkdir()
@@ -169,6 +174,7 @@ class TestVaultRelativeWritePaths:
         with pytest.raises(ValueError, match=r"path|Path|Absolute|Invalid"):
             resolve_path_in_vault(sample_vault, traversal_path, self._allowed_directories)
 
+    @_requires_windows_symlink_privilege
     def test_rejects_symlink_parent_escape(self, sample_vault: Path, tmp_path: Path):
         outside_dir = tmp_path / "outside"
         outside_dir.mkdir()
@@ -181,6 +187,7 @@ class TestVaultRelativeWritePaths:
                 self._allowed_directories,
             )
 
+    @_requires_windows_symlink_privilege
     def test_rejects_symlink_target_to_external_file(self, sample_vault: Path, tmp_path: Path):
         outside_file = tmp_path / "outside.md"
         outside_file.write_text("hack")
@@ -193,6 +200,7 @@ class TestVaultRelativeWritePaths:
                 self._allowed_directories,
             )
 
+    @_requires_windows_symlink_privilege
     def test_atomic_write_rejects_symlinked_note_without_changing_sentinel(
         self,
         sample_vault: Path,


### PR DESCRIPTION
Closes #232

## Summary

Follow-up portability and validation changes for Windows 11 25H2.

- Normalize vault-relative paths consistently across Windows and POSIX.
- Make atomic writes and optional POSIX resource controls safe on Windows.
- Harden Windows-aware path, security, relation, and retrieval behavior.
- Add a sanitized Windows 11 25H2 validation report and update installation documentation.

## Validation

Physical Windows 11 Home 25H2, build 26200.8973, x64; CPython 3.13.14; P.O.W.E.R. 3.3.2.

- Full pytest with coverage and warnings-as-errors: 739 passed, 21 skipped; coverage 78.21%.
- Ruff, MyPy, doc-drift, release-contract, Markdown, and MkDocs strict: passed.
- Wheel/sdist package smoke: passed (16 queries).
- Clean vault lifecycle, FTS, semantic search, reranked search, and MCP preflight: passed.
- GitHub Actions CI, Docs, and CodeQL: passed.

The detailed sanitized evidence is in docs/tests/windows-11-25h2-validation.md.

This follow-up does not move, replace, or reissue the immutable v3.3.2 release tag or artifacts.