### PR TITLE
fix(onnx): enforce actual provider binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
           uv run power --version
           uv run python -c "import power_framework.mcp, onnxruntime; print('imports: OK')"
+          $env:POWER_EMBED_DEVICE = "auto"
+          uv run python -c "import onnxruntime as ort; from power_framework.core.embeddings import select_onnx_providers; selected = select_onnx_providers(ort); print('available providers:', ort.get_available_providers()); print('selected providers:', selected); assert any((p[0] if isinstance(p, tuple) else p) == 'CPUExecutionProvider' for p in selected)"
           uv run power init $vault
           uv run power ingest $vault --type Resource --title "First Note" --description "Windows smoke note"
           uv run power index $vault --strict

--- a/docs/api/embeddings.md
+++ b/docs/api/embeddings.md
@@ -20,6 +20,29 @@ get_embedding_manager(provider: str | None = None) -> (
 - `provider`: overrides `POWER_EMBED_PROVIDER`. One of `bge-m3` (default),
   `fastembed`, `qwen3`, `ollama`. Legacy providers are opt-in for debugging only.
 
+### ONNX device/provider contract
+
+The canonical ONNX managers select the device from `POWER_EMBED_DEVICE`; the
+reranker uses `POWER_RERANKER_DEVICE` and falls back to the embedding setting
+when it is unset. Supported values are `auto`, `cpu`, `cuda`, `rocm`, and
+`directml`.
+
+- `auto` may bind `CPUExecutionProvider`, but logs the provider actually bound
+  by the created `InferenceSession`.
+- An explicit GPU device fails closed when the session binds CPU or a different
+  provider. It never silently turns a requested GPU run into a CPU benchmark.
+- Before provider probing, POWER calls the optional
+  `onnxruntime.preload_dlls()` hook used by pip-installed CUDA/cuDNN wheels.
+- Provider names are resolved case-insensitively because ONNX Runtime builds
+  differ in the spelling of the ROCm provider.
+- `BGEM3OnnxManager.active_provider` and `BGEM3Reranker.active_provider` hold
+  the verified provider after successful session creation; a failed check does
+  not retain the invalid session.
+
+`POWER_EMBED_DEVICE=cuda` and `POWER_RERANKER_DEVICE=cuda` are therefore
+runtime assertions, not performance hints. Set the corresponding variable to
+`auto` when CPU fallback is intended.
+
 ### Canonical — `BGEM3OnnxManager`
 
 ```python

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -137,6 +137,12 @@ power search PATH QUERY [--max-results N] [--mode MODE]
 Dense modes require a compatible full `power sync`; `fts` requires at least an
 FTS sync. `reranked` is explicit opt-in, not the default.
 
+ONNX-backed embedding and reranking honor `POWER_EMBED_DEVICE` and
+`POWER_RERANKER_DEVICE` (`auto`, `cpu`, `cuda`, `rocm`, or `directml`). `auto`
+may fall back to CPU; an explicit accelerator mode fails closed if the created
+session does not bind the requested provider. The actual bound provider is
+logged during initialization.
+
 ### `memory`
 
 Human-governed transactional memory workflow.

--- a/docs/windows-11-installation.md
+++ b/docs/windows-11-installation.md
@@ -255,6 +255,7 @@ runtime. Back it up before deleting either directory.
 | `DLL load failed` while importing `onnxruntime` | Install or repair the current Visual C++ 2015–2022 Redistributable matching the host architecture, then reopen Terminal. |
 | `pip install git+...` fails | Install Git for Windows, or use the release-wheel path, which does not require Git. |
 | MCP client reports module not found | Its `command` points to the wrong Python. Use the full `.venv\Scripts\python.exe` path and restart the client. |
+| Explicit `POWER_EMBED_DEVICE=cuda` fails with `requested_onnx_provider_not_bound` | This is the fail-closed GPU contract: the session did not bind CUDA. Keep the error, verify the pip `nvidia-*` runtime and `onnxruntime-gpu`, or set `POWER_EMBED_DEVICE=auto` only when CPU fallback is intended. |
 | `power init` refuses the directory | The target is not empty. Do not bypass the guard; use a new path or follow the migration guide. |
 | Dense sync fails | Keep the failure closed. Check disk space, network/proxy access, the exact model error, and retry; FTS remains available through `sync --fts-only` and `search --mode fts`. |
 

--- a/docs/windows-11-installation.ua.md
+++ b/docs/windows-11-installation.ua.md
@@ -253,6 +253,7 @@ runtime. Зробіть backup перед видаленням будь-яког
 | `DLL load failed` під час import `onnxruntime` | Встановіть або відновіть актуальний Visual C++ 2015–2022 Redistributable для архітектури хоста, потім відкрийте Terminal знову. |
 | `pip install git+...` падає | Встановіть Git for Windows або використовуйте release wheel, який не потребує Git. |
 | MCP-клієнт повідомляє `module not found` | Його `command` вказує на неправильний Python. Використайте повний шлях `.venv\Scripts\python.exe` і перезапустіть клієнт. |
+| Явний `POWER_EMBED_DEVICE=cuda` завершується `requested_onnx_provider_not_bound` | Це fail-closed GPU-контракт: сесія не прив'язала CUDA. Не приховуйте помилку; перевірте `nvidia-*` runtime, `onnxruntime-gpu`, або задайте `POWER_EMBED_DEVICE=auto` лише коли CPU fallback справді потрібен. |
 | `power init` відмовляється працювати | Каталог не порожній. Не обходьте захисну перевірку; оберіть новий шлях або migration guide. |
 | Dense sync падає | Залишайте failure closed. Перевірте диск, network/proxy та точну model error; FTS доступний через `sync --fts-only` і `search --mode fts`. |
 

--- a/src/power_framework/core/embeddings.py
+++ b/src/power_framework/core/embeddings.py
@@ -78,6 +78,74 @@ def _env_flag(name: str) -> bool:
     return os.getenv(name, "").lower() in {"1", "true", "yes"}
 
 
+def _preload_gpu_runtime(ort: Any) -> None:
+    """Load pip-owned GPU DLLs before asking ONNX Runtime about providers."""
+    preload = getattr(ort, "preload_dlls", None)
+    if preload is None:
+        return
+    try:
+        preload()
+    except Exception as exc:  # pragma: no cover - defensive backend boundary
+        logger.warning("onnxruntime.preload_dlls() failed: %s", exc)
+
+
+_DEVICE_ID_PROVIDERS = frozenset({"cudaexecutionprovider", "rocmexecutionprovider"})
+
+
+def requested_device(env_var: str = "POWER_EMBED_DEVICE") -> str:
+    """Return the normalized device mode for an embedding or reranker session."""
+    value = os.getenv(env_var)
+    if value is None and env_var != "POWER_EMBED_DEVICE":
+        value = os.getenv("POWER_EMBED_DEVICE")
+    return (value or "auto").strip().lower()
+
+
+def _resolve_provider_name(candidate: str, available: set[str]) -> str | None:
+    """Resolve an ORT provider name case-insensitively against the build."""
+    if candidate in available:
+        return candidate
+    lowered = candidate.casefold()
+    return next((name for name in available if name.casefold() == lowered), None)
+
+
+def _provider_name(provider: object) -> str:
+    """Extract a provider name from ORT's tuple or string configuration."""
+    return str(provider[0]) if isinstance(provider, tuple) else str(provider)
+
+
+def verify_bound_provider(session: Any, providers: list[object], env_var: str) -> str:
+    """Return the active provider and fail closed on an explicit mismatch.
+
+    ``get_available_providers()`` describes compiled support, while
+    ``InferenceSession.get_providers()`` describes what actually loaded. Auto
+    mode may bind CPU; an explicit mode must bind the requested provider.
+    """
+    bound = list(session.get_providers())
+    actual = bound[0] if bound else "unknown"
+    requested = requested_device(env_var)
+    logger.info("ONNX Runtime device=%s bound provider=%s", requested, actual)
+
+    if requested == "auto":
+        return actual
+
+    expected = (
+        "CPUExecutionProvider"
+        if requested == "cpu"
+        else (_provider_name(providers[0]) if providers else "unknown")
+    )
+    if actual.casefold() != expected.casefold():
+        fallback_hint = (
+            f"Set {env_var}=auto to allow CPU fallback."
+            if requested != "cpu"
+            else f"Set {env_var}=auto to permit fallback."
+        )
+        raise RuntimeError(
+            f"requested_onnx_provider_not_bound:{expected}; session bound {bound}. "
+            f"The requested provider may be compiled in but unavailable at runtime. {fallback_hint}"
+        )
+    return actual
+
+
 def select_onnx_providers(ort: Any, env_var: str = "POWER_EMBED_DEVICE") -> list[object]:
     """Select ONNX Runtime providers with explicit and automatic device modes.
 
@@ -86,8 +154,9 @@ def select_onnx_providers(ort: Any, env_var: str = "POWER_EMBED_DEVICE") -> list
     fail-closed when unavailable, preventing a requested GPU benchmark from
     silently running on a different backend.
     """
+    _preload_gpu_runtime(ort)
     available = set(ort.get_available_providers())
-    requested = os.getenv(env_var, os.getenv("POWER_EMBED_DEVICE", "auto")).lower()
+    requested = requested_device(env_var)
     if requested not in {"auto", "cpu", "cuda", "rocm", "directml"}:
         raise ValueError(f"invalid_{env_var.lower()}:{requested}")
 
@@ -100,35 +169,37 @@ def select_onnx_providers(ort: Any, env_var: str = "POWER_EMBED_DEVICE") -> list
 
     gpu_candidates = {
         "cuda": "CUDAExecutionProvider",
-        "rocm": "ROCmExecutionProvider",
+        "rocm": "ROCMExecutionProvider",
         "directml": "DmlExecutionProvider",
     }
     if requested != "auto":
-        provider_name = gpu_candidates[requested]
-        if provider_name not in available:
+        provider_name = _resolve_provider_name(gpu_candidates[requested], available)
+        if provider_name is None:
             raise RuntimeError(
-                f"requested_onnx_provider_unavailable:{provider_name}; available={sorted(available)}"
+                f"requested_onnx_provider_unavailable:{gpu_candidates[requested]}; "
+                f"available={sorted(available)}"
             )
         options: dict[str, object] = {}
-        if provider_name in {"CUDAExecutionProvider", "ROCmExecutionProvider"}:
+        if provider_name.casefold() in _DEVICE_ID_PROVIDERS:
             options = {
                 "device_id": int(os.getenv("POWER_EMBED_DEVICE_ID", "0")),
                 "arena_extend_strategy": "kSameAsRequested",
             }
         return [(provider_name, options), cpu_provider]
 
-    for provider_name in (
+    for candidate in (
         "CUDAExecutionProvider",
-        "ROCmExecutionProvider",
+        "ROCMExecutionProvider",
         "DmlExecutionProvider",
     ):
-        if provider_name in available:
+        provider_name = _resolve_provider_name(candidate, available)
+        if provider_name is not None:
             options = (
                 {
                     "device_id": int(os.getenv("POWER_EMBED_DEVICE_ID", "0")),
                     "arena_extend_strategy": "kSameAsRequested",
                 }
-                if provider_name in {"CUDAExecutionProvider", "ROCmExecutionProvider"}
+                if provider_name.casefold() in _DEVICE_ID_PROVIDERS
                 else {}
             )
             logger.info("ONNX Runtime device=auto selected %s", provider_name)
@@ -510,6 +581,7 @@ class BGEM3OnnxManager:
         self._session: Any | None = None
         self._tokenizer: Any | None = None
         self._dim = BGE_M3_DIM
+        self.active_provider: str | None = None
 
     @property
     def dimension(self) -> int:
@@ -584,7 +656,10 @@ class BGEM3OnnxManager:
             so.intra_op_num_threads = max(1, EMBED_NUM_THREADS)
             so.inter_op_num_threads = 1
             providers = select_onnx_providers(ort)
-            self._session = ort.InferenceSession(model_path, providers=providers, sess_options=so)
+            session = ort.InferenceSession(model_path, providers=providers, sess_options=so)
+            active_provider = verify_bound_provider(session, providers, "POWER_EMBED_DEVICE")
+            self._session = session
+            self.active_provider = active_provider
             self._tokenizer = Tokenizer.from_file(tok_path)
             self._tokenizer.enable_truncation(max_length=self._MAX_TOKENS)
             # Probe: eagerly verify the backend can allocate and produce a
@@ -593,6 +668,7 @@ class BGEM3OnnxManager:
             probe = self._embed_raw(["probe"])
             if probe is None or len(probe) != 1 or len(probe[0]) != self._dim:
                 self._session = None
+                self.active_provider = None
                 raise RuntimeError("bge_m3_onnx_probe_failed")
 
     def _embed_raw(self, texts: list[str]) -> list[list[float]] | None:

--- a/src/power_framework/core/reranker.py
+++ b/src/power_framework/core/reranker.py
@@ -7,7 +7,7 @@ import os
 import time
 from typing import Protocol
 
-from .embeddings import select_onnx_providers
+from .embeddings import select_onnx_providers, verify_bound_provider
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +135,7 @@ class BGEM3Reranker:
         self.model_name = f"{repo}@{revision}"
         self._session: object | None = None
         self._tokenizer: object | None = None
+        self.active_provider: str | None = None
 
     def _lazy_init(self) -> None:
         if self._session is not None:
@@ -224,7 +225,10 @@ class BGEM3Reranker:
             so.intra_op_num_threads = max(1, int(os.getenv("POWER_EMBED_NUM_THREADS", "2")))
             so.inter_op_num_threads = 1
             providers = select_onnx_providers(ort, env_var="POWER_RERANKER_DEVICE")
-            self._session = ort.InferenceSession(model_path, providers=providers, sess_options=so)
+            session = ort.InferenceSession(model_path, providers=providers, sess_options=so)
+            active_provider = verify_bound_provider(session, providers, "POWER_RERANKER_DEVICE")
+            self._session = session
+            self.active_provider = active_provider
             self._tokenizer = Tokenizer.from_file(tok_path)
             self._tokenizer.enable_truncation(max_length=self._MAX_TOKENS)
 
@@ -232,6 +236,7 @@ class BGEM3Reranker:
             probe = self._rerank_raw("probe query", "probe passage")
             if probe is None or len(probe) != 1:
                 self._session = None
+                self.active_provider = None
                 raise RuntimeError("bge_reranker_onnx_probe_failed")
 
     def _rerank_batch(self, query: str, documents: list[str]) -> list[float] | None:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import inspect
 import signal
+import sys
+from types import ModuleType
 from typing import TYPE_CHECKING
 
 import pytest
@@ -35,6 +37,81 @@ class TestEmbeddingManager:
         monkeypatch.setenv("POWER_EMBED_DEVICE", "cuda")
         with pytest.raises(RuntimeError, match="requested_onnx_provider_unavailable"):
             embeddings.select_onnx_providers(FakeOrt())
+
+    def test_preload_dlls_runs_before_provider_probe(self, monkeypatch: pytest.MonkeyPatch):
+        calls: list[str] = []
+
+        class FakeOrt:
+            @staticmethod
+            def preload_dlls():
+                calls.append("preload")
+
+            @staticmethod
+            def get_available_providers():
+                calls.append("probe")
+                return ["CPUExecutionProvider"]
+
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cpu")
+        embeddings.select_onnx_providers(FakeOrt())
+        assert calls == ["preload", "probe"]
+
+    def test_missing_preload_dlls_does_not_break_cpu(self, monkeypatch: pytest.MonkeyPatch):
+        class FakeOrt:
+            @staticmethod
+            def get_available_providers():
+                return ["CPUExecutionProvider"]
+
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cpu")
+        assert embeddings.select_onnx_providers(FakeOrt())[0][0] == "CPUExecutionProvider"
+
+    def test_rocm_provider_name_is_resolved_case_insensitively(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        class FakeOrt:
+            @staticmethod
+            def get_available_providers():
+                return ["ROCmExecutionProvider", "CPUExecutionProvider"]
+
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "rocm")
+        providers = embeddings.select_onnx_providers(FakeOrt())
+        assert providers[0][0] == "ROCmExecutionProvider"
+        assert providers[0][1]["device_id"] == 0
+
+    def test_directml_provider_can_be_selected_and_verified(self, monkeypatch: pytest.MonkeyPatch):
+        class FakeOrt:
+            @staticmethod
+            def get_available_providers():
+                return ["DmlExecutionProvider", "CPUExecutionProvider"]
+
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "directml")
+        providers = embeddings.select_onnx_providers(FakeOrt())
+        assert providers[0][0] == "DmlExecutionProvider"
+        assert (
+            embeddings.verify_bound_provider(
+                self._fake_session(["DmlExecutionProvider", "CPUExecutionProvider"]),
+                providers,
+                "POWER_EMBED_DEVICE",
+            )
+            == "DmlExecutionProvider"
+        )
+
+    def test_preload_failure_is_visible_but_not_fatal_for_cpu(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        class FakeOrt:
+            @staticmethod
+            def preload_dlls():
+                raise OSError("missing optional GPU runtime")
+
+            @staticmethod
+            def get_available_providers():
+                return ["CPUExecutionProvider"]
+
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cpu")
+        with caplog.at_level("WARNING"):
+            providers = embeddings.select_onnx_providers(FakeOrt())
+        assert providers[0][0] == "CPUExecutionProvider"
+        assert "preload_dlls() failed" in caplog.text
 
     def test_ollama_attempt_does_not_require_sigalrm(self, monkeypatch: pytest.MonkeyPatch):
         manager = embeddings.OllamaEmbeddingManager()
@@ -103,3 +180,120 @@ class TestEmbeddingManager:
         monkeypatch.setenv("POWER_EMBED_PROVIDER", "totally-unknown-backend")
         with pytest.raises(RuntimeError, match=r"unknown_embed_provider"):
             embeddings.get_embedding_manager()
+
+    @staticmethod
+    def _fake_session(providers: list[str]):
+        class FakeSession:
+            @staticmethod
+            def get_providers():
+                return providers
+
+        return FakeSession()
+
+    def test_explicit_gpu_binding_must_match_requested_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cuda")
+        providers: list[object] = [
+            ("CUDAExecutionProvider", {}),
+            ("CPUExecutionProvider", {}),
+        ]
+        with pytest.raises(RuntimeError, match="requested_onnx_provider_not_bound"):
+            embeddings.verify_bound_provider(
+                self._fake_session(["ROCmExecutionProvider", "CPUExecutionProvider"]),
+                providers,
+                "POWER_EMBED_DEVICE",
+            )
+
+    def test_auto_cpu_fallback_is_visible_but_allowed(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "auto")
+        providers: list[object] = [
+            ("CUDAExecutionProvider", {}),
+            ("CPUExecutionProvider", {}),
+        ]
+        assert (
+            embeddings.verify_bound_provider(
+                self._fake_session(["CPUExecutionProvider"]),
+                providers,
+                "POWER_EMBED_DEVICE",
+            )
+            == "CPUExecutionProvider"
+        )
+
+    def test_explicit_gpu_binding_is_case_insensitive(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cuda")
+        providers: list[object] = [("CUDAExecutionProvider", {}), ("CPUExecutionProvider", {})]
+        assert (
+            embeddings.verify_bound_provider(
+                self._fake_session(["CUDAExecutionProvider", "CPUExecutionProvider"]),
+                providers,
+                "POWER_EMBED_DEVICE",
+            )
+            == "CUDAExecutionProvider"
+        )
+
+    def test_explicit_cpu_binding_is_checked(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cpu")
+        providers: list[object] = [("CPUExecutionProvider", {})]
+        assert (
+            embeddings.verify_bound_provider(
+                self._fake_session(["CPUExecutionProvider"]),
+                providers,
+                "POWER_EMBED_DEVICE",
+            )
+            == "CPUExecutionProvider"
+        )
+
+    def test_explicit_gpu_empty_binding_fails_closed(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cuda")
+        providers: list[object] = [("CUDAExecutionProvider", {}), ("CPUExecutionProvider", {})]
+        with pytest.raises(RuntimeError, match="requested_onnx_provider_not_bound"):
+            embeddings.verify_bound_provider(
+                self._fake_session([]), providers, "POWER_EMBED_DEVICE"
+            )
+
+    def test_requested_device_inherits_embedding_mode_for_reranker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.delenv("POWER_RERANKER_DEVICE", raising=False)
+        monkeypatch.setenv("POWER_EMBED_DEVICE", " CUDA ")
+        assert embeddings.requested_device("POWER_RERANKER_DEVICE") == "cuda"
+        monkeypatch.setenv("POWER_RERANKER_DEVICE", "")
+        assert embeddings.requested_device("POWER_RERANKER_DEVICE") == "auto"
+
+    def test_failed_binding_does_not_retain_an_unsafe_embedder_session(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        class FakeOptions:
+            pass
+
+        class FakeSession:
+            def __init__(self, *args: object, **kwargs: object):
+                pass
+
+            @staticmethod
+            def get_providers():
+                return ["CPUExecutionProvider"]
+
+        fake_ort = ModuleType("onnxruntime")
+        fake_ort.SessionOptions = FakeOptions
+        fake_ort.InferenceSession = FakeSession
+        fake_ort.get_available_providers = lambda: [
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ]
+        fake_hub = ModuleType("huggingface_hub")
+        fake_hub.hf_hub_download = lambda *args, **kwargs: "unused-model-file"
+        fake_tokenizers = ModuleType("tokenizers")
+        fake_tokenizers.Tokenizer = object
+        monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+        monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+        monkeypatch.setitem(sys.modules, "tokenizers", fake_tokenizers)
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cuda")
+        monkeypatch.setenv("POWER_ALLOW_UNVERIFIED_MODELS", "1")
+
+        manager = embeddings.BGEM3OnnxManager(repo="example/repo", revision="dev")
+        with pytest.raises(RuntimeError, match="requested_onnx_provider_not_bound"):
+            manager.embed("provider probe")
+        assert manager._session is None
+        assert manager.active_provider is None


### PR DESCRIPTION
## Summary

Refines #236 against current main and makes the documented explicit-device contract verify the provider actually bound by InferenceSession.

- preload pip-owned ONNX Runtime DLLs before provider discovery when supported
- resolve provider spelling case-insensitively, including ROCm
- verify the first runtime-bound provider for embedding and reranker sessions
- fail closed on explicit CUDA/ROCm/DirectML/CPU mismatch or empty binding; keep auto CPU fallback
- expose active_provider for diagnostics and document both device variables
- add Windows CI provider-selection canary without claiming GPU availability

## Validation

- 784 passed, 10 skipped: .venv/bin/python -m pytest --no-cov -q
- 56 provider/reranker tests passed
- Ruff, MyPy (40 source files), compileall, doc-drift, release-contract and git diff checks passed
- local ONNX Runtime canary selected CPU from available Azure/CPU providers

GitHub Windows CI validates the CPU/auto path; physical CUDA binding on an RTX host remains a field/runtime gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable ONNX device selection for embeddings and reranking, including CPU, CUDA, ROCm, and DirectML support.
  - Added automatic CPU fallback when accelerator selection is set to `auto`.
  - Added verification that the requested execution provider is actually active.

- **Bug Fixes**
  - Prevented unsafe startup when explicitly requested GPU providers are unavailable.
  - Improved GPU runtime library loading and provider name handling.

- **Documentation**
  - Documented device configuration, provider behavior, troubleshooting, and Windows GPU setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->