### PR TITLE
feat(mcp): add sync_vault so an agent can find the note it just wrote

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,14 +1,14 @@
 # P.O.W.E.R. Framework — Agent Instructions
 
 Python 3.11+ toolkit for AI-native Second Brain management. CLI (`power`, 16 top-level
-commands) + MCP server (17 tools).
+commands) + MCP server (18 tools).
 
 ## Project Structure
 
 ```
 src/power_framework/       # Core library
   core/                    #   models, parser, indexer, linter, searcher, embedder
-  mcp/                     #   FastMCP-3.x server (17 async tools)
+  mcp/                     #   FastMCP-3.x server (18 async tools)
 tests/                     # Pytest suite; CI enforces coverage >=70%
 scripts/                   # Dev/CI utilities
 docs/                      # MkDocs-material documentation site
@@ -44,7 +44,7 @@ pre-commit run --all-files # Git hooks (ruff + mypy + pip-audit)
 | `core/linter.py`      | Health checks: links, metadata, orphans, stale/expired |
 | `core/searcher.py`    | FTS5/dense/hybrid/reranked search (`semantic` default) |
 | `core/embeddings.py`  | BGE-M3 ONNX (1024d) + MiniLM fallback                  |
-| `mcp/power_server.py` | FastMCP 3.x, 17 async tools, HTTP transport + /health  |
+| `mcp/power_server.py` | FastMCP 3.x, 18 async tools, HTTP transport + /health  |
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Unlike generic knowledge management tools, P.O.W.E.R. is designed from the groun
 - **Knowledge Graph** — `related` field connects notes across the vault; visualized in sub-indexes for Graph RAG workflows
 - **Freshness Monitoring** — linter detects stale/expired notes based on `expiry` metadata field
 - **Agent Auto-Ingest** — `synthesize_session` MCP tool lets agents autonomously create permanent knowledge artifacts with governance + graph links + full catalog maintenance
-- **MCP-native** — expose 17 tools to MCP-compatible AI clients through FastMCP 3.x
+- **MCP-native** — expose 18 tools to MCP-compatible AI clients through FastMCP 3.x
 - **Windows-safe rename** — `power rename` uses `os.replace()` for the physical
   move, so renaming onto an existing destination works on Windows instead of
   raising `FileExistsError`
@@ -48,7 +48,7 @@ the role-specific guides before touching a vault:
 - **[Windows 11 25H2](docs/windows-11-installation.md)** — complete PowerShell
   installation, Visual C++ prerequisite, exact interpreter paths, and checks
 - **[CLI reference](docs/cli.md)** — all 16 commands, flags, and actual exit behavior
-- **[MCP server](docs/mcp-server.md)** — all 17 governed tools, rate limits,
+- **[MCP server](docs/mcp-server.md)** — all 18 governed tools, rate limits,
   configured-vault boundary, and untrusted retrieval contract
 - **[Migration guide](docs/migration-guide.md)** — 6-phase, manifest/hash-driven
   migration from any Markdown source methodology into a canonical POWER vault
@@ -100,7 +100,7 @@ coverage from checks that must pass on the target Windows host.
 | Feature                          | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **CLI**                          | 16 commands, including `power memory` for explicit proposal, approval, validation, and history                                                                                                                                                                                                                                                                                                                                                                                      |
-| **MCP Server**                   | 17 tools, including governed memory context, proposal, apply, validation, and history operations                                                                                                                                                                                                                                                                                                                                                                                    |
+| **MCP Server**                   | 18 tools, including governed memory context, proposal, apply, validation, and history operations                                                                                                                                                                                                                                                                                                                                                                                    |
 | **OKF Validation**               | Pydantic v2 schemas enforce strict metadata on every note with governance (`owner`, `status`, `expiry`)                                                                                                                                                                                                                                                                                                                                                                             |
 | **Knowledge Graph (Graph RAG)**  | `related` field in OKF frontmatter supporting `TypedRelation` (path, relation, confidence) with BFS traversal and Mermaid diagram export (`to_mermaid`)                                                                                                                                                                                                                                                                                                                             |
 | **Freshness Monitoring**         | Linter flags stale/expired notes by checking `expiry` dates, ensuring your vault stays current                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -476,7 +476,7 @@ flowchart TD
 | `core/constants.py`                       | Centralized exclusion lists and system constants                                                                                                                                                                                   |
 | `core/utils.py`                           | Path traversal protection, atomic writes, backups, rate limiter                                                                                                                                                                    |
 | `core/cli.py`                             | Command-line interface with 16 commands, including transactional memory workflows                                                                                                                                                  |
-| `mcp/power_server.py`                     | FastMCP 3.x server with 17 async tools, loopback HTTP transport, and `/health`                                                                                                                                                     |
+| `mcp/power_server.py`                     | FastMCP 3.x server with 18 async tools, loopback HTTP transport, and `/health`                                                                                                                                                     |
 
 All components share `power_framework.core` as the single source of truth.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ reconcile every file by manifest and hash, and make cutover reversible.
 
 - Python 3.11 or newer.
 - 16 top-level CLI commands; see the [CLI reference](cli.md).
-- 17 MCP tools; see the [MCP server reference](mcp-server.md).
+- 18 MCP tools; see the [MCP server reference](mcp-server.md).
 - `semantic` is the default search mode; `reranked` is an explicit opt-in.
 - The generated root index and MCP sub-index operations cover the canonical P.A.R.A.
   directories. Arbitrary source layouts must be mapped during migration.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -101,6 +101,26 @@ limit 5 calls per minute.
 generate_index(vault_path?: string) -> string
 ```
 
+### 2b. `sync_vault`
+
+Rebuild the search index so newly written notes become findable. `ingest_note`
+and `synthesize_session` write the note and refresh the hierarchical index, but
+the search database is a separate artifact — until it is rebuilt,
+`search_vault_tool` cannot return the note that was just saved. Write path;
+rate limit 5 calls per minute.
+
+```text
+sync_vault(fts_only?: boolean, force_rebuild?: boolean, vault_path?: string) -> string
+```
+
+`fts_only=true` builds only the lexical index and downloads no model assets.
+`force_rebuild=true` re-embeds every chunk, which is required after changing the
+embedding model or dimension.
+
+The returned report states how many notes were scanned, indexed and **excluded**
+by validation. Excluded notes are not searchable; run `power index <vault>
+--strict` to list them by name.
+
 ### 3. `read_sub_index`
 
 Read an existing canonical P.A.R.A. `_index.md`; does not generate it.

--- a/src/power_framework/mcp/power_server.py
+++ b/src/power_framework/mcp/power_server.py
@@ -176,6 +176,62 @@ async def generate_index(vault_path: str | None = None) -> str:
 
 
 @mcp.tool
+async def sync_vault(
+    fts_only: bool = False,
+    force_rebuild: bool = False,
+    vault_path: str | None = None,
+) -> str:
+    """Rebuild the search index so newly written notes become findable.
+
+    ``ingest_note`` and ``synthesize_session`` write the note and refresh the
+    hierarchical index, but the search database is a separate artifact — until
+    it is rebuilt, ``search_vault_tool`` cannot return the note that was just
+    saved. Call this after writing notes.
+
+    Set ``fts_only=True`` for the fast lexical index without embedding model
+    downloads; ``force_rebuild=True`` re-embeds everything (needed after
+    changing the embedding model or dimension).
+    """
+    if not _index_limiter.is_allowed("sync_vault"):
+        remaining = _index_limiter.remaining("sync_vault")
+        raise ToolError(
+            f"Rate limit exceeded. Try again later. ({remaining} requests remaining in window)"
+        )
+
+    path = _get_vault_path(vault_path)
+
+    def _run() -> str:
+        from power_framework.core.generation_index import sync_vault_atomically
+
+        report = sync_vault_atomically(
+            path,
+            sync_embeddings=not fts_only,
+            force_rebuild=force_rebuild,
+        )
+        # Report coverage, not just success: a note excluded by validation is
+        # invisible to search afterwards, and silence there is indistinguishable
+        # from a healthy index.
+        lines = [
+            "=== Vault Sync ===",
+            f"Generation: {report.generation_id}",
+            f"Mode: {'FTS only' if fts_only else 'FTS + embeddings'}",
+            f"Notes scanned: {report.total_scanned}",
+            f"Notes indexed: {report.actual_files}",
+            f"Notes excluded (invalid metadata): {report.invalid_sources}",
+            f"Chunks: {report.actual_chunks}",
+        ]
+        if report.invalid_sources:
+            lines.append("")
+            lines.append(
+                "Excluded notes are not searchable. Run 'power index <vault> --strict' "
+                "to list them, or heal_frontmatter_tool to repair them."
+            )
+        return "\n".join(lines)
+
+    return await run_vault_mutation(path, _run)
+
+
+@mcp.tool
 async def read_sub_index(category: str, vault_path: str | None = None) -> str:
     """Read the sub-index (_index.md) for a specific P.A.R.A. category. Use this after identifying the relevant category from the main index. Read-only — does not generate files."""
     path = _get_vault_path(vault_path)

--- a/tests/test_doc_drift.py
+++ b/tests/test_doc_drift.py
@@ -41,7 +41,7 @@ def test_current_docs_match_executable_interfaces_and_safe_onboarding() -> None:
     documents = gate["_read_current_documents"]()
 
     assert len(facts["cli_commands"]) == 16
-    assert len(facts["mcp_tools"]) == 17
+    assert len(facts["mcp_tools"]) == 18
     assert gate["check_interfaces"](documents, facts) == []
     assert gate["check_onboarding"](documents, facts) == []
     assert gate["check_links"](documents, facts) == []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -25,6 +25,7 @@ from power_framework.mcp.power_server import (
     read_memory_history,
     read_sub_index,
     search_vault_tool,
+    sync_vault,
     synthesize_session,
     validate_memory_state,
 )
@@ -348,3 +349,48 @@ def test_run_requires_configured_vault_root(monkeypatch: pytest.MonkeyPatch) -> 
 
     with pytest.raises(RuntimeError, match="POWER_VAULT_DIR"):
         power_server.run()
+
+
+async def test_ingested_note_is_searchable_after_sync_vault(sample_vault: Path) -> None:
+    """The write -> retrieve loop must be closeable from inside MCP alone.
+
+    Without a sync tool an agent can save a note through `ingest_note` and then
+    fail to find it through `search_vault_tool`, because the hierarchical index
+    and the search database are different artifacts.
+    """
+    marker = "zyrgqx7marker"
+    # Establish an index first: with no index at all a search can still answer
+    # from a fresh scan, which hides the staleness this test is about.
+    await sync_vault(fts_only=True, vault_path=str(sample_vault))
+
+    await ingest_note(
+        name="03_Resources/sync_probe",
+        note_type="Resource",
+        title="Sync Probe",
+        description=f"Probe note carrying {marker}",
+        content=f"# Probe\n\nBody mentioning {marker}.\n",
+        vault_path=str(sample_vault),
+    )
+
+    before = json.loads(
+        await search_vault_tool(query=marker, search_mode="fts", vault_path=str(sample_vault))
+    )
+    assert before["result_count"] == 0
+
+    report = await sync_vault(fts_only=True, vault_path=str(sample_vault))
+    assert "Notes indexed:" in report
+
+    after = json.loads(
+        await search_vault_tool(query=marker, search_mode="fts", vault_path=str(sample_vault))
+    )
+    assert after["result_count"] > 0
+
+
+async def test_sync_vault_reports_excluded_notes(sample_vault: Path) -> None:
+    """A note dropped by validation is invisible to search; say so, do not imply success."""
+    (sample_vault / "03_Resources" / "broken.md").write_text(
+        "---\ntype: NotARealType\ntitle: Broken\n---\n\nBody.\n", encoding="utf-8"
+    )
+    report = await sync_vault(fts_only=True, vault_path=str(sample_vault))
+    assert "Notes excluded (invalid metadata): 1" in report
+    assert "not searchable" in report


### PR DESCRIPTION
Closes #241.

## Problem

`ingest_note` and `synthesize_session` write the note and refresh the
hierarchical index — but the search database is a separate artifact, and no MCP
tool rebuilds it. An agent working only through MCP can save a note and then
fail to retrieve it, so the write → retrieve loop the framework is built around
cannot be closed from inside the protocol.

Reproduced through the MCP dispatcher, against a vault that already has an index:

```
ingest_note(... marker ...)        -> OK
search_vault_tool(marker, fts)     -> 0 hits
sync_vault(fts_only=True)          -> Notes indexed: N
search_vault_tool(marker, fts)     -> 1 hit
```

On a vault with **no** index at all a search can still answer from a fresh scan,
which masks the gap entirely — the test establishes an index first for that
reason, and my first version of it passed for the wrong reason until I noticed.

## Approach

Thin wrapper over the same `sync_vault_atomically` the CLI uses, serialized per
vault through `run_vault_mutation`, sharing the existing 5-calls-per-minute
index rate limit.

`fts_only=true` builds only the lexical index and downloads no model assets —
worth having as the default choice for an agent, since a full dense sync can
take hours on CPU.

The report states notes **scanned / indexed / excluded**:

```
Notes scanned: 2790
Notes indexed: 2406
Notes excluded (invalid metadata): 384
```

A note dropped by validation is silently unsearchable afterwards (#237), and
reporting only success is indistinguishable from a healthy index. If you would
rather keep this tool minimal and handle coverage separately, I am happy to
strip that part.

## Docs

`check_doc_drift.py` correctly refused the change until the docs matched — it
named all four places and the 17 → 18 count, and `test_doc_drift.py` pins it.
That gate did its job; README, docs index, agent instructions, the MCP reference
and the pinned count are updated accordingly.

## Tests

- ingested note is not findable before `sync_vault` and is after
- the report names excluded notes rather than implying success

Both verified to fail when the sync call is stubbed out.

## Checks

CI here is `action_required` (first-time fork contributor), so I ran the
workflow steps locally:

```
pytest tests/ -q          749 passed, 14 skipped   (coverage 79.09%)
ruff check / format       All checks passed! / 98 files already formatted
mypy src/power_framework  Success: no issues found in 39 source files
check_doc_drift.py        passed
verify_release_contract.py passed
Windows lifecycle job     index --strict / lint gate / markdown-check / sync / search — all pass
```
