### PR TITLE
feat(models): opt-in quarantine for foreign frontmatter values (closes the import path in #238)

### DIFF
--- a/src/power_framework/core/models.py
+++ b/src/power_framework/core/models.py
@@ -10,12 +10,23 @@ Supports:
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime
 from datetime import date as date_type
 from enum import StrEnum
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
+
+#: Env var controlling what happens to a known field holding a foreign value.
+#: ``reject`` (default) keeps the existing strict contract; ``quarantine``
+#: moves the value to an ``x-`` key so the note survives an import.
+FOREIGN_FRONTMATTER_ENV = "POWER_FOREIGN_FRONTMATTER"
+
+
+def foreign_frontmatter_quarantined() -> bool:
+    """Return True when foreign field values should be quarantined, not rejected."""
+    return os.getenv(FOREIGN_FRONTMATTER_ENV, "reject").strip().lower() == "quarantine"
 
 
 class TypedRelation(BaseModel):
@@ -198,6 +209,39 @@ class OKFMetadata(BaseModel):
 
     # Unknown fields must survive parsing and healing during the v0.2 rollout.
     model_config = ConfigDict(extra="allow", use_enum_values=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def quarantine_foreign_governance_fields(cls, data: object) -> object:
+        """Opt-in: keep a note valid when an optional field uses a foreign vocabulary.
+
+        Off by default — strict rejection stays the contract. When
+        ``POWER_FOREIGN_FRONTMATTER=quarantine`` is set, an out-of-schema value
+        in ``status`` or ``related`` is moved to an ``x-``-prefixed key instead
+        of failing the whole note, so importing a vault written by another tool
+        does not silently drop every note whose ``status:`` says ``draft``.
+
+        ``type`` is deliberately never covered: it is the one field POWER
+        cannot work without.
+        """
+        if not isinstance(data, dict) or not foreign_frontmatter_quarantined():
+            return data
+
+        status = data.get("status")
+        if status is not None and not isinstance(status, NoteStatus):
+            try:
+                NoteStatus(str(status).strip().lower())
+            except ValueError:
+                data = {**data, "status": None, "x-status": status}
+
+        related = data.get("related")
+        if related is not None:
+            try:
+                cls.coerce_related(related)
+            except (ValueError, TypeError):
+                data = {**data, "related": [], "x-related": related}
+
+        return data
 
     @field_validator("title")
     @classmethod

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
+from typing import ClassVar
 
 import pytest
 from pydantic import ValidationError
@@ -350,3 +351,61 @@ class TestOKFMetadata:
         assert meta.status == "active"
         assert meta.expiry.isoformat() == "2027-01-01"
         assert any(r.path == "03_Resources/Guide.md" for r in meta.related)
+
+
+class TestForeignFrontmatterTolerance:
+    """A foreign vocabulary in an optional field must not delete the note.
+
+    Measured on a real 2790-note Obsidian vault: 366 notes carried a `status:`
+    outside the OKF enum (`verified-external`, `audited`, `stub`, `production`,
+    `draft`, `legacy`) and 2 wrote `related:` as Obsidian wikilinks. All 368
+    failed validation as a whole and never reached the search index.
+    """
+
+    BASE: ClassVar[dict[str, object]] = {
+        "type": "Resource",
+        "title": "T",
+        "description": "D",
+        "timestamp": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+
+    @pytest.fixture(autouse=True)
+    def _enable_quarantine(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("POWER_FOREIGN_FRONTMATTER", "quarantine")
+
+    @pytest.mark.parametrize(
+        "value", ["verified-external", "audited", "stub", "production", "draft", "legacy"]
+    )
+    def test_foreign_status_keeps_the_note_and_preserves_the_value(self, value: str):
+        note = OKFMetadata.model_validate({**self.BASE, "status": value})
+        assert note.status is None
+        assert getattr(note, "x-status", None) == value or note.model_extra["x-status"] == value
+
+    def test_valid_status_is_untouched(self):
+        note = OKFMetadata.model_validate({**self.BASE, "status": "archived"})
+        assert note.status == "archived"
+        assert "x-status" not in (note.model_extra or {})
+
+    def test_wikilink_related_keeps_the_note_and_preserves_the_value(self):
+        raw = [["Some Note"]]  # YAML reads `related: [[Some Note]]` as a nested list
+        note = OKFMetadata.model_validate({**self.BASE, "related": raw})
+        assert note.related == []
+        assert note.model_extra["x-related"] == raw
+
+    def test_valid_related_is_untouched(self):
+        note = OKFMetadata.model_validate(
+            {**self.BASE, "related": [{"path": "02_Areas/x.md", "relation": "depends_on"}]}
+        )
+        assert len(note.related) == 1
+        assert "x-related" not in (note.model_extra or {})
+
+    def test_default_stays_strict(self, monkeypatch: pytest.MonkeyPatch):
+        """Without the opt-in the existing reject contract is unchanged."""
+        monkeypatch.delenv("POWER_FOREIGN_FRONTMATTER", raising=False)
+        with pytest.raises(ValidationError):
+            OKFMetadata.model_validate({**self.BASE, "status": "draft"})
+
+    def test_missing_type_still_fails(self):
+        """Tolerance must not weaken the one field POWER cannot work without."""
+        with pytest.raises(ValidationError):
+            OKFMetadata.model_validate({k: v for k, v in self.BASE.items() if k != "type"})


### PR DESCRIPTION
Implements the proposal in #238, **opt-in and default-off**.

## Problem

A known optional field holding an out-of-schema value fails validation for the
**whole note**, and an invalid note never reaches the search index (#237). So
importing a vault written by another tool loses notes wholesale, with no
symptom.

Measured on a real 2790-note Obsidian vault:

| `status:` value | notes |
|---|---|
| `verified-external` | 232 |
| `audited` | 25 |
| `stub` | 24 |
| `production` | 23 |
| `draft` | 19 |
| `legacy` | 10 |
| `verified` | 3 |

plus 2 notes writing `related:` as Obsidian wikilinks (`[[Note]]`, which YAML
reads as a nested list). 368 notes dropped.

Unknown **keys** already survive via `extra="allow"`. Only known keys with
foreign **values** are fatal — which is the case an importer hits.

## Approach

`POWER_FOREIGN_FRONTMATTER=quarantine` moves the offending value to an
`x-`-prefixed key instead of rejecting the note. It stays indexable, and the
original value survives a round trip rather than being erased.

**The default is unchanged.** `test_invalid_status_rejected` shows strict
rejection is a deliberate decision, not an oversight, so I did not flip it
behind your back — `test_default_stays_strict` pins the existing behaviour.
`type` is never quarantined; it is the one field POWER cannot work without.

If you would rather make quarantine the default for `power import`-style flows
only, or name the env var differently, I am happy to rework it.

## Measured effect

Same 366 real notes, field name the only variable:

```
reject     :   0 / 366 validate
quarantine : 366 / 366 validate
```

## Checks

```
pytest tests/ -q      758 passed, 14 skipped   (coverage 79.10%)
ruff check src tests  All checks passed!
ruff format --check   98 files already formatted
mypy src/power_framework  Success: no issues found in 39 source files
```

## Not included

My local workaround also renamed the fields **in the notes themselves**
(`status:` → `nox_status:`). That belongs in the user's vault, not in the
product, so it is deliberately not part of this PR — with this change it stops
being necessary at all.
