### PR TITLE
feat(sync): print a coverage ledger and add --strict, so silent exclusion has a symptom

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -133,17 +133,22 @@ present. History returns append-only transaction receipts without note content.
 Build the active search generation atomically.
 
 ```text
-power sync PATH [--fts-only] [--force]
+power sync PATH [--fts-only] [--force] [--strict]
 ```
 
 | Flag | Description |
 | --- | --- |
 | `--fts-only` | Build the lightweight FTS index and skip embeddings. |
 | `--force` | Force a full dense rebuild, for example after a model/dimension change. |
+| `--strict` | Exit non-zero when any note is excluded from the search index, listing each excluded note and the reason. Mirrors `index --strict`. |
 
 Full sync downloads and validates the pinned embedding assets as needed. It can
 be resource intensive and fails closed if the generation contract cannot be
 satisfied.
+
+Every sync prints a coverage ledger — notes scanned, indexed, and excluded by
+metadata validation. An excluded note is invisible to **every** search mode, so
+a non-zero excluded count deserves attention even without `--strict`.
 
 ### `rot`
 

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -343,6 +343,33 @@ def _cmd_sync(args: argparse.Namespace) -> int:
         report.expected_files,
         report.actual_chunks,
     )
+    # Coverage is the invariant, not a detail: a note excluded by validation is
+    # invisible to every search mode afterwards, and a sync that only reports
+    # what it indexed is indistinguishable from a healthy one. Always print the
+    # ledger; under --strict, name the offenders and refuse to pretend.
+    logger.info(
+        "Coverage: %d notes scanned, %d indexed, %d excluded (invalid metadata).",
+        report.total_scanned,
+        report.actual_files,
+        report.invalid_sources,
+    )
+    if report.invalid_sources:
+        if getattr(args, "strict", False):
+            from .generation_index import list_invalid_sources
+
+            for rel_path, reason in sorted(list_invalid_sources(vault_dir).items()):
+                logger.error("  excluded: %s (%s)", rel_path, reason)
+            logger.error(
+                "Strict sync failed: %d note(s) are excluded from the search index.",
+                report.invalid_sources,
+            )
+            return 1
+        logger.warning(
+            "%d note(s) are not searchable. Run 'power sync --strict' to fail on "
+            "this, or 'power index %s --strict' to list them.",
+            report.invalid_sources,
+            vault_dir,
+        )
     return 0
 
 
@@ -713,6 +740,15 @@ def main() -> None:
         action="store_true",
         default=False,
         help="Force a full rebuild of dense embeddings (required after changing the embedding model/dimension)",
+    )
+    p_sync.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help=(
+            "Exit non-zero when any note is excluded from the search index, "
+            "listing each excluded note and the reason (mirrors 'index --strict')"
+        ),
     )
     p_sync.set_defaults(func=_cmd_sync)
 

--- a/src/power_framework/core/generation_index.py
+++ b/src/power_framework/core/generation_index.py
@@ -131,6 +131,19 @@ def _init_state_db(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def list_invalid_sources(vault_dir: Path) -> dict[str, str]:
+    """Return {rel_path: reason} for every note the next sync would exclude.
+
+    The generation store persists only a *hash* of each excluded path
+    (``generation_invalid_sources``), so the names cannot be recovered from the
+    database after the fact. Callers that need to show the offenders — e.g.
+    ``power sync --strict`` — re-scan the inventory, which is a frontmatter-only
+    pass and cheap relative to a sync.
+    """
+    root = Path(vault_dir).expanduser().resolve()
+    return dict(_source_inventory(root).invalid_sources)
+
+
 def _source_inventory(vault_dir: Path) -> SourceInventory:
     """Account for every candidate source before staging begins."""
     valid_sources: dict[str, str] = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -400,3 +400,75 @@ def test_ingest_duplicate_returns_1(tmp_path: Path) -> None:
     ):
         main()
     assert exc2.value.code == 1
+
+
+class TestSyncCoverage:
+    """A sync that drops notes must say so; --strict must refuse to pretend.
+
+    Measured origin: on a real 2790-note vault, sync silently excluded 384
+    notes (13.8%) and printed only what it indexed — the hole was found by
+    querying the generation database directly.
+    """
+
+    @staticmethod
+    def _make_vault(tmp_path):
+        import argparse
+
+        from power_framework.core.cli import _cmd_init
+
+        vault = tmp_path / "vault"
+        _cmd_init(argparse.Namespace(path=str(vault)))
+        (vault / "03_Resources" / "good.md").write_text(
+            '---\ntype: Resource\ntitle: "Good"\ndescription: "Valid note"\n'
+            "timestamp: 2026-01-01T00:00:00\n---\n\nBody.\n",
+            encoding="utf-8",
+        )
+        return vault
+
+    @staticmethod
+    def _sync(vault, strict):
+        import argparse
+
+        from power_framework.core.cli import _cmd_sync
+
+        return _cmd_sync(
+            argparse.Namespace(path=str(vault), fts_only=True, force=False, strict=strict)
+        )
+
+    def test_coverage_ledger_is_always_printed(self, tmp_path, caplog):
+        import logging
+
+        vault = self._make_vault(tmp_path)
+        with caplog.at_level(logging.INFO):
+            assert self._sync(vault, strict=False) == 0
+        assert any("Coverage:" in r.getMessage() for r in caplog.records)
+
+    def test_excluded_note_warns_but_does_not_fail_by_default(self, tmp_path, caplog):
+        import logging
+
+        vault = self._make_vault(tmp_path)
+        (vault / "03_Resources" / "broken.md").write_text(
+            "---\ntype: NotARealType\ntitle: Broken\n---\n\nBody.\n", encoding="utf-8"
+        )
+        with caplog.at_level(logging.INFO):
+            assert self._sync(vault, strict=False) == 0
+        rendered = [r.getMessage() for r in caplog.records]
+        assert any("1 excluded" in m for m in rendered)
+        assert any("not searchable" in m for m in rendered)
+
+    def test_strict_fails_and_names_the_excluded_note(self, tmp_path, caplog):
+        import logging
+
+        vault = self._make_vault(tmp_path)
+        (vault / "03_Resources" / "broken.md").write_text(
+            "---\ntype: NotARealType\ntitle: Broken\n---\n\nBody.\n", encoding="utf-8"
+        )
+        with caplog.at_level(logging.INFO):
+            assert self._sync(vault, strict=True) == 1
+        rendered = [r.getMessage() for r in caplog.records]
+        assert any("broken.md" in m for m in rendered)
+        assert any("Strict sync failed" in m for m in rendered)
+
+    def test_strict_passes_on_a_clean_vault(self, tmp_path):
+        vault = self._make_vault(tmp_path)
+        assert self._sync(vault, strict=True) == 0


### PR DESCRIPTION
Implements the core proposal of #237.

## Problem

A note excluded by metadata validation is invisible to **every** search mode
afterwards, and `sync` reported only what it indexed — so a partial index is
indistinguishable from a healthy one. On my real 2790-note vault, 384 notes
(13.8%) were absent from search and the only way to discover it was querying
the generation SQLite directly.

The extreme case is a raw un-healed Obsidian import:

```
Coverage: 2777 notes scanned, 0 indexed, 2777 excluded (invalid metadata).
```

Before this change that vault presented as *an empty search with no
explanation*. `index --strict` already refuses and names the offenders for the
identical input — the two commands treated the same situation in opposite ways.

## Change

- **Every sync ends with the coverage ledger** (scanned / indexed / excluded).
  When excluded > 0, a warning points at `sync --strict` and `index --strict`.
- **`power sync --strict`** exits non-zero and names each excluded note with
  its reason — mirroring the flag and semantics `index --strict` already has.
- **`generation_index.list_invalid_sources()`** (new, public): the generation
  store persists only path *hashes* for excluded notes
  (`generation_invalid_sources`), so names cannot be recovered from the DB
  after the fact; the accessor re-runs the frontmatter-only inventory scan,
  cheap relative to a sync.

**Default exit codes are unchanged** — without `--strict` the ledger and
warning are informational, so existing automation does not break. If you would
rather have sync fail closed by default (with `--allow-partial` as the
escape), I am happy to invert it; I kept the conservative form for a first PR.

Known limit, named rather than hidden: the per-note reason is currently the
generic `invalid_metadata` — a per-field breakdown needs `validate_metadata`
to report details and is a separate change.

## Tests

- ledger always printed
- excluded note warns but passes by default
- `--strict` fails and names the offender
- `--strict` passes on a clean vault

Each mutation-checked: suppressing the strict exit fails the strict test,
suppressing the ledger fails the ledger test.

## Checks

CI here is `action_required` (first-time fork contributor), so I ran the
workflow steps locally:

```
pytest tests/ -q          751 passed, 14 skipped   (coverage 79.12%)
ruff check / format       All checks passed! / 98 files already formatted
mypy src/power_framework  Success: no issues found in 39 source files
check_doc_drift.py        passed
verify_release_contract.py passed
```
