### PR TITLE
fix(index): count navigation links when bounding catalog pages

### DIFF
--- a/src/power_framework/core/indexer.py
+++ b/src/power_framework/core/indexer.py
@@ -586,13 +586,17 @@ def _generate_catalog_pages(
     if not blocks:
         pages.append([])
     else:
-        # The largest possible page number is a safe upper bound for navigation
-        # overhead; the actual page count can only be smaller after partitioning.
+        # Upper bound for navigation overhead. The page number must be both
+        # greater than 1 and less than the page count, otherwise the probe drops
+        # the "Previous" or "Next" link that a real middle page carries and the
+        # bound is short by the width of a whole element -- wider page *numbers*
+        # do not compensate for a missing *link*.
         page_hint = len(blocks)
+        count_hint = page_hint + 1
         current: list[str] = []
         for block in blocks:
             candidate = [*current, block]
-            rendered = _render_catalog_page(folder, candidate, page_hint, page_hint)
+            rendered = _render_catalog_page(folder, candidate, page_hint, count_hint)
             if len(rendered.encode("utf-8")) <= max_bytes:
                 current = candidate
                 continue
@@ -602,7 +606,7 @@ def _generate_catalog_pages(
                 )
             pages.append(current)
             current = [block]
-            single = _render_catalog_page(folder, current, page_hint, page_hint)
+            single = _render_catalog_page(folder, current, page_hint, count_hint)
             if len(single.encode("utf-8")) > max_bytes:
                 raise ValueError(
                     f"catalog_entry_exceeds_limit:{folder}:{len(block.encode('utf-8'))}"

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -532,6 +532,39 @@ class TestRunGenerateHierarchicalIndex:
         assert all(len(content.encode("utf-8")) <= 32 * 1024 for content in pages.values())
         assert sum(content.count("- **Path:**") for content in pages.values()) == 10_000
 
+    def test_variable_width_catalog_stays_bounded(self):
+        # The uniform-size profile above never lands a page within the width of
+        # one navigation link, so it stays green while the bound is short. Real
+        # vaults have variable titles; sweeping the limit shifts where pages
+        # break and reaches the boundary deterministically.
+        notes = [
+            {
+                "rel_path": f"03_Resources/wiki/batch/Note {index}.md",
+                "title": "N" * (1 + index % 37),
+                "description": "d" * (1 + index % 53),
+                "note_type": "Resource",
+                "tags": [],
+                "timestamp": "2026-01-01",
+                "filename": f"Note {index}.md",
+                "owner": "",
+                "status": "",
+                "expiry": "",
+                "related": [],
+            }
+            for index in range(400)
+        ]
+
+        for max_bytes in range(2048, 2048 + 96):
+            pages = _generate_catalog_pages(
+                "03_Resources/wiki/batch", notes, max_bytes=max_bytes
+            )
+            oversized = {
+                name: len(content.encode("utf-8"))
+                for name, content in pages.items()
+                if len(content.encode("utf-8")) > max_bytes
+            }
+            assert not oversized, f"max_bytes={max_bytes} produced {oversized}"
+
     def test_main_index_links_to_sub_indexes(self, sample_vault: Path):
         run_generate_hierarchical_index(sample_vault)
         main_index = sample_vault / "index.md"


### PR DESCRIPTION
`power index` crashes with an uncaught `ValueError` on a real vault, and the
traceback is the only output — stdout is empty, so the CLI just exits 1.

```
$ power index ~/Documents/NOX-Vault --strict
ValueError: catalog_page_exceeds_limit:03_Resources/_index-27.md:32784
```

2 848 notes, `INDEX_MAX_BYTES = 32768`, so the page is **16 bytes** over. The
consequence is that `--strict` never reaches its own check, and the catalog
pages silently stop being regenerated — mine were 3 hours stale before I looked
at the exit code rather than the search results.

### Cause

`_generate_catalog_pages` packs blocks by measuring each candidate as

```python
rendered = _render_catalog_page(folder, candidate, page_hint, page_hint)
```

with `page == page_count`. In that configuration `_catalog_navigation` takes the
page for the last one and omits the `[Next]` link:

```python
if page < page_count:
    links.append(f"[Next](<./{_catalog_page_filename(page + 1)}>)")
```

Every real middle page has one. Measured on a single page, `page_hint`/`page_hint`
renders **17 bytes below** what page 27 of 42 actually renders — which lines up
with the 16-byte overflow above.

The comment says the hint is a safe upper bound because "the actual page count
can only be smaller after partitioning". That is true of the page *numbers* and
not of the *set of links*: widening `2848` to `27 of 42` saves a few digits, but
dropping `[Next]` costs an entire element.

### Fix

Probe with `page_count = page_hint + 1`, so the candidate page is neither first
nor last and both links are rendered at maximum width. One token; the same hint
is reused for the lone-block re-check a few lines below.

### Why CI is green today

`test_large_catalog_renderer_profile_is_bounded` builds 10 000 notes of
identical width, so page breaks land at a fixed offset and never within one
link's width of the limit. Real vaults have variable titles and descriptions.

The added test keeps that shape but varies title and description length and
sweeps `max_bytes` across a 96-byte range, so the boundary is reached
deterministically rather than by luck:

```
# on main
E   ValueError: catalog_page_exceeds_limit:03_Resources/wiki/batch/_index-22.md:2051
# with the fix
1 passed
```

### Verification

`uv run pytest tests/ -q` → **790 passed, 14 skipped, 3 failed**. The three
failures are `tests/test_healer.py` path separators on Windows, pre-existing on
`4f669d5` and unrelated to this change — same ones reported in #255.

### Trade-off

The bound is now conservative by roughly 30–50 bytes out of 32 KiB. A single
block landing inside that margin is rejected as `catalog_entry_exceeds_limit`
instead of being emitted as a lone oversized page; that path already raised for
blocks over the limit, so this only shifts where the line sits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog pagination sizing to correctly account for navigation links, preventing generated pages from exceeding configured byte limits.
  * Fixed rendering behavior for catalogs with variable-length titles and descriptions across different page-size limits.

* **Tests**
  * Added regression coverage validating catalog pages remain within their configured maximum size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->