### PR TITLE
fix(onnx): make the documented fail-closed device contract actually hold

### DIFF
--- a/src/power_framework/core/embeddings.py
+++ b/src/power_framework/core/embeddings.py
@@ -78,6 +78,45 @@ def _env_flag(name: str) -> bool:
     return os.getenv(name, "").lower() in {"1", "true", "yes"}
 
 
+def _preload_gpu_runtime(ort: Any) -> None:
+    """Make the pip-installed CUDA/cuDNN runtime loadable before probing providers.
+
+    ``onnxruntime-gpu`` resolves its provider DLLs against the ``nvidia-*``
+    wheels, but Python 3.8+ on Windows ignores ``PATH`` for extension-module
+    DLL resolution. Without ``preload_dlls()`` the CUDA provider is *listed* by
+    ``get_available_providers()`` and still fails to load at session creation,
+    which is exactly the case the availability check below cannot see.
+    """
+    preload = getattr(ort, "preload_dlls", None)
+    if preload is None:
+        return
+    try:
+        preload()
+    except Exception as exc:  # pragma: no cover - defensive, never fatal
+        logger.debug("onnxruntime.preload_dlls() failed: %s", exc)
+
+
+def verify_bound_provider(session: Any, providers: list[object], env_var: str) -> str:
+    """Return the provider the session actually bound, failing closed on downgrade.
+
+    ``get_available_providers()`` reports what the build was compiled with, not
+    what can load. An explicit GPU request that silently lands on CPU is a
+    ~50x slowdown with no error, so compare the request against the binding.
+    """
+    bound = list(session.get_providers())
+    actual = bound[0] if bound else "unknown"
+    requested_name = providers[0][0] if isinstance(providers[0], tuple) else str(providers[0])
+
+    logger.info("ONNX Runtime provider bound: %s", actual)
+    if requested_name != "CPUExecutionProvider" and actual == "CPUExecutionProvider":
+        raise RuntimeError(
+            f"requested_onnx_provider_not_bound:{requested_name}; "
+            f"session bound {bound}. The provider is compiled in but its runtime "
+            f"libraries failed to load. Set {env_var}=cpu to accept CPU explicitly."
+        )
+    return actual
+
+
 def select_onnx_providers(ort: Any, env_var: str = "POWER_EMBED_DEVICE") -> list[object]:
     """Select ONNX Runtime providers with explicit and automatic device modes.
 
@@ -86,6 +125,7 @@ def select_onnx_providers(ort: Any, env_var: str = "POWER_EMBED_DEVICE") -> list
     fail-closed when unavailable, preventing a requested GPU benchmark from
     silently running on a different backend.
     """
+    _preload_gpu_runtime(ort)
     available = set(ort.get_available_providers())
     requested = os.getenv(env_var, os.getenv("POWER_EMBED_DEVICE", "auto")).lower()
     if requested not in {"auto", "cpu", "cuda", "rocm", "directml"}:
@@ -585,6 +625,7 @@ class BGEM3OnnxManager:
             so.inter_op_num_threads = 1
             providers = select_onnx_providers(ort)
             self._session = ort.InferenceSession(model_path, providers=providers, sess_options=so)
+            verify_bound_provider(self._session, providers, "POWER_EMBED_DEVICE")
             self._tokenizer = Tokenizer.from_file(tok_path)
             self._tokenizer.enable_truncation(max_length=self._MAX_TOKENS)
             # Probe: eagerly verify the backend can allocate and produce a

--- a/src/power_framework/core/embeddings.py
+++ b/src/power_framework/core/embeddings.py
@@ -96,23 +96,52 @@ def _preload_gpu_runtime(ort: Any) -> None:
         logger.debug("onnxruntime.preload_dlls() failed: %s", exc)
 
 
+#: Providers that accept a ``device_id`` option, compared case-insensitively.
+_DEVICE_ID_PROVIDERS = frozenset({"cudaexecutionprovider", "rocmexecutionprovider"})
+
+
+def requested_device(env_var: str = "POWER_EMBED_DEVICE") -> str:
+    """Return the normalized device mode requested through *env_var*."""
+    return os.getenv(env_var, os.getenv("POWER_EMBED_DEVICE", "auto")).strip().lower()
+
+
+def _resolve_provider_name(candidate: str, available: set[str]) -> str | None:
+    """Match a provider name against what ORT reports, ignoring case.
+
+    ONNX Runtime spells the ROCm provider ``ROCMExecutionProvider``; an exact
+    comparison against a differently-cased constant silently never matches, so
+    the device would look unavailable on a working ROCm build.
+    """
+    if candidate in available:
+        return candidate
+    lowered = candidate.lower()
+    return next((name for name in available if name.lower() == lowered), None)
+
+
 def verify_bound_provider(session: Any, providers: list[object], env_var: str) -> str:
     """Return the provider the session actually bound, failing closed on downgrade.
 
     ``get_available_providers()`` reports what the build was compiled with, not
-    what can load. An explicit GPU request that silently lands on CPU is a
-    ~50x slowdown with no error, so compare the request against the binding.
+    what can load, so a GPU provider can pass the availability check and still
+    be dropped at session creation — a ~50x slowdown with no error.
+
+    Only an **explicit** device request is fail-closed. Under ``auto`` a CPU
+    binding is the documented fallback, not a failure, so it is logged and
+    accepted.
     """
     bound = list(session.get_providers())
     actual = bound[0] if bound else "unknown"
-    requested_name = providers[0][0] if isinstance(providers[0], tuple) else str(providers[0])
+    requested = requested_device(env_var)
 
-    logger.info("ONNX Runtime provider bound: %s", actual)
-    if requested_name != "CPUExecutionProvider" and actual == "CPUExecutionProvider":
+    logger.info("ONNX Runtime device=%s bound %s", requested, actual)
+    if requested in {"auto", "cpu"}:
+        return actual
+    if actual == "CPUExecutionProvider":
+        requested_name = providers[0][0] if isinstance(providers[0], tuple) else str(providers[0])
         raise RuntimeError(
             f"requested_onnx_provider_not_bound:{requested_name}; "
             f"session bound {bound}. The provider is compiled in but its runtime "
-            f"libraries failed to load. Set {env_var}=cpu to accept CPU explicitly."
+            f"libraries failed to load. Set {env_var}=auto to allow the CPU fallback."
         )
     return actual
 
@@ -127,7 +156,7 @@ def select_onnx_providers(ort: Any, env_var: str = "POWER_EMBED_DEVICE") -> list
     """
     _preload_gpu_runtime(ort)
     available = set(ort.get_available_providers())
-    requested = os.getenv(env_var, os.getenv("POWER_EMBED_DEVICE", "auto")).lower()
+    requested = requested_device(env_var)
     if requested not in {"auto", "cpu", "cuda", "rocm", "directml"}:
         raise ValueError(f"invalid_{env_var.lower()}:{requested}")
 
@@ -140,39 +169,42 @@ def select_onnx_providers(ort: Any, env_var: str = "POWER_EMBED_DEVICE") -> list
 
     gpu_candidates = {
         "cuda": "CUDAExecutionProvider",
-        "rocm": "ROCmExecutionProvider",
+        "rocm": "ROCMExecutionProvider",
         "directml": "DmlExecutionProvider",
     }
     if requested != "auto":
-        provider_name = gpu_candidates[requested]
-        if provider_name not in available:
+        resolved = _resolve_provider_name(gpu_candidates[requested], available)
+        if resolved is None:
             raise RuntimeError(
-                f"requested_onnx_provider_unavailable:{provider_name}; available={sorted(available)}"
+                f"requested_onnx_provider_unavailable:{gpu_candidates[requested]}; "
+                f"available={sorted(available)}"
             )
+        provider_name = resolved
         options: dict[str, object] = {}
-        if provider_name in {"CUDAExecutionProvider", "ROCmExecutionProvider"}:
+        if provider_name.lower() in _DEVICE_ID_PROVIDERS:
             options = {
                 "device_id": int(os.getenv("POWER_EMBED_DEVICE_ID", "0")),
                 "arena_extend_strategy": "kSameAsRequested",
             }
         return [(provider_name, options), cpu_provider]
 
-    for provider_name in (
+    for candidate in (
         "CUDAExecutionProvider",
-        "ROCmExecutionProvider",
+        "ROCMExecutionProvider",
         "DmlExecutionProvider",
     ):
-        if provider_name in available:
+        auto_name = _resolve_provider_name(candidate, available)
+        if auto_name is not None:
             options = (
                 {
                     "device_id": int(os.getenv("POWER_EMBED_DEVICE_ID", "0")),
                     "arena_extend_strategy": "kSameAsRequested",
                 }
-                if provider_name in {"CUDAExecutionProvider", "ROCmExecutionProvider"}
+                if auto_name.lower() in _DEVICE_ID_PROVIDERS
                 else {}
             )
-            logger.info("ONNX Runtime device=auto selected %s", provider_name)
-            return [(provider_name, options), cpu_provider]
+            logger.info("ONNX Runtime device=auto selected %s", auto_name)
+            return [(auto_name, options), cpu_provider]
 
     logger.info("ONNX Runtime device=auto selected CPUExecutionProvider")
     return [cpu_provider]

--- a/src/power_framework/core/reranker.py
+++ b/src/power_framework/core/reranker.py
@@ -7,7 +7,7 @@ import os
 import time
 from typing import Protocol
 
-from .embeddings import select_onnx_providers
+from .embeddings import select_onnx_providers, verify_bound_provider
 
 logger = logging.getLogger(__name__)
 
@@ -225,6 +225,7 @@ class BGEM3Reranker:
             so.inter_op_num_threads = 1
             providers = select_onnx_providers(ort, env_var="POWER_RERANKER_DEVICE")
             self._session = ort.InferenceSession(model_path, providers=providers, sess_options=so)
+            verify_bound_provider(self._session, providers, "POWER_RERANKER_DEVICE")
             self._tokenizer = Tokenizer.from_file(tok_path)
             self._tokenizer.enable_truncation(max_length=self._MAX_TOKENS)
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -36,6 +36,74 @@ class TestEmbeddingManager:
         with pytest.raises(RuntimeError, match="requested_onnx_provider_unavailable"):
             embeddings.select_onnx_providers(FakeOrt())
 
+    def test_preload_dlls_is_called_before_probing_providers(self, monkeypatch: pytest.MonkeyPatch):
+        """Availability is meaningless until the GPU runtime DLLs are loadable."""
+        calls: list[str] = []
+
+        class FakeOrt:
+            @staticmethod
+            def preload_dlls():
+                calls.append("preload")
+
+            @staticmethod
+            def get_available_providers():
+                calls.append("probe")
+                return ["CPUExecutionProvider"]
+
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cpu")
+        embeddings.select_onnx_providers(FakeOrt())
+        assert calls == ["preload", "probe"]
+
+    def test_missing_preload_dlls_is_tolerated(self, monkeypatch: pytest.MonkeyPatch):
+        """Older onnxruntime builds have no preload_dlls(); that must not break."""
+
+        class FakeOrt:
+            @staticmethod
+            def get_available_providers():
+                return ["CPUExecutionProvider"]
+
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cpu")
+        assert embeddings.select_onnx_providers(FakeOrt())
+
+    def test_gpu_downgraded_to_cpu_at_session_creation_fails_closed(self):
+        """A provider can be listed and still fail to load; only the session knows."""
+
+        class FakeSession:
+            @staticmethod
+            def get_providers():
+                return ["CPUExecutionProvider"]
+
+        providers: list[object] = [
+            ("CUDAExecutionProvider", {}),
+            ("CPUExecutionProvider", {}),
+        ]
+        with pytest.raises(RuntimeError, match="requested_onnx_provider_not_bound"):
+            embeddings.verify_bound_provider(FakeSession(), providers, "POWER_EMBED_DEVICE")
+
+    def test_bound_gpu_provider_is_accepted(self):
+        class FakeSession:
+            @staticmethod
+            def get_providers():
+                return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+        providers: list[object] = [("CUDAExecutionProvider", {}), ("CPUExecutionProvider", {})]
+        assert (
+            embeddings.verify_bound_provider(FakeSession(), providers, "POWER_EMBED_DEVICE")
+            == "CUDAExecutionProvider"
+        )
+
+    def test_explicit_cpu_is_not_treated_as_a_downgrade(self):
+        class FakeSession:
+            @staticmethod
+            def get_providers():
+                return ["CPUExecutionProvider"]
+
+        providers: list[object] = [("CPUExecutionProvider", {})]
+        assert (
+            embeddings.verify_bound_provider(FakeSession(), providers, "POWER_EMBED_DEVICE")
+            == "CPUExecutionProvider"
+        )
+
     def test_ollama_attempt_does_not_require_sigalrm(self, monkeypatch: pytest.MonkeyPatch):
         manager = embeddings.OllamaEmbeddingManager()
         monkeypatch.delattr(signal, "SIGALRM", raising=False)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -65,7 +65,9 @@ class TestEmbeddingManager:
         monkeypatch.setenv("POWER_EMBED_DEVICE", "cpu")
         assert embeddings.select_onnx_providers(FakeOrt())
 
-    def test_gpu_downgraded_to_cpu_at_session_creation_fails_closed(self):
+    def test_gpu_downgraded_to_cpu_at_session_creation_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         """A provider can be listed and still fail to load; only the session knows."""
 
         class FakeSession:
@@ -73,6 +75,7 @@ class TestEmbeddingManager:
             def get_providers():
                 return ["CPUExecutionProvider"]
 
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cuda")
         providers: list[object] = [
             ("CUDAExecutionProvider", {}),
             ("CPUExecutionProvider", {}),
@@ -80,24 +83,74 @@ class TestEmbeddingManager:
         with pytest.raises(RuntimeError, match="requested_onnx_provider_not_bound"):
             embeddings.verify_bound_provider(FakeSession(), providers, "POWER_EMBED_DEVICE")
 
-    def test_bound_gpu_provider_is_accepted(self):
+    def test_auto_may_fall_back_to_cpu_without_raising(self, monkeypatch: pytest.MonkeyPatch):
+        """Under `auto` a CPU binding is the documented fallback, not a failure.
+
+        `auto` still puts the GPU provider first in the list, so inspecting the
+        request list alone cannot tell an auto fallback from an explicit
+        downgrade — the mode has to be read.
+        """
+
+        class FakeSession:
+            @staticmethod
+            def get_providers():
+                return ["CPUExecutionProvider"]
+
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "auto")
+        providers: list[object] = [("CUDAExecutionProvider", {}), ("CPUExecutionProvider", {})]
+        assert (
+            embeddings.verify_bound_provider(FakeSession(), providers, "POWER_EMBED_DEVICE")
+            == "CPUExecutionProvider"
+        )
+
+    def test_rocm_provider_name_is_matched_case_insensitively(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A build may spell it differently from our constant; exact match then
+        silently reports the device as unavailable on a working ROCm host."""
+
+        class FakeOrt:
+            @staticmethod
+            def get_available_providers():
+                return ["ROCmExecutionProvider", "CPUExecutionProvider"]
+
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "rocm")
+        providers = embeddings.select_onnx_providers(FakeOrt())
+        # The name ORT reported wins, not our constant.
+        assert providers[0][0] == "ROCmExecutionProvider"
+        assert providers[0][1]["device_id"] == 0
+
+    def test_auto_selects_rocm_regardless_of_spelling(self, monkeypatch: pytest.MonkeyPatch):
+        class FakeOrt:
+            @staticmethod
+            def get_available_providers():
+                return ["ROCmExecutionProvider", "CPUExecutionProvider"]
+
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "auto")
+        providers = embeddings.select_onnx_providers(FakeOrt())
+        assert providers[0][0] == "ROCmExecutionProvider"
+        assert providers[0][1]["device_id"] == 0
+
+    def test_bound_gpu_provider_is_accepted(self, monkeypatch: pytest.MonkeyPatch):
         class FakeSession:
             @staticmethod
             def get_providers():
                 return ["CUDAExecutionProvider", "CPUExecutionProvider"]
 
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cuda")
         providers: list[object] = [("CUDAExecutionProvider", {}), ("CPUExecutionProvider", {})]
         assert (
             embeddings.verify_bound_provider(FakeSession(), providers, "POWER_EMBED_DEVICE")
             == "CUDAExecutionProvider"
         )
 
-    def test_explicit_cpu_is_not_treated_as_a_downgrade(self):
+    def test_explicit_cpu_is_not_treated_as_a_downgrade(self, monkeypatch: pytest.MonkeyPatch):
         class FakeSession:
             @staticmethod
             def get_providers():
                 return ["CPUExecutionProvider"]
 
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cpu")
         providers: list[object] = [("CPUExecutionProvider", {})]
         assert (
             embeddings.verify_bound_provider(FakeSession(), providers, "POWER_EMBED_DEVICE")


### PR DESCRIPTION
## Problem

`select_onnx_providers` documents this contract:

> An explicit device is fail-closed when unavailable, preventing a requested GPU
> benchmark from silently running on a different backend.

It is enforced against `ort.get_available_providers()` — which reports what the
build was **compiled** with, not what can **load**. A provider whose runtime
libraries are missing is listed, passes the check, and is then silently dropped
by ONNX Runtime inside `InferenceSession`.

### Measured

Windows 11 25H2, RTX 3080 Laptop, `onnxruntime-gpu==1.28.0`, Python 3.14,
`POWER_EMBED_DEVICE=cuda` explicitly set:

| | |
|---|---|
| listed providers | `['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider']` |
| bound provider | `CPUExecutionProvider` |
| throughput | **1.7 chunks/s** |
| plain `POWER_EMBED_DEVICE=cpu` | **1.8 chunks/s** |

A ~50x slowdown that is indistinguishable from CPU, with no exception. The one
log line that would have revealed it — `ONNX Runtime device=auto selected …` —
exists only on the `auto` branch, so an explicit request runs mute.

Root cause on Windows: `onnxruntime-gpu` resolves its provider DLLs against the
`nvidia-*` wheels, and Python 3.8+ ignores `PATH` for extension-module DLL
resolution. I verified that **neither** `PATH` **nor** `os.add_dll_directory()`
is sufficient — both still bind CPU. `onnxruntime.preload_dlls()` is, and it was
never called.

## Fix

- `_preload_gpu_runtime()` before probing, so availability reflects loadability
- `verify_bound_provider()` compares the request with the session's actual
  binding, raises on a GPU→CPU downgrade, and logs the bound provider on every
  path
- wired into both the embedder and the reranker

After the change on the same host: bound `CUDAExecutionProvider`,
**118.9 chunks/s**.

## Note for reviewers

This turns a previously silent downgrade into a `RuntimeError`. That matches the
existing docstring and the project's fail-closed posture, but it *is* a
behaviour change for anyone who set `POWER_EMBED_DEVICE=cuda` on a host where it
never actually worked — they were getting CPU speed and will now get an error
naming the cause. `POWER_EMBED_DEVICE=cpu` and `auto` are unaffected. Happy to
downgrade it to a loud warning if you prefer.

## Checks

```
pytest tests/ -q      752 passed, 14 skipped   (coverage 79.08%)
ruff check src tests  All checks passed!
ruff format --check   98 files already formatted
mypy src/power_framework  Success: no issues found in 39 source files
```
