### PR TITLE
fix(healer): one note with a backslash no longer aborts the whole vault

### DIFF
--- a/src/power_framework/core/healer.py
+++ b/src/power_framework/core/healer.py
@@ -333,8 +333,11 @@ def heal_vault(vault_dir: Path, dry_run: bool = True, limit: int | None = None) 
             try:
                 backup_path = create_backup(filepath)
                 atomic_write(filepath, healed)
-            except OSError as exc:
-                logger.warning("Cannot write %s: %s", rel, exc)
+            except Exception as exc:
+                # Not just OSError: atomic_write and create_backup can fail on
+                # encoding, permissions or a rejected path, and any of those
+                # must cost one note rather than the run.
+                logger.warning("Cannot write %s: %s: %s", rel, type(exc).__name__, exc)
                 failures.append((rel.as_posix(), f"{type(exc).__name__}: {exc}"))
                 continue
         healed_count += 1
@@ -355,7 +358,10 @@ def heal_vault(vault_dir: Path, dry_run: bool = True, limit: int | None = None) 
         lines.append("Changes:")
         lines.extend(changes_log)
         lines.append("")
-    else:
+    elif not failures:
+        # Only claim a clean vault when nothing failed. Saying "no notes needed
+        # healing" next to "Notes failed: 2790" reads as success and is how a
+        # total failure gets mistaken for a no-op.
         lines.append("No notes needed healing.")
         lines.append("")
 

--- a/src/power_framework/core/healer.py
+++ b/src/power_framework/core/healer.py
@@ -24,6 +24,7 @@ from .ignore import should_skip
 from .models import NoteType
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 from .parser import (
@@ -96,6 +97,19 @@ def _extract_first_paragraph(content: str) -> str:
             if clean:
                 return clean[:150]
     return ""
+
+
+def _literal_replacement(text: str) -> Callable[[re.Match[str]], str]:
+    """Return a re.sub replacement that inserts *text* verbatim.
+
+    A ``str`` replacement is parsed as a template, so a backslash carried over
+    from a note's own frontmatter — AutoCAD MTEXT codes such as ``\\P``, a
+    Windows path, LaTeX — is read as a group reference and raises ``re.error``.
+    Recognized fields are protected by ``_escape_yaml`` doubling the backslash;
+    unrecognized ones are rendered by ``yaml.safe_dump`` and keep a single one.
+    A callable replacement is never parsed.
+    """
+    return lambda _match: text
 
 
 def _escape_yaml(value: str) -> str:
@@ -258,7 +272,7 @@ def heal_frontmatter(
     if raw_fm is not None:
         healed = re.sub(
             r"^---.*?\n---\n?",
-            new_fm + "\n",
+            _literal_replacement(new_fm + "\n"),
             content,
             count=1,
             flags=re.DOTALL,
@@ -280,6 +294,7 @@ def heal_vault(vault_dir: Path, dry_run: bool = True, limit: int | None = None) 
     """
     healed_count = 0
     changes_log: list[str] = []
+    failures: list[tuple[str, str]] = []
 
     for filepath in vault_dir.rglob("*.md"):
         rel = filepath.relative_to(vault_dir)
@@ -298,30 +313,42 @@ def heal_vault(vault_dir: Path, dry_run: bool = True, limit: int | None = None) 
         if not content.strip():
             continue
 
-        healed, changes = heal_frontmatter(content, filepath, vault_dir)
+        # One unhealable note must never cost the rest of the vault: record it
+        # and carry on, so a 2 000-note run reports 1 failure instead of 0
+        # successes.
+        try:
+            healed, changes = heal_frontmatter(content, filepath, vault_dir)
+        except Exception as exc:
+            logger.warning("Cannot heal %s: %s: %s", rel, type(exc).__name__, exc)
+            failures.append((rel.as_posix(), f"{type(exc).__name__}: {exc}"))
+            continue
         if not changes:
             continue
 
         if limit is not None and healed_count >= limit:
             break
 
+        backup_path: Path | None = None
+        if not dry_run:
+            try:
+                backup_path = create_backup(filepath)
+                atomic_write(filepath, healed)
+            except OSError as exc:
+                logger.warning("Cannot write %s: %s", rel, exc)
+                failures.append((rel.as_posix(), f"{type(exc).__name__}: {exc}"))
+                continue
         healed_count += 1
-        if dry_run:
-            changes_log.append(f"  {rel}:")
-            changes_log.extend(f"    - {c}" for c in changes)
-        else:
-            backup_path = create_backup(filepath)
-            atomic_write(filepath, healed)
-            changes_log.append(f"  {rel}:")
-            changes_log.extend(f"    - {c}" for c in changes)
-            if backup_path:
-                changes_log.append(f"    (backup: {backup_path.name})")
+        changes_log.append(f"  {rel}:")
+        changes_log.extend(f"    - {c}" for c in changes)
+        if backup_path:
+            changes_log.append(f"    (backup: {backup_path.name})")
 
     lines = [
         "=== Frontmatter Heal Report ===",
         f"Vault: {vault_dir}",
         f"Mode: {'DRY RUN' if dry_run else 'LIVE'}",
         f"Notes healed: {healed_count}",
+        f"Notes failed: {len(failures)}",
         "",
     ]
     if changes_log:
@@ -330,6 +357,11 @@ def heal_vault(vault_dir: Path, dry_run: bool = True, limit: int | None = None) 
         lines.append("")
     else:
         lines.append("No notes needed healing.")
+        lines.append("")
+
+    if failures:
+        lines.append("Failed (left untouched):")
+        lines.extend(f"  {rel_path}: {reason}" for rel_path, reason in failures)
         lines.append("")
 
     return "\n".join(lines)
@@ -405,7 +437,7 @@ def propagate_rename(
             new_fm = _format_frontmatter(fm_data, note_type, title, description, parsed_timestamp)
             healed = re.sub(
                 r"^---.*?\n---\n?",
-                new_fm + "\n",
+                _literal_replacement(new_fm + "\n"),
                 content,
                 count=1,
                 flags=re.DOTALL,

--- a/tests/test_healer.py
+++ b/tests/test_healer.py
@@ -12,6 +12,7 @@ from power_framework.core.healer import (
     heal_vault,
     propagate_rename,
 )
+from power_framework.core.parser import parse_frontmatter
 
 
 class TestInferTitleFromFilename:
@@ -162,7 +163,13 @@ class TestHealBackslashEscapes:
         )
         healed, changes = heal_frontmatter(note.read_text(encoding="utf-8"), note)
         assert changes
-        assert "fArial" in healed
+        # Absence of an exception is not the contract: the escapes must come
+        # through byte-for-byte, not be consumed as re template references.
+        assert r"\fArial|b0;7.5\P" in healed
+        assert (
+            parse_frontmatter(healed)["smoke"]
+            == r'MTEXT guard: (cd:ParseDecimal "{\fArial|b0;7.5\P}")'
+        )
 
     def test_windows_path_in_custom_field_does_not_raise(self, tmp_path: Path):
         note = tmp_path / "note.md"
@@ -175,7 +182,7 @@ class TestHealBackslashEscapes:
         )
         healed, changes = heal_frontmatter(note.read_text(encoding="utf-8"), note)
         assert changes
-        assert "Users" in healed
+        assert parse_frontmatter(healed)["source_dir"] == r"C:\Users\Public\vault"
 
     def test_propagate_rename_survives_backslash_frontmatter(self, tmp_path: Path):
         """`power rename` rewrites frontmatter through the same code path."""
@@ -199,7 +206,10 @@ class TestHealBackslashEscapes:
             vault, "03_Resources/old_name.md", "03_Resources/new_name.md", dry_run=False
         )
         assert updated == 1
-        assert "03_Resources/new_name.md" in note.read_text(encoding="utf-8")
+        rewritten = note.read_text(encoding="utf-8")
+        assert "03_Resources/new_name.md" in rewritten
+        # The unrelated backslash field must survive the rewrite untouched.
+        assert parse_frontmatter(rewritten)["source_dir"] == r"C:\Users\Public\vault"
 
     def test_one_unhealable_note_does_not_abort_the_vault(self, tmp_path: Path, monkeypatch):
         """A single failing note must cost one note, not the whole run."""
@@ -225,3 +235,40 @@ class TestHealBackslashEscapes:
         assert "Notes failed: 1" in report
         assert "poison.md" in report
         assert "type: Project" in (vault / "01_Projects" / "z_note.md").read_text(encoding="utf-8")
+
+    def test_write_failure_other_than_oserror_is_captured(self, tmp_path: Path, monkeypatch):
+        """`atomic_write` can fail on encoding or a rejected path, not just OSError."""
+        vault = tmp_path / "vault"
+        (vault / "01_Projects").mkdir(parents=True)
+        (vault / "01_Projects" / "note.md").write_text(
+            '---\ndescription: "Desc"\ntimestamp: 2026-01-01T00:00:00\n---\n\nBody text.',
+            encoding="utf-8",
+        )
+
+        def refuse(*_args, **_kwargs):
+            raise ValueError("simulated non-OSError write failure")
+
+        monkeypatch.setattr(healer_module, "atomic_write", refuse)
+        report = heal_vault(vault, dry_run=False)
+
+        assert "Notes healed: 0" in report
+        assert "Notes failed: 1" in report
+        assert "ValueError" in report
+
+    def test_total_failure_is_not_reported_as_a_clean_vault(self, tmp_path: Path, monkeypatch):
+        """ "No notes needed healing" next to "Notes failed: N" reads as success."""
+        vault = tmp_path / "vault"
+        (vault / "01_Projects").mkdir(parents=True)
+        (vault / "01_Projects" / "note.md").write_text(
+            '---\ndescription: "Desc"\ntimestamp: 2026-01-01T00:00:00\n---\n\nBody text.',
+            encoding="utf-8",
+        )
+
+        def explode(*_args, **_kwargs):
+            raise ValueError("simulated per-note failure")
+
+        monkeypatch.setattr(healer_module, "heal_frontmatter", explode)
+        report = heal_vault(vault, dry_run=False)
+
+        assert "Notes failed: 1" in report
+        assert "No notes needed healing" not in report

--- a/tests/test_healer.py
+++ b/tests/test_healer.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from power_framework.core import healer as healer_module
 from power_framework.core.healer import (
     _extract_first_paragraph,
     _infer_title_from_filename,
     heal_frontmatter,
     heal_vault,
+    propagate_rename,
 )
 
 
@@ -137,3 +139,89 @@ class TestHealVault:
         assert "LIVE" in report
         content = note.read_text()
         assert "type: Project" in content
+
+
+class TestHealBackslashEscapes:
+    r"""Frontmatter is user data and may legitimately contain backslashes.
+
+    Recognized fields are routed through ``_escape_yaml``, which doubles the
+    backslash, so they never triggered this. Unrecognized fields go through
+    ``yaml.safe_dump`` and keep a single backslash; the resulting frontmatter
+    was then passed to ``re.sub`` as a *string* replacement, where ``\P``
+    (AutoCAD MTEXT) is an unknown group escape and raises ``re.error``.
+    """
+
+    def test_mtext_escape_in_custom_field_does_not_raise(self, tmp_path: Path):
+        note = tmp_path / "cable_table.md"
+        note.write_text(
+            "---\n"
+            "smoke: 'MTEXT guard: (cd:ParseDecimal \"{\\fArial|b0;7.5\\P}\")'\n"
+            "timestamp: 2026-01-01T00:00:00\n"
+            "---\n\nBody text here.\n",
+            encoding="utf-8",
+        )
+        healed, changes = heal_frontmatter(note.read_text(encoding="utf-8"), note)
+        assert changes
+        assert "fArial" in healed
+
+    def test_windows_path_in_custom_field_does_not_raise(self, tmp_path: Path):
+        note = tmp_path / "note.md"
+        note.write_text(
+            "---\n"
+            "source_dir: 'C:\\Users\\Public\\vault'\n"
+            "timestamp: 2026-01-01T00:00:00\n"
+            "---\n\nBody text here.\n",
+            encoding="utf-8",
+        )
+        healed, changes = heal_frontmatter(note.read_text(encoding="utf-8"), note)
+        assert changes
+        assert "Users" in healed
+
+    def test_propagate_rename_survives_backslash_frontmatter(self, tmp_path: Path):
+        """`power rename` rewrites frontmatter through the same code path."""
+        vault = tmp_path / "vault"
+        (vault / "02_Areas").mkdir(parents=True)
+        note = vault / "02_Areas" / "referrer.md"
+        note.write_text(
+            "---\n"
+            "type: Area\n"
+            'title: "Referrer"\n'
+            'description: "Points at the renamed note"\n'
+            "source_dir: 'C:\\Users\\Public\\vault'\n"
+            "related:\n"
+            '  - path: "03_Resources/old_name.md"\n'
+            "    relation: depends_on\n"
+            "timestamp: 2026-01-01T00:00:00\n"
+            "---\n\nBody text here.\n",
+            encoding="utf-8",
+        )
+        updated, _log = propagate_rename(
+            vault, "03_Resources/old_name.md", "03_Resources/new_name.md", dry_run=False
+        )
+        assert updated == 1
+        assert "03_Resources/new_name.md" in note.read_text(encoding="utf-8")
+
+    def test_one_unhealable_note_does_not_abort_the_vault(self, tmp_path: Path, monkeypatch):
+        """A single failing note must cost one note, not the whole run."""
+        vault = tmp_path / "vault"
+        (vault / "01_Projects").mkdir(parents=True)
+        for name in ("a_note.md", "poison.md", "z_note.md"):
+            (vault / "01_Projects" / name).write_text(
+                '---\ndescription: "Desc"\ntimestamp: 2026-01-01T00:00:00\n---\n\nBody text.',
+                encoding="utf-8",
+            )
+
+        real_heal = healer_module.heal_frontmatter
+
+        def explode(content, filepath, vault_dir=None):
+            if filepath.name == "poison.md":
+                raise ValueError("simulated per-note failure")
+            return real_heal(content, filepath, vault_dir)
+
+        monkeypatch.setattr(healer_module, "heal_frontmatter", explode)
+        report = heal_vault(vault, dry_run=False)
+
+        assert "Notes healed: 2" in report
+        assert "Notes failed: 1" in report
+        assert "poison.md" in report
+        assert "type: Project" in (vault / "01_Projects" / "z_note.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Problem

`re.sub` parses a **string** replacement as a template. The healer builds the
new frontmatter as a string and passes it straight in, so a backslash carried
over from the note's own frontmatter is read as a group reference:

```
re.PatternError: bad escape \P at position 766 (line 26, column 83)
```

Recognized fields never hit this, because `_escape_yaml` doubles the backslash.
**Unrecognized** fields are rendered by `yaml.safe_dump`, which keeps a single
one — so any custom field holding an AutoCAD MTEXT code (`\P`, `\f`), a Windows
path (`C:\Users` → `bad escape \U`) or LaTeX raises.

`heal_vault` has no per-note isolation, so the first such note aborts the run.

### Measured impact

Real vault, 2790 notes, one note carrying `\fArial|b0;7.5\P` in a custom
`smoke:` field:

```
$ power heal <vault> --no-dry-run
re.PatternError: bad escape \P at position 766
Notes healed: 0        # of 2790
```

Reproduced on a clean v3.3.2 install made by following
`docs/windows-11-installation.md` (release wheel, Windows 11 25H2, Python 3.14).
`heal_frontmatter_tool` is affected identically over MCP.

The same expression in `propagate_rename` is on the `power rename` path, so
renaming inside such a vault fails too — worth noting given the Windows
rename work in 3.3.1.

## Fix

- `_literal_replacement()` returns a callable replacement, which `re.sub`
  inserts verbatim and never parses. Used at **both** call sites.
- `heal_vault` isolates each note: a failure is logged, counted and skipped
  rather than aborting. The report gains `Notes failed: N` and lists them, so
  the loss is visible instead of silent.

## Tests

Three regressions, each **verified to fail before the fix** (mutation-checked,
not just green):

- `test_mtext_escape_in_custom_field_does_not_raise`
- `test_windows_path_in_custom_field_does_not_raise`
- `test_propagate_rename_survives_backslash_frontmatter`
- plus `test_one_unhealable_note_does_not_abort_the_vault` for the isolation

## Checks

```
pytest tests/ -q      751 passed, 14 skipped   (was 747; coverage 79%)
ruff check src tests  All checks passed!
ruff format --check   98 files already formatted
mypy src/power_framework  Success: no issues found in 39 source files
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Backslashes in custom frontmatter fields are now preserved correctly during note healing and rename propagation.
  - Vault healing continues processing remaining notes when an individual note fails.
  - Healing reports now include notes that could not be processed, making failures easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->