### PR TITLE
fix(sync): refuse --fts-only when it would discard an existing dense index

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -173,14 +173,18 @@ Build the active search generation atomically.
 
 ```text
 power sync PATH [--fts-only] [--force] [--strict | --allow-partial]
+                [--accept-dense-loss]
 ```
 
 | Flag | Description |
 | --- | --- |
 | `--fts-only` | Build the lightweight FTS index and skip embeddings. |
+| `--accept-dense-loss` | Allow `--fts-only` to replace an existing dense index. Without it, such a run is refused. |
 | `--force` | Force a full dense rebuild, for example after a model/dimension change. |
 | `--strict` | Explicitly select the default fail-closed coverage policy; the command exits non-zero when notes are excluded. |
 | `--allow-partial` | Explicitly accept excluded notes, continue with a warning, and exit zero with the complete path/reason receipt. Mutually exclusive with `--strict`. |
+
+An `--fts-only` run publishes a generation with zero chunks. When sources changed, that generation supersedes a dense one and every dense search mode then fails, so `--fts-only` is refused on a vault that already has an active dense index unless `--accept-dense-loss` is passed.
 
 Every sync prints scanned, indexed and excluded note counts plus deterministic
 exclusion reasons. Full sync downloads and validates the pinned embedding assets

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -389,6 +389,26 @@ def _cmd_sync(args: argparse.Namespace) -> int:
 
     sync_embeddings = not getattr(args, "fts_only", False)
 
+    # An --fts-only run publishes a generation with zero chunks. When sources
+    # changed, that generation SUPERSEDES a dense one, and every dense search
+    # mode starts failing with DenseIndexUnavailableError — a working vault is
+    # downgraded by a flag whose name promises only to skip work.
+    if not sync_embeddings and not getattr(args, "accept_dense_loss", False):
+        existing_chunks = _active_chunk_count(vault_dir)
+        if existing_chunks:
+            logger.error(
+                "Refusing --fts-only: this vault has an active dense index (%d chunks). "
+                "Rebuilding FTS-only would replace it with a chunkless generation and "
+                "break semantic, hybrid and reranked search.",
+                existing_chunks,
+            )
+            logger.error(
+                "Run 'power sync %s' to keep dense search, or pass --accept-dense-loss "
+                "to discard the embeddings deliberately.",
+                vault_dir,
+            )
+            return 1
+
     # v2.2.0 low-RAM guard: cap the address space so an over-sized embedding
     # batch cannot trigger the kernel OOM-killer and take down the host. This is
     # an OPT-IN backstop (default 0 = disabled) because some backends (e.g.
@@ -464,6 +484,26 @@ def _cmd_sync(args: argparse.Namespace) -> int:
         if not allow_partial:
             return 1
     return 0
+
+
+def _active_chunk_count(vault_dir: Path) -> int:
+    """Return the chunk count of the active generation, 0 when there is none."""
+    import sqlite3
+    from contextlib import closing
+
+    from .generation_index import IndexGenerationError, resolve_active_generation_path
+
+    try:
+        active = resolve_active_generation_path(vault_dir)
+    except IndexGenerationError:
+        return 0
+    if active is None or not active.is_file():
+        return 0
+    try:
+        with closing(sqlite3.connect(f"file:{active.as_posix()}?mode=ro", uri=True)) as conn:
+            return int(conn.execute("SELECT COUNT(*) FROM chunk_embeddings").fetchone()[0])
+    except sqlite3.Error:
+        return 0
 
 
 def _cmd_rot(args: argparse.Namespace) -> int:
@@ -862,6 +902,15 @@ def main() -> None:
         action="store_true",
         default=False,
         help="Only build the lightweight FTS index (skip embedding generation)",
+    )
+    p_sync.add_argument(
+        "--accept-dense-loss",
+        action="store_true",
+        default=False,
+        help=(
+            "Allow --fts-only to replace an existing dense index, discarding "
+            "embeddings and disabling semantic/hybrid/reranked search"
+        ),
     )
     p_sync.add_argument(
         "--force",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -626,3 +626,80 @@ def test_ingest_duplicate_returns_1(tmp_path: Path) -> None:
     ):
         main()
     assert exc2.value.code == 1
+
+
+class TestFtsOnlyDenseGuard:
+    """`--fts-only` must not silently discard an existing dense index.
+
+    Reproduced on a real vault: an fts-only refresh after editing notes replaced
+    a 19 893-chunk generation with a chunkless one, and every dense search mode
+    then raised DenseIndexUnavailableError.
+    """
+
+    NOTE = (
+        '---\ntype: Resource\ntitle: "N"\ndescription: "note"\n'
+        "timestamp: 2026-01-01T00:00:00\n---\n\n{body}\n"
+    )
+
+    @staticmethod
+    def _sync(vault, *, fts_only, accept_dense_loss=False):
+        import argparse
+
+        from power_framework.core.cli import _cmd_sync
+
+        return _cmd_sync(
+            argparse.Namespace(
+                path=str(vault),
+                fts_only=fts_only,
+                force=False,
+                strict=False,
+                allow_partial=True,
+                accept_dense_loss=accept_dense_loss,
+            )
+        )
+
+    def _vault_with_dense(self, tmp_path):
+        import argparse
+
+        from power_framework.core.cli import _cmd_init
+
+        vault = tmp_path / "vault"
+        _cmd_init(argparse.Namespace(path=str(vault)))
+        note = vault / "03_Resources" / "n.md"
+        note.write_text(self.NOTE.format(body="Body one."), encoding="utf-8")
+        self._sync(vault, fts_only=False)
+        return vault, note
+
+    def test_fts_only_refuses_to_discard_an_existing_dense_index(self, tmp_path, caplog):
+        import logging
+
+        from power_framework.core.cli import _active_chunk_count
+
+        vault, note = self._vault_with_dense(tmp_path)
+        assert _active_chunk_count(vault) > 0
+
+        note.write_text(self.NOTE.format(body="Body EDITED."), encoding="utf-8")
+        with caplog.at_level(logging.INFO):
+            assert self._sync(vault, fts_only=True) == 1
+        assert any("Refusing --fts-only" in r.getMessage() for r in caplog.records)
+        assert _active_chunk_count(vault) > 0, "the dense index must survive a refusal"
+
+    def test_explicit_opt_in_still_allows_the_downgrade(self, tmp_path):
+        from power_framework.core.cli import _active_chunk_count
+
+        vault, note = self._vault_with_dense(tmp_path)
+        note.write_text(self.NOTE.format(body="Body EDITED."), encoding="utf-8")
+        assert self._sync(vault, fts_only=True, accept_dense_loss=True) == 0
+        assert _active_chunk_count(vault) == 0
+
+    def test_fts_only_is_unaffected_when_there_is_no_dense_index(self, tmp_path):
+        import argparse
+
+        from power_framework.core.cli import _cmd_init
+
+        vault = tmp_path / "fresh"
+        _cmd_init(argparse.Namespace(path=str(vault)))
+        (vault / "03_Resources" / "n.md").write_text(
+            self.NOTE.format(body="Body."), encoding="utf-8"
+        )
+        assert self._sync(vault, fts_only=True) == 0


### PR DESCRIPTION
## Problem

An `--fts-only` run publishes a generation with **zero chunks**. When sources
changed, that generation supersedes the dense one — and every dense search mode
then fails with `DenseIndexUnavailableError`.

A flag whose name promises only to *skip work* silently destroys embeddings
that a full sync just spent minutes, or on CPU hours, producing.

## Reproduction

On current `main`, before this change:

```
dense sync                 -> chunk_embeddings = 1
edit one note, --fts-only  -> chunk_embeddings = 0
```

The edit is the condition. With no changed sources the sync is a no-op and the
generation survives — which is exactly why this is easy to miss. My first
reproduction attempt found nothing for that reason.

I found it the expensive way: an automated refresh saw a busy GPU, fell back to
`--fts-only` as a courtesy, and turned a 19 893-chunk index into a chunkless
one. Semantic search was dead until a full 742 s rebuild.

## Change

`--fts-only` is refused when the vault has an active dense index:

```
Refusing --fts-only: this vault has an active dense index (19893 chunks).
Rebuilding FTS-only would replace it with a chunkless generation and break
semantic, hybrid and reranked search.
Run 'power sync <vault>' to keep dense search, or pass --accept-dense-loss
to discard the embeddings deliberately.
```

`--accept-dense-loss` makes the downgrade an explicit choice rather than a side
effect. A vault with **no** dense index is unaffected, so the documented "fast
lexical index on a fresh vault" workflow keeps working exactly as before.

This follows the posture #253 established for devices: an explicit request that
would silently degrade capability fails closed instead.

## Tests

- refusal leaves the dense index intact
- `--accept-dense-loss` still performs the downgrade
- a vault without embeddings is untouched

Both behaviours mutation-checked — removing the guard and ignoring the opt-in
each fail exactly one test.

## Checks

CI is `action_required` for fork contributors, so I ran the workflow steps
locally on Windows 11:

```
pytest tests/ -q          792 passed, 14 skipped, 3 failed
ruff check / format       All checks passed!
mypy src/power_framework  Success: no issues found in 40 source files
check_doc_drift.py        passed
verify_release_contract.py passed
```

The three failures are the pre-existing Windows path-separator issue in
`tests/test_healer.py` on current main — unrelated, reported and fixed in #255.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `--accept-dense-loss` option to explicitly allow replacing dense search data with an FTS-only index.
  * FTS-only syncs now warn and stop when an active dense index would be discarded unless this option is provided.

* **Bug Fixes**
  * Prevented accidental loss of dense search data during synchronization.

* **Documentation**
  * Documented the new option and FTS-only synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->