### PR TITLE
docs: complete Windows 11 25H2 validation receipt

### DIFF
--- a/docs/tests/windows-11-25h2-validation.md
+++ b/docs/tests/windows-11-25h2-validation.md
@@ -26,6 +26,41 @@ machine-specific paths, addresses, credentials, or private configuration.
 | Reranked search | Passed |
 | MCP preflight | Passed |
 
+## Reproduction record
+
+The following gates were executed on the validation host; each command returned
+exit code `0`:
+
+```text
+uv run ruff check src tests scripts
+uv run ruff format --check src tests scripts
+uv run mypy src/power_framework
+uv run python scripts/check_doc_drift.py
+uv run python scripts/verify_release_contract.py
+uv run power markdown-check docs
+uv run pytest tests/ -v --tb=short --cov=src/power_framework/ --cov-report=term-missing --cov-fail-under=70 -W error
+uv run python -m build --sdist --wheel
+uv run python scripts/smoke_package.py --wheel <wheel> --sdist <sdist>
+```
+
+The full test suite elapsed time was `79.20s`; its exit code was `0`. The
+clean-vault, FTS, dense, reranked, and MCP acceptance commands also returned
+exit code `0`.
+
+## Warning classification
+
+- No warning was accepted as a product failure or left unclassified.
+- The 21 skipped tests were classified as: 5 optional neural-benchmark cases
+  requiring an explicit benchmark flag or real brain vault; 11 optional
+  reranker-cache cases; 1 real-brain-vault quality case; and 4 Windows symlink
+  cases requiring `SeCreateSymbolicLinkPrivilege`.
+- Windows symlink-privilege and model-cache symlink messages were classified as
+  host capability/cache warnings; model-backed acceptance completed with the
+  pinned CPU runtime.
+- MkDocs reported existing historical pages outside `nav`; this was a
+  non-blocking documentation warning and the strict build still returned exit
+  code `0`.
+
 The dense and reranked checks used the pinned model contract and CPU runtime.
 The FTS checks were also run independently of model-backed retrieval.
 
@@ -38,3 +73,12 @@ unchanged artifact that was not rebuilt from this revision.
 
 The Microsoft Visual C++ runtime was present on the validation host. CUDA was
 not required because the acceptance run used the CPU ONNX Runtime backend.
+
+## Post-merge read-back
+
+- PR #231 merged by squash as `11e2248`.
+- `main` and `origin/main` matched at the read-back.
+- Post-merge CI, Docs, and CodeQL runs for `11e2248` completed successfully.
+- Public GitHub Pages returned HTTP `200` and exposed the Windows 11 25H2
+  validation navigation.
+- Issue #232 was closed automatically by `Closes #232`.


### PR DESCRIPTION
Closes #232

This follow-up completes the public Windows 11 25H2 validation receipt.

It records the exact reproduction commands, exit codes, elapsed time, all 21 skip classifications, non-blocking warning classification, post-merge read-back, GitHub Actions results, and GitHub Pages verification.

The report remains sanitized and does not expose private paths, addresses, credentials, or private evaluation data.