### PR TITLE
fix(sync): make coverage an explicit invariant

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -133,17 +133,20 @@ present. History returns append-only transaction receipts without note content.
 Build the active search generation atomically.
 
 ```text
-power sync PATH [--fts-only] [--force]
+power sync PATH [--fts-only] [--force] [--strict | --allow-partial]
 ```
 
 | Flag | Description |
 | --- | --- |
 | `--fts-only` | Build the lightweight FTS index and skip embeddings. |
 | `--force` | Force a full dense rebuild, for example after a model/dimension change. |
+| `--strict` | Explicitly select the default fail-closed coverage policy; the command exits non-zero when notes are excluded. |
+| `--allow-partial` | Explicitly accept excluded notes, continue with a warning, and exit zero with the complete path/reason receipt. Mutually exclusive with `--strict`. |
 
-Full sync downloads and validates the pinned embedding assets as needed. It can
-be resource intensive and fails closed if the generation contract cannot be
-satisfied.
+Every sync prints scanned, indexed and excluded note counts plus deterministic
+exclusion reasons. Full sync downloads and validates the pinned embedding assets
+as needed. It can be resource intensive. The default is fail-closed when any
+note is excluded; use `--allow-partial` only when a partial index is deliberate.
 
 ### `rot`
 

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -343,6 +343,31 @@ def _cmd_sync(args: argparse.Namespace) -> int:
         report.expected_files,
         report.actual_chunks,
     )
+    logger.info(
+        "Coverage: %d notes scanned, %d indexed, %d excluded.",
+        report.total_scanned,
+        report.actual_files,
+        report.invalid_sources,
+    )
+    if report.excluded_reason_counts:
+        reasons = ", ".join(
+            f"{reason}={count}" for reason, count in report.excluded_reason_counts.items()
+        )
+        logger.info("Exclusion reasons: %s", reasons)
+    if report.excluded_sources:
+        allow_partial = getattr(args, "allow_partial", False)
+        level = logger.warning if allow_partial else logger.error
+        level(
+            "%d note(s) are not searchable. %s",
+            report.invalid_sources,
+            "Continuing because --allow-partial was requested."
+            if allow_partial
+            else "Sync failed closed; pass --allow-partial to accept a partial index.",
+        )
+        for rel_path, reason in sorted(report.excluded_sources.items()):
+            level("  excluded: %s (%s)", rel_path, reason)
+        if not allow_partial:
+            return 1
     return 0
 
 
@@ -713,6 +738,19 @@ def main() -> None:
         action="store_true",
         default=False,
         help="Force a full rebuild of dense embeddings (required after changing the embedding model/dimension)",
+    )
+    sync_coverage = p_sync.add_mutually_exclusive_group()
+    sync_coverage.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help="Fail when any note is excluded (the default coverage policy)",
+    )
+    sync_coverage.add_argument(
+        "--allow-partial",
+        action="store_true",
+        default=False,
+        help="Accept excluded notes and exit zero with a complete exclusion receipt",
     )
     p_sync.set_defaults(func=_cmd_sync)
 

--- a/src/power_framework/core/generation_index.py
+++ b/src/power_framework/core/generation_index.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import sqlite3
 import uuid
+from collections import Counter
 from contextlib import closing
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -49,6 +50,24 @@ class GenerationReport:
     actual_chunks: int
     total_scanned: int
     invalid_sources: int
+    excluded_sources: dict[str, str]
+    excluded_reason_counts: dict[str, int]
+
+
+def _excluded_reason_counts(excluded_sources: dict[str, str]) -> dict[str, int]:
+    """Return deterministic counts for the reasons in an exclusion ledger."""
+    return dict(sorted(Counter(excluded_sources.values()).items()))
+
+
+def list_invalid_sources(vault_dir: Path) -> dict[str, str]:
+    """Return the deterministic path/reason ledger for the next sync.
+
+    The generation state database intentionally stores only hashes for excluded
+    paths. This read-only inventory helper exposes the same path/reason data
+    used by a sync without persisting user paths in the state store.
+    """
+    root = Path(vault_dir).expanduser().resolve()
+    return dict(_source_inventory(root).invalid_sources)
 
 
 def _state_db_path(vault_dir: Path) -> Path:
@@ -167,7 +186,7 @@ def _snapshot_hash(sources: dict[str, str]) -> str:
     return digest.hexdigest()
 
 
-def _assert_source_snapshot_unchanged(vault_dir: Path, expected_sources: dict[str, str]) -> None:
+def _assert_source_snapshot_unchanged(vault_dir: Path, expected_inventory: SourceInventory) -> None:
     """Reject a build when source content changed after staging began.
 
     A path-only coverage check cannot prove that the staged rows describe the
@@ -175,7 +194,26 @@ def _assert_source_snapshot_unchanged(vault_dir: Path, expected_sources: dict[st
     BLAKE2 identities again immediately before publication so callers retry
     instead of activating a stale generation.
     """
-    current_sources = _source_inventory(vault_dir).valid_sources
+    current_inventory = _source_inventory(vault_dir)
+    expected_sources = {
+        **{
+            path: f"valid:{content_hash}"
+            for path, content_hash in expected_inventory.valid_sources.items()
+        },
+        **{
+            path: f"excluded:{reason}"
+            for path, reason in expected_inventory.invalid_sources.items()
+        },
+    }
+    current_sources = {
+        **{
+            path: f"valid:{content_hash}"
+            for path, content_hash in current_inventory.valid_sources.items()
+        },
+        **{
+            path: f"excluded:{reason}" for path, reason in current_inventory.invalid_sources.items()
+        },
+    }
     if current_sources == expected_sources:
         return
 
@@ -503,7 +541,7 @@ def _migrate_legacy_database(
                 staging_conn, set(inventory.valid_sources), sync_embeddings
             )
             staging_conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-        _assert_source_snapshot_unchanged(vault_dir, inventory.valid_sources)
+        _assert_source_snapshot_unchanged(vault_dir, inventory)
         _publish(
             vault_dir,
             generation_id,
@@ -534,6 +572,8 @@ def _migrate_legacy_database(
         actual_chunks=actual_chunks,
         total_scanned=inventory.total_scanned,
         invalid_sources=len(inventory.invalid_sources),
+        excluded_sources=dict(inventory.invalid_sources),
+        excluded_reason_counts=_excluded_reason_counts(inventory.invalid_sources),
     )
 
 
@@ -578,7 +618,7 @@ def sync_vault_atomically(
                 sync_embeddings=sync_embeddings,
                 force_rebuild=force_rebuild,
             )
-            _assert_source_snapshot_unchanged(root, sources)
+            _assert_source_snapshot_unchanged(root, inventory)
             actual_files, actual_chunks, provider, model = _validate_staging(
                 conn, set(sources), sync_embeddings
             )
@@ -612,4 +652,6 @@ def sync_vault_atomically(
         actual_chunks=actual_chunks,
         total_scanned=inventory.total_scanned,
         invalid_sources=len(inventory.invalid_sources),
+        excluded_sources=dict(inventory.invalid_sources),
+        excluded_reason_counts=_excluded_reason_counts(inventory.invalid_sources),
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,6 +132,112 @@ def test_index_strict_reports_invalid_notes(tmp_path: Path) -> None:
     assert (tmp_path / "index.md").exists()
 
 
+def _add_invalid_note(vault: Path) -> Path:
+    invalid = vault / "03_Resources" / "invalid_sync.md"
+    invalid.write_text("# no frontmatter\n", encoding="utf-8")
+    return invalid
+
+
+def test_sync_clean_vault_has_zero_exit_and_coverage_ledger(
+    sample_vault: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    with (
+        caplog.at_level("INFO"),
+        patch.object(
+            sys,
+            "argv",
+            ["power", "sync", str(sample_vault), "--fts-only"],
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+
+    assert exc.value.code == 0
+    assert any(
+        "Coverage: 5 notes scanned, 5 indexed, 0 excluded." in r.message for r in caplog.records
+    )
+
+
+def test_sync_default_fails_closed_and_names_excluded_note(
+    sample_vault: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    invalid = _add_invalid_note(sample_vault)
+    with (
+        caplog.at_level("INFO"),
+        patch.object(
+            sys,
+            "argv",
+            ["power", "sync", str(sample_vault), "--fts-only"],
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+
+    assert exc.value.code == 1
+    messages = [record.message for record in caplog.records]
+    assert any(
+        "Coverage: 6 notes scanned, 5 indexed, 1 excluded." in message for message in messages
+    )
+    assert any("Exclusion reasons: invalid_metadata=1" in message for message in messages)
+    assert any(
+        f"excluded: {invalid.relative_to(sample_vault).as_posix()} (invalid_metadata)" in message
+        for message in messages
+    )
+
+
+def test_sync_strict_fails_closed_and_allow_partial_is_explicit(
+    sample_vault: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _add_invalid_note(sample_vault)
+    with (
+        caplog.at_level("INFO"),
+        patch.object(
+            sys,
+            "argv",
+            ["power", "sync", str(sample_vault), "--fts-only", "--strict"],
+        ),
+        pytest.raises(SystemExit) as strict_exc,
+    ):
+        main()
+    assert strict_exc.value.code == 1
+
+    caplog.clear()
+    with (
+        caplog.at_level("INFO"),
+        patch.object(
+            sys,
+            "argv",
+            ["power", "sync", str(sample_vault), "--fts-only", "--allow-partial"],
+        ),
+        pytest.raises(SystemExit) as partial_exc,
+    ):
+        main()
+    assert partial_exc.value.code == 0
+    assert any(
+        "Continuing because --allow-partial was requested." in r.message for r in caplog.records
+    )
+
+
+def test_sync_rejects_contradictory_coverage_flags(sample_vault: Path) -> None:
+    with (
+        patch.object(
+            sys,
+            "argv",
+            [
+                "power",
+                "sync",
+                str(sample_vault),
+                "--fts-only",
+                "--strict",
+                "--allow-partial",
+            ],
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+    assert exc.value.code == 2
+
+
 def test_ingest_creates_note(sample_vault: Path) -> None:
     with (
         patch.object(

--- a/tests/test_generation_index.py
+++ b/tests/test_generation_index.py
@@ -219,6 +219,8 @@ def test_invalid_sources_are_explicitly_recorded(
     report = sync_vault_atomically(vault, sync_embeddings=False)
 
     assert (report.total_scanned, report.invalid_sources, report.expected_files) == (2, 1, 1)
+    assert report.excluded_sources == {"01_Projects/Invalid.md": "invalid_metadata"}
+    assert report.excluded_reason_counts == {"invalid_metadata": 1}
     with closing(sqlite3.connect(_state_db_path(vault))) as conn:
         invalid_count = conn.execute(
             "SELECT COUNT(*) FROM generation_invalid_sources WHERE generation_id = ?",
@@ -229,6 +231,43 @@ def test_invalid_sources_are_explicitly_recorded(
             (report.generation_id,),
         ).fetchone()[0]
     assert (invalid_count, reason) == (1, "invalid_metadata")
+
+
+def test_excluded_source_change_during_sync_keeps_previous_active_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A note becoming valid during sync must invalidate the source snapshot."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    vault = _vault(tmp_path, "excluded-change", "stable-token")
+    invalid = vault / "01_Projects" / "Invalid.md"
+    invalid.write_text("# no frontmatter\n", encoding="utf-8")
+    sync_vault_atomically(vault, sync_embeddings=False)
+    active_db = _active_db(vault)
+    before = active_db.read_bytes()
+
+    from power_framework.core import searcher
+
+    original_sync = searcher._sync_vault_to_db
+
+    def sync_then_repair_excluded(*args: object, **kwargs: object) -> None:
+        original_sync(*args, **kwargs)
+        invalid.write_text(
+            "---\n"
+            "type: Project\n"
+            "title: Repaired\n"
+            "description: repaired note\n"
+            "timestamp: 2026-07-27T00:00:00+00:00\n"
+            "---\n\nrepaired-token\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(searcher, "_sync_vault_to_db", sync_then_repair_excluded)
+    with pytest.raises(IndexGenerationError, match=r"snapshot changed during sync.*Invalid.md"):
+        sync_vault_atomically(vault, sync_embeddings=False)
+
+    assert active_db.read_bytes() == before
+    assert search_vault(vault, "stable-token", mode="fts")
+    assert not search_vault(vault, "repaired-token", mode="fts")
 
 
 def test_legacy_search_database_is_imported_before_removal(


### PR DESCRIPTION
Closes #237

## What changed

- make the sync coverage result carry scanned/indexed/excluded counts, deterministic exclusion reasons, and the path/reason receipt from the same source inventory used for generation;
- always print the coverage ledger;
- make sync fail closed by default when notes are excluded;
- keep `--strict` as an explicit fail-closed mode and add mutually exclusive `--allow-partial` as the deliberate opt-out;
- document the real flags and add regression coverage for clean, strict, default-failure, allow-partial, reason-count and contradictory-flag behavior.

## Why

Before this change, sync could publish and report a partial search corpus without a symptom or non-zero exit. An agent or automation could treat 86% coverage as a healthy index.

## Validation

- `./.venv/bin/pytest tests/ -q` — 755 passed, 10 skipped, 79.61% coverage;
- targeted `tests/test_generation_index.py tests/test_cli.py` — 37 passed;
- `ruff check src tests scripts` — passed;
- `ruff format --check` on all changed files — passed;
- `mypy src/power_framework` — passed;
- `scripts/check_doc_drift.py` — passed;
- `scripts/verify_release_contract.py` — passed.

The repository-wide format check still reports four pre-existing unrelated files outside this change; they were not modified. Commit is GPG-signed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict and allow-partial modes for synchronization.
  * Sync results now show coverage totals, excluded notes, and deterministic exclusion reasons.
* **Bug Fixes**
  * Synchronization now fails by default when invalid sources are excluded, helping prevent incomplete results.
* **Documentation**
  * Updated CLI documentation with coverage policies, sync counts, exclusion reasons, and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->