### PR TITLE
fix(indexer): render catalog entries as resolvable links so lint stops calling them orphans

### DIFF
--- a/src/power_framework/core/indexer.py
+++ b/src/power_framework/core/indexer.py
@@ -9,6 +9,7 @@ Scans the vault for OKF-annotated notes and generates hierarchical index files:
 from __future__ import annotations
 
 import json
+import posixpath
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -413,6 +414,23 @@ def generate_main_index_content(
     return "\n".join(lines)
 
 
+def _catalog_link(folder: str, rel_path: str) -> str:
+    """Render a catalog entry path as a resolvable Markdown link.
+
+    A backtick code span is stripped before link extraction, so a catalog built
+    from code spans contributes no inbound links at all and every note it lists
+    is then reported as an orphan by ``power lint`` — the index the product
+    generates fails the check the product itself runs.
+
+    GFM targets resolve relative to the *source* file, and the sub-index lives
+    at ``<folder>/_index.md``, so the target is made relative to ``folder``.
+    Angle brackets keep paths containing spaces valid.
+    """
+    normalized = rel_path.replace("\\", "/")
+    target = posixpath.relpath(normalized, folder)
+    return f"[{normalized}](<{target}>)"
+
+
 def generate_sub_index_content(folder: str, notes: list[dict]) -> str:
     """Generate a detailed _index.md for a specific P.A.R.A. folder."""
     display_name = folder.replace("_", " ")
@@ -440,7 +458,7 @@ def generate_sub_index_content(folder: str, notes: list[dict]) -> str:
 
         for note in sorted_notes:
             lines.append(f"## {note['title']}")
-            lines.append(f"- **Path:** `{note['rel_path']}`")
+            lines.append(f"- **Path:** {_catalog_link(folder, note['rel_path'])}")
             lines.append(f"- **Type:** {note['note_type']}")
             lines.append(f"- **Description:** {truncate_for_catalog(note['description'])}")
             if note.get("tags"):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -17,6 +17,7 @@ from power_framework.core.indexer import (
     scan_vault_notes,
     truncate_for_catalog,
 )
+from power_framework.core.linter import run_lint_report
 
 
 class TestScanVaultNotes:
@@ -184,6 +185,25 @@ class TestGenerateSubIndexContent:
         content = generate_sub_index_content("01_Projects", folder_notes["01_Projects"])
         assert "## Test Project" in content
         assert "## Weby-QRank Architecture" in content
+
+    def test_catalog_entry_is_a_resolvable_link_not_a_code_span(self, sample_vault: Path):
+        """A code span is stripped before link extraction, so a catalog built
+        from code spans contributes no inbound links and lint calls every note
+        it lists an orphan — the generated index failing the product's own check.
+        """
+        folder_notes = scan_folder_notes(sample_vault)
+        content = generate_sub_index_content("01_Projects", folder_notes["01_Projects"])
+        note = folder_notes["01_Projects"][0]
+        rel = note["rel_path"].replace("\\", "/")
+        target = rel.split("/", 1)[1]  # relative to the folder the index lives in
+
+        assert f"`{note['rel_path']}`" not in content
+        assert f"[{rel}](<{target}>)" in content
+
+    def test_generated_index_leaves_no_orphans(self, sample_vault: Path):
+        """index -> lint must not report the notes the index just catalogued."""
+        run_generate_hierarchical_index(sample_vault)
+        assert "Orphan notes" not in run_lint_report(sample_vault)
 
     def test_contains_note_metadata(self, sample_vault: Path):
         folder_notes = scan_folder_notes(sample_vault)


### PR DESCRIPTION
Fixes the first half of #239.

## Problem

`generate_sub_index_content` renders each entry's path as a backtick code span:

```markdown
- **Path:** `03_Resources/wiki/techniques/some-note.md`
```

`_extract_links` strips inline code before collecting links, so the generated
catalog contributes **no inbound links at all** — and `power lint` then reports
every note it catalogued as an orphan. The index the product generates fails the
check the product itself runs.

### Measured

2778-note vault, `power index` followed by `power lint`:

| | orphans | broken links |
|---|---|---|
| `main` | **1031** | 649 |
| this branch | **0** | 649 |

## The part that needed care

GFM targets resolve relative to the **source** file, and the sub-index lives at
`<folder>/_index.md`. Emitting the vault-relative path would have resolved to
`03_Resources/03_Resources/…` and traded 1031 orphans for ~2772 *broken* links.

So the target is made relative to `folder`, backslashes are normalized, and
angle brackets keep paths containing spaces valid. The unchanged broken-link
count above is the evidence that none were introduced.

## Note

Your Windows CI job already guards this invariant:

```
throw "Lint treated a generated sub-index as an orphan note"
```

It does not fire today because on a one-note vault that note stays reachable by
other means. The gate is right; it just needs a corpus to bite on.

## Tests

- the entry is a resolvable link and not a code span
- `index` → `lint` reports no orphans

Both verified to fail when the code span is restored.

## Checks

CI here is `action_required` (first-time fork contributor), so I ran the
workflow steps locally:

```
pytest tests/ -q          749 passed, 14 skipped   (coverage 79.01%)
ruff check / format       All checks passed! / 98 files already formatted
mypy src/power_framework  Success: no issues found in 39 source files
check_doc_drift.py        passed
verify_release_contract.py passed
Windows lifecycle job     index --strict / lint gate / markdown-check / sync / search — all pass
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sub-index catalog entries now use clickable Markdown links instead of plain text paths.
  * Links correctly handle nested folders, path separators, and paths containing spaces.
  * Hierarchical indexes no longer produce orphan-note lint errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->