### PR TITLE
fix(index): complete 3.4.0 catalog boundary contract

### DIFF
--- a/src/power_framework/core/indexer.py
+++ b/src/power_framework/core/indexer.py
@@ -586,13 +586,17 @@ def _generate_catalog_pages(
     if not blocks:
         pages.append([])
     else:
-        # The largest possible page number is a safe upper bound for navigation
-        # overhead; the actual page count can only be smaller after partitioning.
+        # Upper bound for navigation overhead. The page number must be both
+        # greater than 1 and less than the page count, otherwise the probe drops
+        # the "Previous" or "Next" link that a real middle page carries and the
+        # bound is short by the width of a whole element -- wider page *numbers*
+        # do not compensate for a missing *link*.
         page_hint = len(blocks)
+        count_hint = page_hint + 1
         current: list[str] = []
         for block in blocks:
             candidate = [*current, block]
-            rendered = _render_catalog_page(folder, candidate, page_hint, page_hint)
+            rendered = _render_catalog_page(folder, candidate, page_hint, count_hint)
             if len(rendered.encode("utf-8")) <= max_bytes:
                 current = candidate
                 continue
@@ -602,7 +606,7 @@ def _generate_catalog_pages(
                 )
             pages.append(current)
             current = [block]
-            single = _render_catalog_page(folder, current, page_hint, page_hint)
+            single = _render_catalog_page(folder, current, page_hint, count_hint)
             if len(single.encode("utf-8")) > max_bytes:
                 raise ValueError(
                     f"catalog_entry_exceeds_limit:{folder}:{len(block.encode('utf-8'))}"

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -532,6 +532,39 @@ class TestRunGenerateHierarchicalIndex:
         assert all(len(content.encode("utf-8")) <= 32 * 1024 for content in pages.values())
         assert sum(content.count("- **Path:**") for content in pages.values()) == 10_000
 
+    def test_variable_width_catalog_stays_bounded(self):
+        # The uniform-size profile above never lands a page within the width of
+        # one navigation link, so it stays green while the bound is short. Real
+        # vaults have variable titles; sweeping the limit shifts where pages
+        # break and reaches the boundary deterministically.
+        notes = [
+            {
+                "rel_path": f"03_Resources/wiki/batch/Note {index}.md",
+                "title": "N" * (1 + index % 37),
+                "description": "d" * (1 + index % 53),
+                "note_type": "Resource",
+                "tags": [],
+                "timestamp": "2026-01-01",
+                "filename": f"Note {index}.md",
+                "owner": "",
+                "status": "",
+                "expiry": "",
+                "related": [],
+            }
+            for index in range(400)
+        ]
+
+        for max_bytes in range(2048, 2048 + 96):
+            pages = _generate_catalog_pages(
+                "03_Resources/wiki/batch", notes, max_bytes=max_bytes
+            )
+            oversized = {
+                name: len(content.encode("utf-8"))
+                for name, content in pages.items()
+                if len(content.encode("utf-8")) > max_bytes
+            }
+            assert not oversized, f"max_bytes={max_bytes} produced {oversized}"
+
     def test_main_index_links_to_sub_indexes(self, sample_vault: Path):
         run_generate_hierarchical_index(sample_vault)
         main_index = sample_vault / "index.md"

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -555,15 +555,37 @@ class TestRunGenerateHierarchicalIndex:
         ]
 
         for max_bytes in range(2048, 2048 + 96):
-            pages = _generate_catalog_pages(
-                "03_Resources/wiki/batch", notes, max_bytes=max_bytes
-            )
+            pages = _generate_catalog_pages("03_Resources/wiki/batch", notes, max_bytes=max_bytes)
             oversized = {
                 name: len(content.encode("utf-8"))
                 for name, content in pages.items()
                 if len(content.encode("utf-8")) > max_bytes
             }
             assert not oversized, f"max_bytes={max_bytes} produced {oversized}"
+
+    def test_10k_variable_width_catalog_stays_bounded(self):
+        notes = [
+            {
+                "rel_path": f"03_Resources/wiki/batch/Note {index}.md",
+                "title": "N" * (1 + index % 37),
+                "description": "d" * (1 + index % 53),
+                "note_type": "Resource",
+                "tags": [],
+                "timestamp": "2026-01-01",
+                "filename": f"Note {index}.md",
+                "owner": "",
+                "status": "",
+                "expiry": "",
+                "related": [],
+            }
+            for index in range(10_000)
+        ]
+
+        pages = _generate_catalog_pages("03_Resources/wiki/batch", notes)
+
+        assert pages
+        assert all(len(content.encode("utf-8")) <= 32 * 1024 for content in pages.values())
+        assert sum(content.count("- **Path:**") for content in pages.values()) == 10_000
 
     def test_main_index_links_to_sub_indexes(self, sample_vault: Path):
         run_generate_hierarchical_index(sample_vault)


### PR DESCRIPTION
## What changed

This maintainer branch carries the verified fix from #260 and adds the missing
3.4.0 acceptance coverage:

- catalog sizing probes reserve both navigation links;
- the variable-width regression is formatter-clean;
- a 10,000-note variable-width fixture verifies the default 32 KiB bound;
- generated pages remain within the byte limit and retain all note entries.

## Root cause

The old sizing probe rendered a candidate as the last page, omitting the
Previous/Next navigation shape that a real middle page can contain. The probe
therefore underestimated the page size and could publish a catalog page above
the configured limit.

## Validation

- base origin/main reproduces the defect at the 10,000-note boundary;
- PR head passes the 400-note sweep and the 10,000-note default-limit test;
- pytest tests/: 798 passed, 10 skipped, 80.75% coverage;
- ruff check src tests scripts;
- ruff format --check src tests scripts;
- mypy src/power_framework;
- documentation drift and release-contract checks;
- benchmark integrity: 111 passed, 1 skipped;
- pip-audit --skip-editable: no known vulnerabilities;
- wheel/sdist build and isolated package smoke: passed.

Supersedes the untrusted fork workflow state of #260 by adding the maintainer
acceptance test and running repository CI from an in-repository branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog pagination to reserve space for navigation controls, preserving consistent page layouts.
  * Ensured generated catalog pages remain within configured size limits, including catalogs with variable-length titles and descriptions.

* **Tests**
  * Added coverage for pagination boundary conditions and large catalogs containing up to 10,000 notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->