### PR TITLE
fix(skill): refresh the bundled skill and extend the doc-drift gate to cover it

### DIFF
--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -54,6 +54,7 @@ HIERARCHICAL = REPO_ROOT / "docs" / "hierarchical-index-migration.md"
 HIERARCHICAL_UA = REPO_ROOT / "docs" / "hierarchical-index-migration.ua.md"
 INVENTORY_UA = REPO_ROOT / "docs" / "documentation-inventory.ua.md"
 AGENT_INSTRUCTIONS = REPO_ROOT / ".agents" / "AGENTS.md"
+AGENT_SKILL = REPO_ROOT / "skills" / "power" / "SKILL.md"
 CURRENT_DOCUMENTS = {
     "README": README,
     "README.ua": README_UA,
@@ -73,6 +74,7 @@ CURRENT_DOCUMENTS = {
     "Hierarchical report UA": HIERARCHICAL_UA,
     "Documentation inventory UA": INVENTORY_UA,
     "Agent instructions": AGENT_INSTRUCTIONS,
+    "Agent skill": AGENT_SKILL,
 }
 
 # Canonical provider -> the human-readable token(s) the README MUST contain to
@@ -297,6 +299,31 @@ def check_interfaces(documents: dict[str, str], facts: dict[str, Any]) -> list[s
             errors.append(f"{label} does not declare all {len(mcp_tools)} MCP tools.")
     if f"{len(mcp_tools)} tools" not in documents["Agent instructions"]:
         errors.append(f"Agent instructions do not declare `{len(mcp_tools)} tools`.")
+
+    # The bundled skill is what an agent actually loads, so it drifts with the
+    # same consequences as the reference docs and is checked the same way.
+    skill = documents["Agent skill"]
+    if f"{len(mcp_tools)} tools" not in skill and f"MCP Tools ({len(mcp_tools)})" not in skill:
+        errors.append(f"Agent skill does not declare `{len(mcp_tools)} tools`.")
+    # The skill is authored in Ukrainian, so match the count next to the "CLI"
+    # marker rather than an English noun.
+    if not re.search(rf"CLI[^\n]*\b{len(cli_commands)}\b", skill):
+        errors.append(f"Agent skill does not declare all {len(cli_commands)} CLI commands.")
+    errors.extend(
+        f"Agent skill is missing executable tool `{tool}`."
+        for tool in mcp_tools
+        if f"`{tool}`" not in skill
+    )
+    # Pin the frontmatter field itself: "3.3.2 appears somewhere in the body"
+    # would still pass while the declared skill version rots.
+    if not re.search(rf"^version:\s*{re.escape(facts['version'])}\s*$", skill, re.M):
+        errors.append(f"Agent skill frontmatter does not declare version {facts['version']}.")
+    for pattern, description in {
+        r"/root/": "absolute path from a foreign machine",
+        r"POWER_VAULT_PATH": "legacy MCP vault variable",
+    }.items():
+        if re.search(pattern, skill):
+            errors.append(f"Agent skill contains a forbidden {description}.")
     return errors
 
 

--- a/skills/power/SKILL.md
+++ b/skills/power/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: power
-version: 3.2.7
+version: 3.3.2
 description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + OKF v0.1 + Graph RAG + LLM-Wiki + Execution Rules).
 ---
 
@@ -28,46 +28,41 @@ description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + O
 
 Скілл містить автоматизовані скрипти у каталозі `scripts/` та CLI:
 
-### Scripts
-
-1.  **`lint_brain.py`** — скрипт лінтера + ROT аудиту (v3.2.7):
-
-```bash
-python3 .agents/skills/power/scripts/lint_brain.py
-```
-
-2.  **`generate_index.py`** — скрипт автоматичної побудови ієрархічного індексу:
-
-```bash
-python3 .agents/skills/power/scripts/generate_index.py
-```
-
-### CLI (power, 15 команд)
+### CLI (power, 17 команд)
 
 1. `power init <path>` — створити структуру vault
 2. `power lint <path>` — перевірка метаданих, посилань, orphan
-3. `power index <path>` — генерація ієрархічного індексу
+3. `power index <path> [--strict]` — генерація рекурсивних каталогів
 4. `power ingest <path>` — створення нотатки з OKF метаданими
-5. `power search <path> <query>` — повнотекстовий пошук
-6. `power sync <path>` — побудова FTS і dense-індексу
-7. `power rot <path>` — ROT аудит (дублікати, застарілі, тривіальні)
-8. `power archive <path>` — архівування застарілих нотаток
-9. `power status <path>` — панель стану vault
-10. `power cron <path>` — автоматичне обслуговування
-11. `power heal <path>` — автовиправлення frontmatter
-12. `power markdown-check <path>` — перевірка якості Markdown
-13. `power suggest-related <path>` — пропозиції зв'язків Graph RAG
-14. `power synthesize <path>` — створення підсумкової нотатки сесії
-15. `power rename <path> --old <old_path> --new <new_path>` — перейменування нотатки з оновленням зв'язків Graph RAG
+5. `power import <source> --into <folder>` — préflight-імпорт наявного дерева Markdown
+6. `power search <path> <query>` — пошук (`semantic` за замовчуванням)
+7. `power memory <sub> <path>` — керована транзакційна пам'ять
+8. `power sync <path> [--fts-only] [--strict|--allow-partial]` — побудова індексу пошуку
+9. `power rot <path>` — ROT аудит (дублікати, застарілі, тривіальні)
+10. `power archive <path>` — архівування застарілих нотаток
+11. `power status <path>` — панель стану vault
+12. `power cron <path>` — автоматичне обслуговування
+13. `power heal <path>` — автовиправлення frontmatter
+14. `power markdown-check <path>` — перевірка якості Markdown
+15. `power suggest-related <path>` — пропозиції зв'язків Graph RAG
+16. `power synthesize <path>` — створення підсумкової нотатки сесії
+17. `power rename <path> --old <old> --new <new>` — перейменування з оновленням зв'язків
 
-### MCP Tools (12) — FastMCP 3.x (v3.2.7)
+### MCP Tools (18) — FastMCP 3.x (v3.3.2)
 
-- `lint_vault`, `generate_index`, `read_sub_index`, `ensure_sub_index`, `ingest_note`
-- `search_vault_tool`, `synthesize_session`
-- `rot_audit`, `archive_notes`, `suggest_related_tool`
-- `heal_frontmatter_tool`, `check_markdown_tool`
+- Індекси й каталог: `generate_index`, `read_sub_index`, `ensure_sub_index`
+- Запис: `ingest_note`, `synthesize_session`
+- Пошук: `search_vault_tool`, `sync_vault`, `suggest_related_tool`
+- Здоров'я: `lint_vault`, `heal_frontmatter_tool`, `check_markdown_tool`
+- Обслуговування: `rot_audit`, `archive_notes`
+- Керована пам'ять: `get_memory_context`, `propose_memory_change`,
+  `apply_memory_change`, `validate_memory_state`, `read_memory_history`
 
-### Конфігурація (v3.2.7)
+**Записав нотатку — виклич `sync_vault`.** `ingest_note` і `synthesize_session`
+оновлюють ієрархічний каталог, але база пошуку — окремий артефакт: доти
+`search_vault_tool` щойно збережену нотатку не поверне.
+
+### Конфігурація (v3.3.2)
 
 - **Модель ембеддінгів** — канонічно `BAAI/bge-m3` (1024 dim) через direct ONNX Runtime. BGE-M3 natively підтримує **dense + sparse + ColBERT** в одній моделі, що дозволяє гібридний пошук (RRF) без окремого BM25. Провайдер змінюється через `POWER_EMBED_PROVIDER`; `fastembed`/MiniLM лишається полегшеним opt-in fallback.
 - **Реранкер за замовчуванням** — `onnx-community/bge-reranker-v2-m3-ONNX` (SHA-pinned, Apache-2.0, UA+EN). `jinaai/jina-reranker-v2-base-multilingual` (CC-BY-NC) лишається явним opt-in.
@@ -77,7 +72,12 @@ python3 .agents/skills/power/scripts/generate_index.py
   - `POWER_EMBED_COMMIT_EVERY` (за замовчуванням `50`) — частота збереження векторів у SQLite для зниження навантаження на диск.
   - `POWER_SYNC_VMEM_LIMIT_MB` (за замовчуванням `0` = вимкнено) — опціональний ліміт віртуальної пам'яті (RLIMIT_AS) процесу синхронізації.
 - **ROT аудит (A2)** — паралельна перевірка посилань через `ThreadPoolExecutor(max_workers=16)`.
-- **MCP ентрі-поінт** — `/root/geminicli/.agents/mcp_servers/power_server.py` → `power_framework.mcp`
+- **MCP ентрі-поінт** — `python -m power_framework.mcp`, запущений тим самим
+  інтерпретатором, у якому встановлено пакет; `POWER_VAULT_DIR` обов'язковий
+  і задає єдиний доступний vault.
+- **Пристрій ONNX** — `POWER_EMBED_DEVICE` / `POWER_RERANKER_DEVICE`
+  (`auto`, `cpu`, `cuda`, `rocm`, `directml`). `auto` може лягти на CPU;
+  явний прискорювач fail-closed, якщо сесія не прив'язала запитаний провайдер.
 
 ---
 
@@ -138,7 +138,7 @@ timestamp: YYYY-MM-DDTHH:MM:SS+TZ
 Після додавання/зміни файлу виконайте скрипт генерації індексу. Він автоматично оновить `index.md`, рекурсивні `_index.md` каталоги та сторінки `_index-N.md` у межах 32 KiB:
 
 ```bash
-python3 .agents/skills/power/scripts/generate_index.py
+power lint <path>
 ```
 
 ### Крок 3. Додавання запису у Change Log
@@ -157,7 +157,7 @@ python3 .agents/skills/power/scripts/generate_index.py
 Запустіть скрипт лінтера, щоб перевірити, чи не з'явилися нові биті посилання чи сторінки-сироти:
 
 ```bash
-python3 .agents/skills/power/scripts/lint_brain.py
+power lint <path>
 ```
 
 _Якщо лінтер звітує про помилки (наприклад, broken links у Home.md), негайно виправте їх._


### PR DESCRIPTION
Closes the last open item of #242.

## Problem

`skills/power/SKILL.md` is what an agent actually loads, and it had drifted
further than any reference document:

| In the skill | Reality on main |
|---|---|
| `version: 3.2.7` | 3.3.2 |
| `MCP Tools (12)` | 18 |
| CLI list of 15 | 17 — missing `import` and `memory` |
| `python3 .agents/skills/power/scripts/lint_brain.py` | no such path in this repo |
| `/root/geminicli/.agents/mcp_servers/power_server.py` | absolute path from a foreign machine |

The cause is mechanical rather than editorial: `check_doc_drift.py` covers
README, the docs tree and `.agents/AGENTS.md`, but never looked at `skills/`.
The one document that steers agent behaviour was the only one with no gate.

## Change

**Gate first.** Adding `skills/power/SKILL.md` to `CURRENT_DOCUMENTS` and
asserting the same contracts you already enforce elsewhere immediately produced
ten concrete errors — including six MCP tools the skill had never mentioned
(`sync_vault` and the five memory tools):

```
- Agent skill does not declare `18 tools`.
- Agent skill does not declare all 17 CLI commands.
- Agent skill is missing executable tool `sync_vault`.
- Agent skill is missing executable tool `get_memory_context`.
  ... 4 more ...
- Agent skill does not declare the current version 3.3.2.
- Agent skill contains a forbidden absolute path from a foreign machine.
```

**Then the content:** 17 CLI commands including `import`/`memory`, all 18 MCP
tools grouped by purpose, `POWER_EMBED_DEVICE` / `POWER_RERANKER_DEVICE`
semantics, and an explicit "write a note → call `sync_vault`" note, because
`ingest_note` alone leaves the note unsearchable.

One deliberate detail: the CLI-count assertion matches the number beside the
`CLI` marker rather than an English noun, since this skill is authored in
Ukrainian. Making the gate language-agnostic seemed better than bending the
skill's prose to fit a regex.

## Mutation-checked

Every new rule was verified to fail when violated: lowering the tool count,
renaming a tool, removing the CLI count, restoring the `/root/` path, and
reverting the frontmatter version each produce exactly the corresponding error.

The version rule needed a second pass — my first form checked "the version
string appears somewhere in the file", which still passed while the frontmatter
rotted, because `3.3.2` also occurs in section headings. It now pins the
frontmatter field itself.

## Checks

```
ruff check / format       All checks passed! / 113 files already formatted
mypy src/power_framework  Success: no issues found in 40 source files
check_doc_drift.py        passed
verify_release_contract.py passed
pytest tests/ -q          789 passed, 14 skipped, 3 failed
```

The three failures are the pre-existing Windows path-separator issue in
`tests/test_healer.py` on current main — unrelated to this change, reported and
fixed in #255.
