### PR TITLE
feat(import): add fail-closed foreign-frontmatter migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ the role-specific guides before touching a vault:
   executable acceptance gate, FTS, and MCP preflight
 - **[Windows 11 25H2](docs/windows-11-installation.md)** — complete PowerShell
   installation, Visual C++ prerequisite, exact interpreter paths, and checks
-- **[CLI reference](docs/cli.md)** — all 16 commands, flags, and actual exit behavior
+- **[CLI reference](docs/cli.md)** — all 17 commands, flags, and actual exit behavior
 - **[MCP server](docs/mcp-server.md)** — all 17 governed tools, rate limits,
   configured-vault boundary, and untrusted retrieval contract
 - **[Migration guide](docs/migration-guide.md)** — 6-phase, manifest/hash-driven
@@ -99,7 +99,7 @@ coverage from checks that must pass on the target Windows host.
 
 | Feature                          | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **CLI**                          | 16 commands, including `power memory` for explicit proposal, approval, validation, and history                                                                                                                                                                                                                                                                                                                                                                                      |
+| **CLI**                          | 17 commands, including `power import` for preflighted Markdown migration and `power memory` for explicit proposal, approval, validation, and history                                                                                                                                                                                                                                                                                                                            |
 | **MCP Server**                   | 17 tools, including governed memory context, proposal, apply, validation, and history operations                                                                                                                                                                                                                                                                                                                                                                                    |
 | **OKF Validation**               | Pydantic v2 schemas enforce strict metadata on every note with governance (`owner`, `status`, `expiry`)                                                                                                                                                                                                                                                                                                                                                                             |
 | **Knowledge Graph (Graph RAG)**  | `related` field in OKF frontmatter supporting `TypedRelation` (path, relation, confidence) with BFS traversal and Mermaid diagram export (`to_mermaid`)                                                                                                                                                                                                                                                                                                                             |
@@ -204,6 +204,8 @@ power lint <path>              Scan for broken links, missing metadata, orphans
 power index <path>             Generate hierarchical index (index.md + _index.md files)
 power search <path> <query>    Full-text search with relevance scoring
 power ingest <path> [options]  Create a new note with validated OKF metadata
+power import <dir> --into FOLDER [options]
+                                Preflight/import an existing Markdown tree
 power memory <operation>       Governed memory context, proposal, apply, validation, and history
 power sync <path>              Build FTS and dense search indexes
 power rot <path>               ROT Audit — detect redundant, outdated, trivial notes
@@ -475,7 +477,7 @@ flowchart TD
 | `core/markdown_checks.py`                 | Markdown quality checks: trailing whitespace, list markers, header jumps                                                                                                                                                           |
 | `core/constants.py`                       | Centralized exclusion lists and system constants                                                                                                                                                                                   |
 | `core/utils.py`                           | Path traversal protection, atomic writes, backups, rate limiter                                                                                                                                                                    |
-| `core/cli.py`                             | Command-line interface with 16 commands, including transactional memory workflows                                                                                                                                                  |
+| `core/cli.py`                             | Command-line interface with 17 commands, including preflighted import and transactional memory workflows                                                                                                                           |
 | `mcp/power_server.py`                     | FastMCP 3.x server with 17 async tools, loopback HTTP transport, and `/health`                                                                                                                                                     |
 
 All components share `power_framework.core` as the single source of truth.

--- a/README.ua.md
+++ b/README.ua.md
@@ -45,7 +45,7 @@ P.O.W.E.R. створений для роботи як людьми, так і A
   vault, executable acceptance gate, FTS і MCP preflight
 - **[Windows 11 25H2](docs/windows-11-installation.ua.md)** — повне
   PowerShell-встановлення, Visual C++ prerequisite, точні interpreter paths і checks
-- **[CLI reference](docs/cli.md)** — усі 16 команд, flags і реальна exit behavior
+- **[CLI reference](docs/cli.md)** — усі 17 команд, flags і реальна exit behavior
 - **[MCP server](docs/mcp-server.md)** — усі 17 governed tools, rate limits,
   configured-vault boundary і untrusted retrieval contract
 - **[Migration guide](docs/migration-guide.ua.md)** — 6-фазна manifest/hash-driven
@@ -98,7 +98,7 @@ venv interpreter, troubleshooting, rollback і uninstall.
 
 | Функція                          | Що робить                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **CLI**                          | 16 команд, включно з `power memory` для явного proposal, approval, validation та history                                                                                                                                                                                                                                                                                                                                                                                             |
+| **CLI**                          | 17 команд, включно з `power import` для preflighted Markdown migration та `power memory` для явного proposal, approval, validation та history                                                                                                                                                                                                                                                                                                                                     |
 | **MCP Server**                   | 17 інструментів, включно з керованими операціями memory context, proposal, apply, validation та history                                                                                                                                                                                                                                                                                                                                                                              |
 | **OKF Validation**               | Pydantic v2 схеми забезпечують строгі OKF-метадані на кожній нотатці з governance-полями (`owner`, `status`, `expiry`)                                                                                                                                                                                                                                                                                                                                                               |
 | **Knowledge Graph (Graph RAG)**  | Поле `related` в OKF frontmatter з підтримкою `TypedRelation` (path, relation, confidence), BFS обходом та експортом підграфів у Mermaid-діаграми (`to_mermaid`)                                                                                                                                                                                                                                                                                                                     |
@@ -201,6 +201,8 @@ power lint <path>              Сканування на биті посилан
 power index <path>             Згенерувати ієрархічний індекс (index.md + _index.md)
 power search <path> <query>    Повнотекстовий пошук з релевантним ранжуванням
 power ingest <path> [опції]    Створити нову нотатку з валідованими OKF метаданими
+power import <dir> --into FOLDER [опції]
+                                Перевірити/імпортувати наявне Markdown-дерево
 power memory <операція>        Керований memory context, proposal, apply, validation та history
 power sync <path>              Побудувати FTS і dense-індекси пошуку
 power rot <path>               ROT Audit — виявити дублікати, застарілі, тривіальні
@@ -472,7 +474,7 @@ flowchart TD
 | `core/markdown_checks.py`                 | Перевірки якості Markdown: trailing whitespace, списки, заголовки                                                                                                                                                                                      |
 | `core/constants.py`                       | Централізовані списки виключень та системні константи                                                                                                                                                                                                  |
 | `core/utils.py`                           | Захист від path traversal, атомарний запис, бекапи, rate limiter                                                                                                                                                                                       |
-| `core/cli.py`                             | Командний рядок із 16 командами, включно з transactional memory workflows                                                                                                                                                                              |
+| `core/cli.py`                             | Командний рядок із 17 командами, включно з preflighted import і transactional memory workflows                                                                                                                                             |
 | `mcp/power_server.py`                     | FastMCP 3.x сервер із 17 async tools, loopback HTTP transport та `/health`                                                                                                                                                                             |
 
 Всі компоненти використовують `power_framework.core` як єдине джерело правди.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@ This reference is aligned with the executable P.O.W.E.R. `v3.3.2` parser.
 
 ```text
 power [-h] [-v] [--verbose]
-      {init,lint,index,ingest,search,memory,sync,rot,archive,status,cron,heal,markdown-check,suggest-related,synthesize,rename} ...
+      {init,lint,index,ingest,import,search,memory,sync,rot,archive,status,cron,heal,markdown-check,suggest-related,synthesize,rename} ...
 ```
 
 ## Global options
@@ -91,6 +91,30 @@ power ingest PATH --type TYPE --title TITLE --description DESCRIPTION
 | `--domain` | Explicit domain slug from `.power/domains.yaml`; otherwise configured rules may route the note. |
 
 Without a domain registry, note type determines the canonical target folder.
+
+### `import`
+
+Preflight and import an existing Markdown tree into a canonical vault folder.
+The source is never modified. The command scans every source note and builds
+the complete report before creating a destination file or search index.
+
+```text
+power import SOURCE --into VAULT_FOLDER [--path VAULT]
+                    [--policy strict|quarantine] [--dry-run]
+                    [--allow-partial]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--into` | Required vault-relative destination beginning with `00_Inbox`, a P.A.R.A. folder, or `PROTOCOLS`. |
+| `--path` | Target vault; defaults to `POWER_VAULT_DIR`, `POWER_VAULT_PATH`, or the current directory. |
+| `--policy` | `strict` (default) rejects foreign known values; explicit `quarantine` retains `status`/`related` values under additive `x-status`/`x-related` fields. |
+| `--dry-run` | Print the deterministic coverage, quarantine, exclusion, and collision report without writing anything. |
+| `--allow-partial` | Explicitly permit importing valid notes when fatal source notes or collisions remain excluded. |
+
+`type` remains fatal. A successful apply regenerates the hierarchical catalog
+and builds an FTS index, so imported notes are searchable immediately. Dense
+embeddings remain an explicit follow-up through `power sync PATH`.
 
 ### `search`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ reconcile every file by manifest and hash, and make cutover reversible.
 ## Executable contract
 
 - Python 3.11 or newer.
-- 16 top-level CLI commands; see the [CLI reference](cli.md).
+- 17 top-level CLI commands; see the [CLI reference](cli.md).
 - 17 MCP tools; see the [MCP server reference](mcp-server.md).
 - `semantic` is the default search mode; `reranked` is an explicit opt-in.
 - The generated root index and MCP sub-index operations cover the canonical P.A.R.A.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -53,7 +53,8 @@ An agent must read the relevant documents before changing data:
 - MCP `read_sub_index` and `ensure_sub_index` accept canonical P.A.R.A.
   categories, not arbitrary source folders.
 - CLI `power ingest` creates a new note but does not import an existing note
-  body. It is not a batch migration command.
+  body. For a bounded batch import, use `power import`; it is the only command
+  that accepts an explicit source directory and produces a preflight report.
 - `power heal` repairs missing/invalid frontmatter fields; it does not classify
   arbitrary top-level folders, repair wikilinks, or call an LLM.
 - `power rename` is dry-run by default and updates `related` metadata paths. It
@@ -61,6 +62,37 @@ An agent must read the relevant documents before changing data:
 
 These constraints are why this protocol uses a staging vault and a migration
 manifest instead of pretending that one command performs a lossless migration.
+
+### Bounded import fast path
+
+For a source tree whose destination folder and filename mapping are already
+known, `power import` provides the executable preflight without mutating the
+source:
+
+```bash
+power import /absolute/path/to/source --into 03_Resources \
+  --path /absolute/path/to/vault --policy quarantine --dry-run
+```
+
+The default `strict` policy rejects a source note whose known field uses a
+foreign value. The explicit `quarantine` policy moves a foreign `status` to
+`x-status` and a foreign `related` shape to `x-related`, preserving the
+original value and Markdown body. `type`, malformed YAML/frontmatter, and
+other schema failures remain excluded. The report lists scanned, importable,
+quarantined, unchanged, excluded, collision, and per-field counts before any
+write.
+
+Apply only after reviewing the report:
+
+```bash
+power import /absolute/path/to/source --into 03_Resources \
+  --path /absolute/path/to/vault --policy quarantine
+power index /absolute/path/to/vault --strict
+power search /absolute/path/to/vault "known phrase" --mode fts
+```
+
+Use `--allow-partial` only when the named exclusions are acceptable. The
+source remains unchanged; a conflicting destination is never overwritten.
 
 ## Six-phase protocol
 

--- a/docs/migration-guide.ua.md
+++ b/docs/migration-guide.ua.md
@@ -52,8 +52,9 @@ rollback path.
   регенерує index, дописує `log.md` та запускає lint.
 - MCP `read_sub_index` і `ensure_sub_index` приймають канонічні P.A.R.A.
   categories, а не довільні source folders.
-- CLI `power ingest` створює нову нотатку, але не імпортує body наявної. Це не
-  batch migration command.
+- CLI `power ingest` створює нову нотатку, але не імпортує body наявної. Для
+  bounded batch import використовуйте `power import`: це єдина команда, яка
+  приймає source directory і формує preflight report.
 - `power heal` виправляє missing/invalid frontmatter fields, але не класифікує
   довільні top-level folders, не ремонтує wikilinks і не викликає LLM.
 - `power rename` за замовчуванням працює як dry run і оновлює paths у metadata
@@ -61,6 +62,35 @@ rollback path.
 
 Саме тому протокол використовує staging vault і migration manifest, а не
 видає одну команду за lossless migration.
+
+### Обмежений fast path імпорту
+
+Якщо destination folder і mapping імен уже відомі, `power import` дає
+виконуваний preflight без зміни source:
+
+```bash
+power import /absolute/path/to/source --into 03_Resources \
+  --path /absolute/path/to/vault --policy quarantine --dry-run
+```
+
+Політика `strict` за замовчуванням відхиляє note, якщо відоме поле має
+foreign value. Явна `quarantine` переносить foreign `status` у `x-status`, а
+foreign shape `related` — у `x-related`, зберігаючи оригінальне значення та
+Markdown body. `type`, malformed YAML/frontmatter та інші schema failures
+залишаються excluded. Звіт до будь-якого write показує scanned, importable,
+quarantined, unchanged, excluded, collision і field-level counts.
+
+Після перевірки звіту застосуйте імпорт:
+
+```bash
+power import /absolute/path/to/source --into 03_Resources \
+  --path /absolute/path/to/vault --policy quarantine
+power index /absolute/path/to/vault --strict
+power search /absolute/path/to/vault "known phrase" --mode fts
+```
+
+`--allow-partial` використовуйте лише коли названі exclusions прийнятні.
+Source залишається незмінним; destination collision ніколи не перезаписується.
 
 ## Шестифазний протокол
 

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -322,6 +322,7 @@ def _cmd_import(args: argparse.Namespace) -> int:
     try:
 
         def apply_and_index() -> tuple[int, tuple[str, GenerationReport]]:
+            """Write the planned notes, then publish catalog and FTS state."""
             written = apply_import_plan(plan, allow_partial=args.allow_partial)
             index_message = run_generate_hierarchical_index(vault_dir)
             sync_report = sync_vault_atomically(vault_dir, sync_embeddings=False)

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -17,6 +17,7 @@ import os
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 try:  # resource is POSIX-only; Windows uses the no-limit path.
     import resource
@@ -33,6 +34,12 @@ from .domains import (
 )
 from .healer import heal_vault
 from .ignore import should_skip
+from .importer import (
+    ImportPolicy,
+    apply_import_plan,
+    build_import_plan,
+    format_import_report,
+)
 from .indexer import generate_log_initial, run_generate_hierarchical_index
 from .linter import (
     archive_stale_notes,
@@ -62,6 +69,9 @@ from .synthesize import synthesize_session_ingest
 from .utils import __version__, atomic_write
 
 logger = logging.getLogger("power")
+
+if TYPE_CHECKING:
+    from .generation_index import GenerationReport
 
 TEMPLATE_NOTE = """\
 ---
@@ -255,6 +265,88 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
     logger.info("Created note: %s", note_path.relative_to(vault_dir))
     if domain:
         logger.info("Domain routing: %s (template: %s)", domain.name, domain.template)
+    return 0
+
+
+def _resolve_import_target(vault_dir: Path, relative_path: str) -> Path:
+    """Resolve an import target inside the vault's documented note scope."""
+    candidate = Path(relative_path).expanduser()
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise ValueError("--into must be a relative path inside the vault")
+    target = (vault_dir / candidate).resolve()
+    try:
+        target.relative_to(vault_dir)
+    except ValueError as exc:
+        raise ValueError("--into must stay inside the vault") from exc
+    if not candidate.parts or candidate.parts[0] not in (*VAULT_STRUCTURE, "00_Inbox"):
+        raise ValueError("--into must start with a P.A.R.A. or PROTOCOLS folder")
+    return target
+
+
+def _cmd_import(args: argparse.Namespace) -> int:
+    """Preflight and import Markdown notes with an explicit compatibility policy."""
+    vault_dir = _resolve_path(args.path)
+    source_dir = Path(args.source).expanduser().resolve()
+    if not source_dir.is_dir():
+        logger.error("Import source directory not found: %s", source_dir)
+        return 1
+    if not vault_dir.is_dir():
+        logger.error("Vault not found: %s", vault_dir)
+        return 1
+
+    try:
+        target_dir = _resolve_import_target(vault_dir, args.into)
+    except ValueError as exc:
+        logger.error("Invalid import target: %s", exc)
+        return 1
+    if source_dir == vault_dir or source_dir.is_relative_to(vault_dir):
+        logger.error("Import source must be outside the target vault: %s", source_dir)
+        return 1
+    if target_dir.is_relative_to(source_dir):
+        logger.error("Import target must not be inside the source directory: %s", source_dir)
+        return 1
+
+    plan = build_import_plan(source_dir, target_dir, ImportPolicy(args.policy))
+    logger.info(format_import_report(plan, dry_run=args.dry_run))
+    if plan.excluded and not args.allow_partial:
+        logger.error(
+            "Import failed closed: %d note(s) are excluded; pass --allow-partial to import the rest.",
+            len(plan.excluded),
+        )
+        return 1
+    if args.dry_run or not plan.will_write:
+        return 0
+
+    from .generation_index import IndexGenerationError, sync_vault_atomically
+
+    try:
+
+        def apply_and_index() -> tuple[int, tuple[str, GenerationReport]]:
+            written = apply_import_plan(plan, allow_partial=args.allow_partial)
+            index_message = run_generate_hierarchical_index(vault_dir)
+            sync_report = sync_vault_atomically(vault_dir, sync_embeddings=False)
+            return written, (index_message, sync_report)
+
+        written, result = execute_vault_mutation(vault_dir, apply_and_index)
+    except (IndexGenerationError, OSError, ValueError) as exc:
+        logger.error("Import apply failed: %s", exc)
+        return 1
+
+    index_message, sync_report = result
+    logger.info("Imported %d note(s).", written)
+    logger.info("%s", index_message)
+    if sync_report.invalid_sources:
+        logger.error(
+            "Import produced a partial searchable index: %d note(s) excluded.",
+            sync_report.invalid_sources,
+        )
+        if not args.allow_partial:
+            return 1
+    logger.info(
+        "FTS index ready: %d/%d notes indexed.",
+        sync_report.actual_files,
+        sync_report.total_scanned,
+    )
     return 0
 
 
@@ -666,6 +758,41 @@ def main() -> None:
         help="Domain slug; without it, configured domain rules route the note automatically",
     )
     p_ingest.set_defaults(func=_cmd_ingest)
+
+    p_import = subparsers.add_parser(
+        "import",
+        help="Preflight and import Markdown notes from another vault",
+    )
+    p_import.add_argument("source", help="Source directory containing Markdown notes")
+    p_import.add_argument(
+        "--into",
+        required=True,
+        help="Vault-relative destination folder, for example 03_Resources",
+    )
+    p_import.add_argument(
+        "--path",
+        default=None,
+        help="Target vault path (defaults to POWER_VAULT_DIR or the current directory)",
+    )
+    p_import.add_argument(
+        "--policy",
+        choices=[policy.value for policy in ImportPolicy],
+        default=ImportPolicy.STRICT.value,
+        help="Foreign frontmatter policy (default: strict)",
+    )
+    p_import.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Only print the deterministic plan; do not write notes or indexes",
+    )
+    p_import.add_argument(
+        "--allow-partial",
+        action="store_true",
+        default=False,
+        help="Import valid notes even when some source notes remain excluded",
+    )
+    p_import.set_defaults(func=_cmd_import)
 
     p_search = subparsers.add_parser("search", help="Full-text search across vault notes")
     p_search.add_argument("path", help="Path to the vault directory")

--- a/src/power_framework/core/importer.py
+++ b/src/power_framework/core/importer.py
@@ -1,0 +1,284 @@
+"""Fail-closed, import-compatible migration of foreign Markdown notes."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import ValidationError
+
+from .constants import EXCLUDED_DIRS, SKIP_FILES
+from .models import NoteStatus, OKFMetadata
+from .parser import (
+    FRONTMATTER_PATTERN,
+    build_frontmatter,
+    extract_frontmatter_raw,
+    parse_frontmatter,
+)
+from .utils import atomic_write
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class ImportPolicy(StrEnum):
+    """Policy used to handle source notes that do not match OKF exactly."""
+
+    STRICT = "strict"
+    QUARANTINE = "quarantine"
+
+
+@dataclass(frozen=True)
+class QuarantineChange:
+    """One foreign value retained under an additive ``x-`` key."""
+
+    field: str
+    quarantine_field: str
+    reason: str
+
+
+@dataclass
+class ImportItem:
+    """Preflight result for one source note."""
+
+    source: Path
+    relative_path: str
+    destination: Path
+    content: str | None = None
+    output: str | None = None
+    changes: list[QuarantineChange] = field(default_factory=list)
+    excluded_reason: str | None = None
+    collision: bool = False
+    unchanged: bool = False
+
+    @property
+    def importable(self) -> bool:
+        """Whether this item can be copied without overwriting another note."""
+        return self.output is not None and self.excluded_reason is None and not self.collision
+
+
+@dataclass
+class ImportPlan:
+    """Complete deterministic import plan, built before any target write."""
+
+    source_dir: Path
+    target_dir: Path
+    policy: ImportPolicy
+    items: list[ImportItem]
+
+    @property
+    def scanned(self) -> int:
+        """Number of source Markdown notes considered by the plan."""
+        return len(self.items)
+
+    @property
+    def excluded(self) -> list[ImportItem]:
+        """Items that cannot be imported under the selected policy."""
+        return [item for item in self.items if item.excluded_reason or item.collision]
+
+    @property
+    def candidates(self) -> list[ImportItem]:
+        """Items that are valid and safe to import or leave unchanged."""
+        return [item for item in self.items if item.output is not None and not item.excluded_reason]
+
+    @property
+    def quarantined(self) -> list[ImportItem]:
+        """Items whose frontmatter needs an explicit additive quarantine."""
+        return [item for item in self.items if item.changes]
+
+    @property
+    def will_write(self) -> list[ImportItem]:
+        """Items that will create a new or changed destination note."""
+        return [item for item in self.candidates if item.importable and not item.unchanged]
+
+    @property
+    def reason_counts(self) -> Counter[str]:
+        """Stable counts for the human-readable import report."""
+        counts: Counter[str] = Counter()
+        for item in self.items:
+            if item.excluded_reason:
+                counts[item.excluded_reason] += 1
+            elif item.collision:
+                counts["destination_exists_with_different_content"] += 1
+            for change in item.changes:
+                counts[f"{change.field}: {change.reason}"] += 1
+        return counts
+
+
+def _source_notes(source_dir: Path) -> list[tuple[Path, str]]:
+    """Return source notes in deterministic order without applying vault scope."""
+    notes: list[tuple[Path, str]] = []
+    for path in sorted(source_dir.rglob("*.md")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source_dir).as_posix()
+        if path.name in SKIP_FILES or any(part in EXCLUDED_DIRS for part in Path(relative).parts):
+            continue
+        notes.append((path, relative))
+    return notes
+
+
+def _safe_quarantine_field(data: dict[str, object], base: str, value: object) -> str:
+    """Choose an additive key without overwriting an existing user value."""
+    candidate = base
+    suffix = 1
+    while candidate in data and data[candidate] != value:
+        suffix += 1
+        candidate = f"{base}-{suffix}"
+    data[candidate] = value
+    return candidate
+
+
+def _normalize_foreign_fields(
+    source: Mapping[str, object],
+    policy: ImportPolicy,
+) -> tuple[dict[str, object], list[QuarantineChange]]:
+    """Move known foreign optional values to additive ``x-`` fields."""
+    data = dict(source)
+    changes: list[QuarantineChange] = []
+    if policy is ImportPolicy.STRICT:
+        return data, changes
+
+    status = data.get("status")
+    if status is not None:
+        valid_status = isinstance(status, NoteStatus)
+        if isinstance(status, str):
+            try:
+                NoteStatus(status)
+            except ValueError:
+                valid_status = False
+            else:
+                valid_status = True
+        if not valid_status:
+            data.pop("status", None)
+            quarantined = _safe_quarantine_field(data, "x-status", status)
+            changes.append(QuarantineChange("status", quarantined, "foreign status value"))
+
+    related = data.get("related")
+    if related is not None:
+        try:
+            OKFMetadata.coerce_related(related)
+        except (TypeError, ValueError, ValidationError):
+            data.pop("related", None)
+            quarantined = _safe_quarantine_field(data, "x-related", related)
+            changes.append(QuarantineChange("related", quarantined, "foreign relation shape"))
+
+    return data, changes
+
+
+def _validation_reason(data: Mapping[str, object], error: ValidationError) -> str:
+    """Create a stable, non-sensitive exclusion reason from Pydantic errors."""
+    if "type" not in data:
+        return "missing_type"
+    fields = sorted({".".join(str(part) for part in issue["loc"]) for issue in error.errors()})
+    if fields == ["type"]:
+        return "invalid_type"
+    return "invalid_metadata:" + ",".join(fields)
+
+
+def _replace_frontmatter(content: str, metadata: OKFMetadata) -> str:
+    """Render normalized metadata while preserving the original Markdown body."""
+    match = FRONTMATTER_PATTERN.match(content)
+    if match is None:
+        raise ValueError("source frontmatter disappeared during import preflight")
+    return f"{build_frontmatter(metadata)}\n{content[match.end() :]}"
+
+
+def _plan_item(source: Path, relative: str, destination: Path, policy: ImportPolicy) -> ImportItem:
+    """Build one import item without touching the destination."""
+    item = ImportItem(source=source, relative_path=relative, destination=destination)
+    try:
+        content = source.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        item.excluded_reason = "read_error"
+        return item
+    item.content = content
+
+    if extract_frontmatter_raw(content) is None:
+        item.excluded_reason = "missing_or_malformed_frontmatter"
+        return item
+    data = parse_frontmatter(content)
+    if data is None:
+        item.excluded_reason = "invalid_yaml"
+        return item
+
+    normalized, changes = _normalize_foreign_fields(data, policy)
+    item.changes = changes
+    try:
+        metadata = OKFMetadata.model_validate(normalized)
+    except ValidationError as error:
+        item.excluded_reason = _validation_reason(normalized, error)
+        return item
+
+    item.output = _replace_frontmatter(content, metadata) if changes else content
+    if destination.exists():
+        try:
+            item.unchanged = destination.read_text(encoding="utf-8") == item.output
+        except (OSError, UnicodeError):
+            item.collision = True
+        if not item.unchanged and not item.collision:
+            item.collision = True
+    return item
+
+
+def build_import_plan(source_dir: Path, target_dir: Path, policy: ImportPolicy) -> ImportPlan:
+    """Preflight every source note and return a deterministic, write-free plan."""
+    source = source_dir.expanduser().resolve()
+    target = target_dir.expanduser().resolve()
+    items = [
+        _plan_item(path, relative, target / relative, policy)
+        for path, relative in _source_notes(source)
+    ]
+    return ImportPlan(source, target, policy, items)
+
+
+def apply_import_plan(plan: ImportPlan, *, allow_partial: bool = False) -> int:
+    """Apply a preflighted plan and return the number of newly written notes."""
+    if plan.excluded and not allow_partial:
+        raise ValueError("import plan contains excluded notes; pass --allow-partial to apply")
+    written = 0
+    for item in plan.will_write:
+        if item.content is None or item.output is None:
+            continue
+        if item.destination.exists():
+            try:
+                current = item.destination.read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as exc:
+                raise ValueError(f"cannot recheck destination: {item.relative_path}") from exc
+            if current == item.output:
+                continue
+            raise ValueError(f"destination changed during import: {item.relative_path}")
+        atomic_write(item.destination, item.output)
+        written += 1
+    return written
+
+
+def format_import_report(plan: ImportPlan, *, dry_run: bool) -> str:
+    """Render the deterministic preflight/apply summary and warnings."""
+    lines = [
+        f"Import {'dry run' if dry_run else 'plan'}:",
+        f"  source: {plan.source_dir}",
+        f"  target: {plan.target_dir}",
+        f"  policy: {plan.policy.value}",
+        f"  notes scanned: {plan.scanned}",
+        f"  will import: {len(plan.will_write)}",
+        f"  will quarantine: {len(plan.quarantined)}",
+        f"  unchanged: {sum(item.unchanged for item in plan.items)}",
+        f"  excluded: {len(plan.excluded)}",
+    ]
+    for key, count in sorted(plan.reason_counts.items()):
+        lines.append(f"    {key}: {count}")
+    for item in plan.items:
+        lines.extend(
+            f"  WARN {item.relative_path}: {change.field} -> {change.quarantine_field} "
+            f"({change.reason})"
+            for change in item.changes
+        )
+        if item.excluded_reason:
+            lines.append(f"  EXCLUDE {item.relative_path}: {item.excluded_reason}")
+        elif item.collision:
+            lines.append(f"  EXCLUDE {item.relative_path}: destination collision")
+    return "\n".join(lines)

--- a/tests/test_doc_drift.py
+++ b/tests/test_doc_drift.py
@@ -40,7 +40,7 @@ def test_current_docs_match_executable_interfaces_and_safe_onboarding() -> None:
     facts = gate["_load_code_facts"]()
     documents = gate["_read_current_documents"]()
 
-    assert len(facts["cli_commands"]) == 16
+    assert len(facts["cli_commands"]) == 17
     assert len(facts["mcp_tools"]) == 17
     assert gate["check_interfaces"](documents, facts) == []
     assert gate["check_onboarding"](documents, facts) == []

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -18,11 +18,13 @@ from power_framework.core.searcher import search_vault
 
 
 def _write_note(path: Path, frontmatter: str, body: str) -> None:
+    """Write one minimal Markdown note into a temporary source tree."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(f"---\n{frontmatter}\n---\n\n{body}\n", encoding="utf-8")
 
 
 def _foreign_source(tmp_path: Path) -> Path:
+    """Build a source tree containing valid, foreign, and fatal metadata cases."""
     source = tmp_path / "source"
     _write_note(
         source / "valid.md",
@@ -50,6 +52,7 @@ def _foreign_source(tmp_path: Path) -> Path:
 
 
 def test_import_plan_is_write_free_and_policy_explicit(tmp_path: Path) -> None:
+    """Verify strict and quarantine plans account for every source note pre-write."""
     source = _foreign_source(tmp_path)
     target = tmp_path / "vault" / "03_Resources"
 
@@ -76,6 +79,7 @@ def test_import_plan_is_write_free_and_policy_explicit(tmp_path: Path) -> None:
 
 
 def test_import_dry_run_does_not_mutate_vault(sample_vault: Path, tmp_path: Path) -> None:
+    """Verify dry-run reports exclusions without creating notes or indexes."""
     source = _foreign_source(tmp_path)
     with (
         patch.object(
@@ -104,6 +108,7 @@ def test_import_dry_run_does_not_mutate_vault(sample_vault: Path, tmp_path: Path
 
 
 def test_quarantine_import_is_searchable_and_idempotent(sample_vault: Path, tmp_path: Path) -> None:
+    """Verify quarantine apply preserves values, searchability, and rerun stability."""
     source = _foreign_source(tmp_path)
     args = [
         "power",

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,141 @@
+"""Regression coverage for fail-closed, foreign-frontmatter imports."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path  # noqa: TC003
+from unittest.mock import patch
+
+import pytest
+
+from power_framework.core.cli import main
+from power_framework.core.importer import (
+    ImportPolicy,
+    build_import_plan,
+    format_import_report,
+)
+from power_framework.core.searcher import search_vault
+
+
+def _write_note(path: Path, frontmatter: str, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\n{frontmatter}\n---\n\n{body}\n", encoding="utf-8")
+
+
+def _foreign_source(tmp_path: Path) -> Path:
+    source = tmp_path / "source"
+    _write_note(
+        source / "valid.md",
+        "type: Resource\ntitle: Valid\ndescription: Valid source\ntimestamp: 2026-01-01T00:00:00Z",
+        "A valid source note.",
+    )
+    _write_note(
+        source / "status.md",
+        "type: Resource\ntitle: Foreign status\ndescription: Foreign status\n"
+        "status: verified-external\ntimestamp: 2026-01-01T00:00:00Z",
+        "Status quarantine body with unique-status-import-token.",
+    )
+    _write_note(
+        source / "related.md",
+        "type: Resource\ntitle: Foreign relation\ndescription: Foreign relation\n"
+        "related:\n  - - Obsidian Link\ntimestamp: 2026-01-01T00:00:00Z",
+        "Relation quarantine body with unique-related-import-token.",
+    )
+    _write_note(
+        source / "fatal.md",
+        "title: Missing type\ndescription: This remains fatal\ntimestamp: 2026-01-01T00:00:00Z",
+        "This note must remain excluded.",
+    )
+    return source
+
+
+def test_import_plan_is_write_free_and_policy_explicit(tmp_path: Path) -> None:
+    source = _foreign_source(tmp_path)
+    target = tmp_path / "vault" / "03_Resources"
+
+    strict = build_import_plan(source, target, ImportPolicy.STRICT)
+    assert strict.scanned == 4
+    assert len(strict.candidates) == 1
+    assert len(strict.excluded) == 3
+    assert strict.quarantined == []
+    assert not target.exists()
+
+    quarantine = build_import_plan(source, target, ImportPolicy.QUARANTINE)
+    assert quarantine.scanned == 4
+    assert len(quarantine.will_write) == 3
+    assert len(quarantine.quarantined) == 2
+    assert quarantine.reason_counts["status: foreign status value"] == 1
+    assert quarantine.reason_counts["related: foreign relation shape"] == 1
+    assert quarantine.reason_counts["missing_type"] == 1
+    assert not target.exists()
+
+    report = format_import_report(quarantine, dry_run=True)
+    assert "notes scanned: 4" in report
+    assert "will quarantine: 2" in report
+    assert "EXCLUDE fatal.md: missing_type" in report
+
+
+def test_import_dry_run_does_not_mutate_vault(sample_vault: Path, tmp_path: Path) -> None:
+    source = _foreign_source(tmp_path)
+    with (
+        patch.object(
+            sys,
+            "argv",
+            [
+                "power",
+                "import",
+                str(source),
+                "--into",
+                "03_Resources",
+                "--path",
+                str(sample_vault),
+                "--policy",
+                "quarantine",
+                "--dry-run",
+            ],
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+
+    assert exc.value.code == 1
+    assert not (sample_vault / "03_Resources" / "status.md").exists()
+    assert not (sample_vault / "index.md").exists()
+
+
+def test_quarantine_import_is_searchable_and_idempotent(sample_vault: Path, tmp_path: Path) -> None:
+    source = _foreign_source(tmp_path)
+    args = [
+        "power",
+        "import",
+        str(source),
+        "--into",
+        "03_Resources/imported",
+        "--path",
+        str(sample_vault),
+        "--policy",
+        "quarantine",
+        "--allow-partial",
+    ]
+    with patch.object(sys, "argv", args), pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 0
+
+    status_note = sample_vault / "03_Resources" / "imported" / "status.md"
+    related_note = sample_vault / "03_Resources" / "imported" / "related.md"
+    assert "x-status: verified-external" in status_note.read_text(encoding="utf-8")
+    assert "x-related:" in related_note.read_text(encoding="utf-8")
+    assert search_vault(sample_vault, "unique-status-import-token", mode="fts")
+    assert search_vault(sample_vault, "unique-related-import-token", mode="fts")
+
+    with (
+        patch.object(sys, "argv", ["power", "index", str(sample_vault), "--strict"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+    assert exc.value.code == 0
+
+    with patch.object(sys, "argv", args), pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 0
+    assert len(list((sample_vault / "03_Resources" / "imported").glob("*.md"))) == 3


### PR DESCRIPTION
## Summary

Adds the first executable import path for foreign Markdown/Obsidian vaults.

- Introduces `power import SOURCE --into FOLDER` with a deterministic preflight report.
- Keeps `strict` as the default and adds explicit `--policy quarantine`.
- Preserves foreign `status` and `related` values under additive `x-status`/`x-related` fields.
- Keeps `type`, malformed frontmatter/YAML, schema failures, and destination conflicts fail-closed.
- Applies only after the complete plan is built; source files are never modified.
- Regenerates the hierarchical catalog and FTS index after apply.
- Documents the 17-command CLI contract in English and Ukrainian.

This addresses the import gap tracked by #238 and supersedes the env-only direction proposed in #243 for the CLI path. #243's model-level experiment is intentionally not wired into global validation.

## Validation

- `760 passed, 10 skipped`
- Coverage: `79.74%`
- `ruff check src tests`
- `ruff format --check src tests`
- `mypy src/power_framework`
- executable doc-drift check
- focused importer regression tests: dry-run no writes, strict/quarantine policy, `x-status`/`x-related` round-trip, FTS searchability, `index --strict`, and idempotent re-import
- signed commit verified with GPG

## Scope boundary

This phase does not add MCP `sync_vault`, ANN search, recursive catalog budgets, or reranker quality gates; those remain scheduled roadmap phases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `power import` command for importing Markdown notes from an external directory.
  * Supports dry-run previews, strict or quarantine validation, partial imports, collision protection, atomic writes, and automatic index/search updates.
  * Preserves source files and reports imported, excluded, quarantined, and indexed notes.

* **Documentation**
  * Updated English and Ukrainian command references, migration guides, and CLI documentation to describe the new import workflow.

* **Tests**
  * Added coverage for validation, quarantine handling, dry runs, indexing, and repeat imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->