### PR TITLE
feat(mcp): close ingest and search index loop

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,14 +1,14 @@
 # P.O.W.E.R. Framework — Agent Instructions
 
 Python 3.11+ toolkit for AI-native Second Brain management. CLI (`power`, 16 top-level
-commands) + MCP server (17 tools).
+commands) + MCP server (18 tools).
 
 ## Project Structure
 
 ```
 src/power_framework/       # Core library
   core/                    #   models, parser, indexer, linter, searcher, embedder
-  mcp/                     #   FastMCP-3.x server (17 async tools)
+  mcp/                     #   FastMCP-3.x server (18 async tools)
 tests/                     # Pytest suite; CI enforces coverage >=70%
 scripts/                   # Dev/CI utilities
 docs/                      # MkDocs-material documentation site
@@ -44,7 +44,7 @@ pre-commit run --all-files # Git hooks (ruff + mypy + pip-audit)
 | `core/linter.py`      | Health checks: links, metadata, orphans, stale/expired |
 | `core/searcher.py`    | FTS5/dense/hybrid/reranked search (`semantic` default) |
 | `core/embeddings.py`  | BGE-M3 ONNX (1024d) + MiniLM fallback                  |
-| `mcp/power_server.py` | FastMCP 3.x, 17 async tools, HTTP transport + /health  |
+| `mcp/power_server.py` | FastMCP 3.x, 18 async tools, HTTP transport + /health  |
 
 ## Workflow
 

--- a/.agents/INSTRUCTIONS.md
+++ b/.agents/INSTRUCTIONS.md
@@ -34,7 +34,7 @@ mypy src/power_framework/  # type check
 ```
 src/power_framework/
 ├── core/          # CLI, models, parser, indexer, linter, searcher, embeddings, reranker
-├── mcp/           # FastMCP 3.x server — 12 async tools
+├── mcp/           # FastMCP 3.x server — 18 async tools
 tests/             # pytest, asyncio_mode=auto, coverage >= 70%
 scripts/           # utility scripts (excluded from ruff T20/S310)
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Unlike generic knowledge management tools, P.O.W.E.R. is designed from the groun
 - **Knowledge Graph** — `related` field connects notes across the vault; visualized in sub-indexes for Graph RAG workflows
 - **Freshness Monitoring** — linter detects stale/expired notes based on `expiry` metadata field
 - **Agent Auto-Ingest** — `synthesize_session` MCP tool lets agents autonomously create permanent knowledge artifacts with governance + graph links + full catalog maintenance
-- **MCP-native** — expose 17 tools to MCP-compatible AI clients through FastMCP 3.x
+- **MCP-native** — expose 18 tools to MCP-compatible AI clients through FastMCP 3.x
 - **Windows-safe rename** — `power rename` uses `os.replace()` for the physical
   move, so renaming onto an existing destination works on Windows instead of
   raising `FileExistsError`
@@ -48,7 +48,7 @@ the role-specific guides before touching a vault:
 - **[Windows 11 25H2](docs/windows-11-installation.md)** — complete PowerShell
   installation, Visual C++ prerequisite, exact interpreter paths, and checks
 - **[CLI reference](docs/cli.md)** — all 17 commands, flags, and actual exit behavior
-- **[MCP server](docs/mcp-server.md)** — all 17 governed tools, rate limits,
+- **[MCP server](docs/mcp-server.md)** — all 18 governed tools, rate limits,
   configured-vault boundary, and untrusted retrieval contract
 - **[Migration guide](docs/migration-guide.md)** — 6-phase, manifest/hash-driven
   migration from any Markdown source methodology into a canonical POWER vault
@@ -100,7 +100,7 @@ coverage from checks that must pass on the target Windows host.
 | Feature                          | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **CLI**                          | 17 commands, including `power import` for preflighted Markdown migration and `power memory` for explicit proposal, approval, validation, and history                                                                                                                                                                                                                                                                                                                            |
-| **MCP Server**                   | 17 tools, including governed memory context, proposal, apply, validation, and history operations                                                                                                                                                                                                                                                                                                                                                                                    |
+| **MCP Server**                   | 18 tools, including governed memory context, proposal, apply, validation, history, and search-index synchronization operations                                                                                                                                                                                                                                                                                                                                                    |
 | **OKF Validation**               | Pydantic v2 schemas enforce strict metadata on every note with governance (`owner`, `status`, `expiry`)                                                                                                                                                                                                                                                                                                                                                                             |
 | **Knowledge Graph (Graph RAG)**  | `related` field in OKF frontmatter supporting `TypedRelation` (path, relation, confidence) with BFS traversal and Mermaid diagram export (`to_mermaid`)                                                                                                                                                                                                                                                                                                                             |
 | **Freshness Monitoring**         | Linter flags stale/expired notes by checking `expiry` dates, ensuring your vault stays current                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -478,7 +478,7 @@ flowchart TD
 | `core/constants.py`                       | Centralized exclusion lists and system constants                                                                                                                                                                                   |
 | `core/utils.py`                           | Path traversal protection, atomic writes, backups, rate limiter                                                                                                                                                                    |
 | `core/cli.py`                             | Command-line interface with 17 commands, including preflighted import and transactional memory workflows                                                                                                                           |
-| `mcp/power_server.py`                     | FastMCP 3.x server with 17 async tools, loopback HTTP transport, and `/health`                                                                                                                                                     |
+| `mcp/power_server.py`                     | FastMCP 3.x server with 18 async tools, loopback HTTP transport, and `/health`                                                                                                                                                     |
 
 All components share `power_framework.core` as the single source of truth.
 

--- a/README.ua.md
+++ b/README.ua.md
@@ -46,7 +46,7 @@ P.O.W.E.R. створений для роботи як людьми, так і A
 - **[Windows 11 25H2](docs/windows-11-installation.ua.md)** — повне
   PowerShell-встановлення, Visual C++ prerequisite, точні interpreter paths і checks
 - **[CLI reference](docs/cli.md)** — усі 17 команд, flags і реальна exit behavior
-- **[MCP server](docs/mcp-server.md)** — усі 17 governed tools, rate limits,
+- **[MCP server](docs/mcp-server.md)** — усі 18 governed tools, rate limits,
   configured-vault boundary і untrusted retrieval contract
 - **[Migration guide](docs/migration-guide.ua.md)** — 6-фазна manifest/hash-driven
   міграція з будь-якої Markdown source methodology у canonical POWER vault
@@ -475,7 +475,7 @@ flowchart TD
 | `core/constants.py`                       | Централізовані списки виключень та системні константи                                                                                                                                                                                                  |
 | `core/utils.py`                           | Захист від path traversal, атомарний запис, бекапи, rate limiter                                                                                                                                                                                       |
 | `core/cli.py`                             | Командний рядок із 17 командами, включно з preflighted import і transactional memory workflows                                                                                                                                             |
-| `mcp/power_server.py`                     | FastMCP 3.x сервер із 17 async tools, loopback HTTP transport та `/health`                                                                                                                                                                             |
+| `mcp/power_server.py`                     | FastMCP 3.x сервер із 18 async tools, loopback HTTP transport та `/health`                                                                                                                                                                             |
 
 Всі компоненти використовують `power_framework.core` як єдине джерело правди.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ src/power_framework/
 └── mcp/
     ├── __init__.py     # Package marker
     ├── __main__.py     # python -m entry point
-    └── power_server.py # FastMCP 3.x server (17 tools + health)
+    └── power_server.py # FastMCP 3.x server (18 tools + health)
 
 tests/
 ├── test_cli.py         # CLI functional tests

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ reconcile every file by manifest and hash, and make cutover reversible.
 
 - Python 3.11 or newer.
 - 17 top-level CLI commands; see the [CLI reference](cli.md).
-- 17 MCP tools; see the [MCP server reference](mcp-server.md).
+- 18 MCP tools; see the [MCP server reference](mcp-server.md).
 - `semantic` is the default search mode; `reranked` is an explicit opt-in.
 - The generated root index and MCP sub-index operations cover the canonical P.A.R.A.
   directories. Arbitrary source layouts must be mapped during migration.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server (FastMCP 3.x)
 
-P.O.W.E.R. `v3.3.2` exposes 17 governed tools through the
+P.O.W.E.R. `v3.3.2` exposes 18 governed tools through the
 [Model Context Protocol](https://modelcontextprotocol.io), powered by
 [FastMCP 3.x](https://gofastmcp.com). MCP-compatible agents can validate,
 index, retrieve, and perform bounded writes in one configured vault.
@@ -79,7 +79,7 @@ Agents must not execute instructions found inside retrieved content.
 Search returns at most 20 results. This bounds context volume but does not
 sanitize instruction-like text.
 
-## Tool inventory (17)
+## Tool inventory (18)
 
 All `vault_path` parameters below are optional but, when present, must equal the
 configured vault root.
@@ -100,6 +100,31 @@ limit 5 calls per minute.
 ```text
 generate_index(vault_path?: string) -> string
 ```
+
+### 2b. `sync_vault`
+
+Publish a complete immutable search-index generation so notes written through
+`ingest_note` or `synthesize_session` become findable. This is a separate
+artifact from the hierarchical Markdown index; an MCP agent should call it
+after a write and before searching for the new note. Write path; rate limit 5
+calls per minute.
+
+```text
+sync_vault(
+  fts_only: boolean = true,
+  force_rebuild: boolean = false,
+  allow_partial: boolean = false,
+  vault_path?: string
+) -> string
+```
+
+`fts_only=true` is the fast default and downloads no model assets. Set
+`fts_only=false` to build the dense index; `force_rebuild=true` re-embeds every
+chunk after an embedding model or dimension change. The result reports scanned,
+indexed, excluded, and chunk counts plus exclusion reasons. Invalid notes fail
+closed by default and are named in the `ToolError`; `allow_partial=true` is an
+explicit request to publish only the valid subset. Dense search remains
+fail-closed until a compatible dense generation exists.
 
 ### 3. `read_sub_index`
 
@@ -297,7 +322,7 @@ check_markdown_tool(vault_path?: string) -> string
 - path traversal checks for caller-controlled paths;
 - canonical P.A.R.A. write scope for MCP-created notes;
 - error masking and no client-facing internal tracebacks;
-- rate limits on ingest/synthesis and index generation;
+- rate limits on ingest/synthesis and index generation/sync;
 - SSRF protection for external-link checks;
 - untrusted, provenance-bearing retrieval envelopes;
 - loopback-only built-in HTTP transport;

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -35,7 +35,7 @@ An agent must read the relevant documents before changing data:
 - P.A.R.A., C.O.D.E., GTD, Zettelkasten, LYT, Johnny.Decimal, flat folders,
   and hybrid trees are supported as **source classifications**.
 - The destination uses canonical P.O.W.E.R. top-level folders so hierarchical
-  indexing and the 17 MCP tools have their documented behavior.
+  indexing and the 18 MCP tools have their documented behavior.
 - A non-Markdown system must first export notes to Markdown and attachments to
   files. Vendor database extraction is outside P.O.W.E.R.'s current CLI.
 - Unknown frontmatter fields may be retained, but the required OKF fields must

--- a/docs/migration-guide.ua.md
+++ b/docs/migration-guide.ua.md
@@ -35,7 +35,7 @@ rollback path.
 - P.A.R.A., C.O.D.E., GTD, Zettelkasten, LYT, Johnny.Decimal, flat folders та
   hybrid trees підтримуються як **класифікації джерела**.
 - Destination використовує канонічні top-level folders P.O.W.E.R., щоб
-  hierarchical index і 17 MCP tools мали задокументовану поведінку.
+  hierarchical index і 18 MCP tools мали задокументовану поведінку.
 - Не-Markdown система має спочатку експортувати нотатки у Markdown, а
   attachments — у файли. Vendor database extraction не реалізовано в CLI.
 - Невідомі frontmatter fields можна зберегти, але required OKF fields мають

--- a/src/power_framework/core/generation_index.py
+++ b/src/power_framework/core/generation_index.py
@@ -578,12 +578,30 @@ def _migrate_legacy_database(
 
 
 def sync_vault_atomically(
-    vault_dir: Path, *, sync_embeddings: bool, force_rebuild: bool = False
+    vault_dir: Path,
+    *,
+    sync_embeddings: bool,
+    force_rebuild: bool = False,
+    allow_partial: bool = True,
 ) -> GenerationReport:
-    """Build a complete staged generation and atomically publish it on success."""
+    """Build a complete staged generation and atomically publish it on success.
+
+    ``allow_partial=False`` rejects an inventory containing invalid sources
+    before a new generation is staged. The default remains permissive for the
+    low-level compatibility API; CLI and MCP callers expose explicit
+    fail-closed policy at their user-facing boundaries.
+    """
     root = Path(vault_dir).expanduser().resolve()
     ensure_vault_identity(root)
     inventory = _source_inventory(root)
+    if inventory.invalid_sources and not allow_partial:
+        details = "; ".join(
+            f"{rel_path} ({reason})"
+            for rel_path, reason in sorted(inventory.invalid_sources.items())
+        )
+        raise IndexGenerationError(
+            f"sync failed closed: {len(inventory.invalid_sources)} source(s) excluded; {details}"
+        )
     sources = inventory.valid_sources
     snapshot_hash = _snapshot_hash(sources)
     migrated = _migrate_legacy_database(

--- a/src/power_framework/mcp/power_server.py
+++ b/src/power_framework/mcp/power_server.py
@@ -5,6 +5,7 @@ P.O.W.E.R. MCP Server (FastMCP 3.x).
 Exposes MCP tools for AI agent interaction with the knowledge vault:
 - lint_vault: Health check for metadata, links, and orphans
 - generate_index: Compile hierarchical catalog (index.md + _index.md files)
+- sync_vault: Publish an atomic FTS/dense search-index generation
 - read_sub_index: Read a specific category sub-index on-demand (read-only)
 - ensure_sub_index: Generate and read a category sub-index (write path)
 - ingest_note: Create a new note with validated OKF frontmatter
@@ -173,6 +174,86 @@ async def generate_index(vault_path: str | None = None) -> str:
     path = _get_vault_path(vault_path)
     # Serialize index regeneration within this vault while preserving other-vault parallelism.
     return await run_vault_mutation(path, lambda: run_generate_hierarchical_index(path))
+
+
+@mcp.tool
+async def sync_vault(
+    fts_only: bool = True,
+    force_rebuild: bool = False,
+    allow_partial: bool = False,
+    vault_path: str | None = None,
+) -> str:
+    """Publish an atomic search-index generation for the configured vault.
+
+    ``ingest_note`` and ``synthesize_session`` write the note and refresh the
+    hierarchical index, but the search database is a separate artifact — until
+    it is rebuilt, ``search_vault_tool`` cannot return the note that was just
+    saved. Call this after writing notes.
+
+    The default is ``fts_only=True`` so an agent can close the write/search loop
+    without downloading or loading an embedding model. Set ``fts_only=False``
+    for the dense index and ``force_rebuild=True`` after changing the embedding
+    model or dimension. Invalid notes fail closed unless ``allow_partial=True``.
+    """
+    if not _index_limiter.is_allowed("sync_vault"):
+        remaining = _index_limiter.remaining("sync_vault")
+        raise ToolError(
+            f"Rate limit exceeded. Try again later. ({remaining} requests remaining in window)"
+        )
+
+    path = _get_vault_path(vault_path)
+
+    def _run() -> str:
+        from power_framework.core.generation_index import (
+            IndexGenerationError,
+            list_invalid_sources,
+            sync_vault_atomically,
+        )
+
+        invalid_sources = list_invalid_sources(path)
+        if invalid_sources and not allow_partial:
+            details = "; ".join(
+                f"{rel_path} ({reason})" for rel_path, reason in sorted(invalid_sources.items())
+            )
+            raise ToolError(
+                "Vault sync failed closed: "
+                f"{len(invalid_sources)} note(s) are excluded and remain unsearchable. "
+                f"Excluded: {details}. Pass allow_partial=True only to publish the valid subset."
+            )
+
+        try:
+            report = sync_vault_atomically(
+                path,
+                sync_embeddings=not fts_only,
+                force_rebuild=force_rebuild,
+                allow_partial=allow_partial,
+            )
+        except IndexGenerationError as exc:
+            raise ToolError(f"Vault sync failed; previous index remains active: {exc}") from exc
+
+        lines = [
+            "=== Vault Sync ===",
+            f"Generation: {report.generation_id}",
+            f"Mode: {'FTS only' if fts_only else 'FTS + embeddings'}",
+            f"Notes scanned: {report.total_scanned}",
+            f"Notes indexed: {report.actual_files}",
+            f"Notes excluded (invalid metadata): {report.invalid_sources}",
+            f"Chunks: {report.actual_chunks}",
+        ]
+        if report.invalid_sources:
+            lines.append("")
+            lines.append("Exclusion reasons:")
+            lines.extend(
+                f"- {rel_path}: {reason}"
+                for rel_path, reason in sorted(report.excluded_sources.items())
+            )
+            lines.append(
+                "Excluded notes are not searchable. Run 'power index <vault> --strict' "
+                "to list them, or heal_frontmatter_tool to repair them."
+            )
+        return "\n".join(lines)
+
+    return await run_vault_mutation(path, _run)
 
 
 @mcp.tool
@@ -373,15 +454,23 @@ async def search_vault_tool(
         raise ToolError(str(exc)) from exc
 
     def _do_search() -> str:
-        results = search_vault(
-            path,
-            query,
-            max_results=max_results,
-            mode=search_mode,
-            temporal_view=temporal_view,
-            as_of=normalized_as_of,
-            domain=domain,
-        )
+        try:
+            results = search_vault(
+                path,
+                query,
+                max_results=max_results,
+                mode=search_mode,
+                temporal_view=temporal_view,
+                as_of=normalized_as_of,
+                domain=domain,
+            )
+        except RuntimeError as exc:
+            from power_framework.core.generation_index import ActiveGenerationError
+            from power_framework.core.searcher import DenseIndexUnavailableError
+
+            if not isinstance(exc, (ActiveGenerationError, DenseIndexUnavailableError)):
+                raise
+            raise ToolError(str(exc)) from exc
         return format_untrusted_search_envelope(
             results,
             query,

--- a/tests/test_doc_drift.py
+++ b/tests/test_doc_drift.py
@@ -41,7 +41,7 @@ def test_current_docs_match_executable_interfaces_and_safe_onboarding() -> None:
     documents = gate["_read_current_documents"]()
 
     assert len(facts["cli_commands"]) == 17
-    assert len(facts["mcp_tools"]) == 17
+    assert len(facts["mcp_tools"]) == 18
     assert gate["check_interfaces"](documents, facts) == []
     assert gate["check_onboarding"](documents, facts) == []
     assert gate["check_links"](documents, facts) == []

--- a/tests/test_generation_index.py
+++ b/tests/test_generation_index.py
@@ -233,6 +233,22 @@ def test_invalid_sources_are_explicitly_recorded(
     assert (invalid_count, reason) == (1, "invalid_metadata")
 
 
+def test_sync_can_fail_closed_before_publishing_excluded_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    vault = _vault(tmp_path, "strict-inventory", "valid-token")
+    invalid = vault / "01_Projects" / "Invalid.md"
+    invalid.write_text("# no frontmatter\n", encoding="utf-8")
+
+    with pytest.raises(IndexGenerationError, match=r"sync failed closed.*Invalid\.md"):
+        sync_vault_atomically(vault, sync_embeddings=False, allow_partial=False)
+
+    assert resolve_active_generation_path(vault) is None
+    report = sync_vault_atomically(vault, sync_embeddings=False, allow_partial=True)
+    assert report.invalid_sources == 1
+
+
 def test_excluded_source_change_during_sync_keeps_previous_active_index(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,9 +5,12 @@ Tests for P.O.W.E.R. MCP Server tool calls using FastMCP functions directly.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import subprocess
+import sys
 from contextlib import closing
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -25,12 +28,10 @@ from power_framework.mcp.power_server import (
     read_memory_history,
     read_sub_index,
     search_vault_tool,
+    sync_vault,
     synthesize_session,
     validate_memory_state,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 async def test_read_sub_index_existing_category(sample_vault: Path) -> None:
@@ -226,6 +227,82 @@ async def test_ingest_note_tool(sample_vault: Path) -> None:
             content="Hello world",
             vault_path=str(sample_vault),
         )
+
+
+async def test_mcp_write_search_loop_survives_a_fresh_process(
+    sample_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MCP-only ingest plus sync must be visible after the server restarts."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    marker = "mcp-fresh-process-acceptance-7f3c"
+
+    await sync_vault(fts_only=True, vault_path=str(sample_vault))
+    await ingest_note(
+        name="03_Resources/fresh-process-probe",
+        note_type="Resource",
+        title="Fresh process probe",
+        description=f"A restart acceptance note carrying {marker}",
+        content=f"# Probe\n\nThe body contains {marker}.\n",
+        vault_path=str(sample_vault),
+    )
+
+    before = json.loads(
+        await search_vault_tool(query=marker, search_mode="fts", vault_path=str(sample_vault))
+    )
+    assert before["result_count"] == 0
+
+    report = await sync_vault(fts_only=True, vault_path=str(sample_vault))
+    assert "Notes excluded (invalid metadata): 0" in report
+
+    source_root = Path(__file__).resolve().parents[1] / "src"
+    script = (
+        "import json, sys\n"
+        "from power_framework.core.searcher import search_vault\n"
+        "results = search_vault(sys.argv[1], sys.argv[2], mode='fts')\n"
+        "print(json.dumps([result.rel_path for result in results]))\n"
+    )
+    child_env = os.environ.copy()
+    child_env.pop("POWER_SEARCH_DB", None)
+    child_env["PYTHONPATH"] = os.pathsep.join(
+        [str(source_root), child_env.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+    completed = subprocess.run(  # noqa: S603 - executable and script are fixed by this test.
+        [sys.executable, "-c", script, str(sample_vault), marker],
+        capture_output=True,
+        check=False,
+        env=child_env,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "03_Resources/fresh-process-probe.md" in json.loads(completed.stdout)
+
+    with pytest.raises(ToolError, match="Dense index"):
+        await search_vault_tool(
+            query=marker,
+            search_mode="semantic",
+            vault_path=str(sample_vault),
+        )
+
+
+async def test_sync_vault_fails_closed_and_can_explicitly_allow_partial(
+    sample_vault: Path,
+) -> None:
+    """Coverage omissions are an explicit MCP error, never an implied success."""
+    await sync_vault(fts_only=True, vault_path=str(sample_vault))
+    invalid = sample_vault / "03_Resources" / "broken-sync-note.md"
+    invalid.write_text("# no OKF frontmatter\n", encoding="utf-8")
+
+    with pytest.raises(ToolError, match=r"failed closed.*broken-sync-note\.md"):
+        await sync_vault(fts_only=True, vault_path=str(sample_vault))
+
+    report = await sync_vault(
+        fts_only=True,
+        allow_partial=True,
+        vault_path=str(sample_vault),
+    )
+    assert "Notes excluded (invalid metadata): 1" in report
+    assert "- 03_Resources/broken-sync-note.md: invalid_metadata" in report
+    assert "not searchable" in report
 
 
 async def test_synthesize_session_serializes_write_and_stores_candidate_triplets(


### PR DESCRIPTION
## Summary

Closes the MCP write-to-search gap documented in the P5.0.4 roadmap.

- add sync_vault with FTS-only default, explicit dense mode, force rebuild, rate limit, and coverage receipt
- fail closed on invalid sources unless allow_partial is explicit; preserve atomic generation semantics
- map missing dense/active-generation failures to truthful MCP ToolError responses
- add MCP-only ingest, FTS, semantic fail-closed, and fresh-process acceptance coverage
- align English/Ukrainian documentation and executable MCP tool count

## Verification

- 772 passed, 10 skipped in the project venv
- mypy src/power_framework: passed
- ruff check and ruff format: passed
- git diff --check: passed

Supersedes the older implementation attempt in #245; this branch is based on current main after #251.