### PR TITLE
fix(sync): enforce dense-loss policy across all sync paths

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -173,14 +173,18 @@ Build the active search generation atomically.
 
 ```text
 power sync PATH [--fts-only] [--force] [--strict | --allow-partial]
+                [--accept-dense-loss]
 ```
 
 | Flag | Description |
 | --- | --- |
 | `--fts-only` | Build the lightweight FTS index and skip embeddings. |
+| `--accept-dense-loss` | Allow `--fts-only` to replace an existing dense index. Without it, such a run is refused. |
 | `--force` | Force a full dense rebuild, for example after a model/dimension change. |
 | `--strict` | Explicitly select the default fail-closed coverage policy; the command exits non-zero when notes are excluded. |
 | `--allow-partial` | Explicitly accept excluded notes, continue with a warning, and exit zero with the complete path/reason receipt. Mutually exclusive with `--strict`. |
+
+An `--fts-only` run publishes a generation with zero chunks. When sources changed, that generation supersedes a dense one and every dense search mode then fails, so `--fts-only` is refused on a vault that already has an active dense index unless `--accept-dense-loss` is passed.
 
 Every sync prints scanned, indexed and excluded note counts plus deterministic
 exclusion reasons. Full sync downloads and validates the pinned embedding assets

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -112,6 +112,7 @@ calls per minute.
 ```text
 sync_vault(
   fts_only: boolean = true,
+  accept_dense_loss: boolean = false,
   force_rebuild: boolean = false,
   allow_partial: boolean = false,
   vault_path?: string
@@ -125,6 +126,11 @@ indexed, excluded, and chunk counts plus exclusion reasons. Invalid notes fail
 closed by default and are named in the `ToolError`; `allow_partial=true` is an
 explicit request to publish only the valid subset. Dense search remains
 fail-closed until a compatible dense generation exists.
+
+If the vault already has an active dense index, an FTS-only sync is refused
+because source changes would discard that capability. Pass
+`accept_dense_loss=true` only when the agent or operator explicitly accepts
+losing semantic, hybrid, and reranked search until the next dense rebuild.
 
 ### 3. `read_sub_index`
 

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -389,26 +389,6 @@ def _cmd_sync(args: argparse.Namespace) -> int:
 
     sync_embeddings = not getattr(args, "fts_only", False)
 
-    # An --fts-only run publishes a generation with zero chunks. When sources
-    # changed, that generation SUPERSEDES a dense one, and every dense search
-    # mode starts failing with DenseIndexUnavailableError — a working vault is
-    # downgraded by a flag whose name promises only to skip work.
-    if not sync_embeddings and not getattr(args, "accept_dense_loss", False):
-        existing_chunks = _active_chunk_count(vault_dir)
-        if existing_chunks:
-            logger.error(
-                "Refusing --fts-only: this vault has an active dense index (%d chunks). "
-                "Rebuilding FTS-only would replace it with a chunkless generation and "
-                "break semantic, hybrid and reranked search.",
-                existing_chunks,
-            )
-            logger.error(
-                "Run 'power sync %s' to keep dense search, or pass --accept-dense-loss "
-                "to discard the embeddings deliberately.",
-                vault_dir,
-            )
-            return 1
-
     # v2.2.0 low-RAM guard: cap the address space so an over-sized embedding
     # batch cannot trigger the kernel OOM-killer and take down the host. This is
     # an OPT-IN backstop (default 0 = disabled) because some backends (e.g.
@@ -439,6 +419,7 @@ def _cmd_sync(args: argparse.Namespace) -> int:
         vault_dir,
     )
     force_rebuild = getattr(args, "force", False)
+    accept_dense_loss = getattr(args, "accept_dense_loss", False)
     try:
         report = execute_vault_mutation(
             vault_dir,
@@ -446,6 +427,7 @@ def _cmd_sync(args: argparse.Namespace) -> int:
                 vault_dir,
                 sync_embeddings=sync_embeddings,
                 force_rebuild=force_rebuild,
+                accept_dense_loss=accept_dense_loss,
             ),
         )
     except IndexGenerationError as exc:
@@ -484,26 +466,6 @@ def _cmd_sync(args: argparse.Namespace) -> int:
         if not allow_partial:
             return 1
     return 0
-
-
-def _active_chunk_count(vault_dir: Path) -> int:
-    """Return the chunk count of the active generation, 0 when there is none."""
-    import sqlite3
-    from contextlib import closing
-
-    from .generation_index import IndexGenerationError, resolve_active_generation_path
-
-    try:
-        active = resolve_active_generation_path(vault_dir)
-    except IndexGenerationError:
-        return 0
-    if active is None or not active.is_file():
-        return 0
-    try:
-        with closing(sqlite3.connect(f"file:{active.as_posix()}?mode=ro", uri=True)) as conn:
-            return int(conn.execute("SELECT COUNT(*) FROM chunk_embeddings").fetchone()[0])
-    except sqlite3.Error:
-        return 0
 
 
 def _cmd_rot(args: argparse.Namespace) -> int:

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -389,6 +389,26 @@ def _cmd_sync(args: argparse.Namespace) -> int:
 
     sync_embeddings = not getattr(args, "fts_only", False)
 
+    # An --fts-only run publishes a generation with zero chunks. When sources
+    # changed, that generation SUPERSEDES a dense one, and every dense search
+    # mode starts failing with DenseIndexUnavailableError — a working vault is
+    # downgraded by a flag whose name promises only to skip work.
+    if not sync_embeddings and not getattr(args, "accept_dense_loss", False):
+        existing_chunks = _active_chunk_count(vault_dir)
+        if existing_chunks:
+            logger.error(
+                "Refusing --fts-only: this vault has an active dense index (%d chunks). "
+                "Rebuilding FTS-only would replace it with a chunkless generation and "
+                "break semantic, hybrid and reranked search.",
+                existing_chunks,
+            )
+            logger.error(
+                "Run 'power sync %s' to keep dense search, or pass --accept-dense-loss "
+                "to discard the embeddings deliberately.",
+                vault_dir,
+            )
+            return 1
+
     # v2.2.0 low-RAM guard: cap the address space so an over-sized embedding
     # batch cannot trigger the kernel OOM-killer and take down the host. This is
     # an OPT-IN backstop (default 0 = disabled) because some backends (e.g.
@@ -464,6 +484,26 @@ def _cmd_sync(args: argparse.Namespace) -> int:
         if not allow_partial:
             return 1
     return 0
+
+
+def _active_chunk_count(vault_dir: Path) -> int:
+    """Return the chunk count of the active generation, 0 when there is none."""
+    import sqlite3
+    from contextlib import closing
+
+    from .generation_index import IndexGenerationError, resolve_active_generation_path
+
+    try:
+        active = resolve_active_generation_path(vault_dir)
+    except IndexGenerationError:
+        return 0
+    if active is None or not active.is_file():
+        return 0
+    try:
+        with closing(sqlite3.connect(f"file:{active.as_posix()}?mode=ro", uri=True)) as conn:
+            return int(conn.execute("SELECT COUNT(*) FROM chunk_embeddings").fetchone()[0])
+    except sqlite3.Error:
+        return 0
 
 
 def _cmd_rot(args: argparse.Namespace) -> int:
@@ -862,6 +902,15 @@ def main() -> None:
         action="store_true",
         default=False,
         help="Only build the lightweight FTS index (skip embedding generation)",
+    )
+    p_sync.add_argument(
+        "--accept-dense-loss",
+        action="store_true",
+        default=False,
+        help=(
+            "Allow --fts-only to replace an existing dense index, discarding "
+            "embeddings and disabling semantic/hybrid/reranked search"
+        ),
     )
     p_sync.add_argument(
         "--force",

--- a/src/power_framework/core/generation_index.py
+++ b/src/power_framework/core/generation_index.py
@@ -370,6 +370,24 @@ def resolve_active_generation_path(vault_dir: Path) -> Path | None:
     return _verified_generation_path(root, generation_id, str(db_sha256), int(db_size))
 
 
+def active_dense_chunk_count(vault_dir: Path) -> int:
+    """Return active dense chunk count, failing closed on unreadable state."""
+    active = resolve_active_generation_path(vault_dir)
+    database = active or vault_db_path(vault_dir)
+    if not database.is_file():
+        return 0
+    try:
+        with closing(
+            sqlite3.connect(f"file:{database.as_posix()}?mode=ro", uri=True, timeout=30)
+        ) as conn:
+            row = conn.execute("SELECT COUNT(*) FROM chunk_embeddings").fetchone()
+    except sqlite3.Error as exc:
+        raise ActiveGenerationError("active generation dense state is unreadable") from exc
+    if row is None:
+        raise ActiveGenerationError("active generation dense state returned no count")
+    return int(row[0])
+
+
 def _cleanup_generations(vault_dir: Path) -> None:
     """Best-effort retention, called only after an active-generation readback."""
     with closing(sqlite3.connect(_state_db_path(vault_dir), timeout=30)) as conn:
@@ -583,6 +601,7 @@ def sync_vault_atomically(
     sync_embeddings: bool,
     force_rebuild: bool = False,
     allow_partial: bool = True,
+    accept_dense_loss: bool = False,
 ) -> GenerationReport:
     """Build a complete staged generation and atomically publish it on success.
 
@@ -590,9 +609,19 @@ def sync_vault_atomically(
     before a new generation is staged. The default remains permissive for the
     low-level compatibility API; CLI and MCP callers expose explicit
     fail-closed policy at their user-facing boundaries.
+    ``accept_dense_loss=True`` is required to replace an active dense
+    generation with an FTS-only generation.
     """
     root = Path(vault_dir).expanduser().resolve()
     ensure_vault_identity(root)
+    if not sync_embeddings and not accept_dense_loss:
+        existing_chunks = active_dense_chunk_count(root)
+        if existing_chunks:
+            raise IndexGenerationError(
+                "Refusing --fts-only: the vault has an active dense index "
+                f"({existing_chunks} chunks). Pass accept_dense_loss=True "
+                "to explicitly discard the embeddings (CLI: --accept-dense-loss)."
+            )
     inventory = _source_inventory(root)
     if inventory.invalid_sources and not allow_partial:
         details = "; ".join(

--- a/src/power_framework/mcp/power_server.py
+++ b/src/power_framework/mcp/power_server.py
@@ -179,6 +179,7 @@ async def generate_index(vault_path: str | None = None) -> str:
 @mcp.tool
 async def sync_vault(
     fts_only: bool = True,
+    accept_dense_loss: bool = False,
     force_rebuild: bool = False,
     allow_partial: bool = False,
     vault_path: str | None = None,
@@ -194,6 +195,8 @@ async def sync_vault(
     without downloading or loading an embedding model. Set ``fts_only=False``
     for the dense index and ``force_rebuild=True`` after changing the embedding
     model or dimension. Invalid notes fail closed unless ``allow_partial=True``.
+    When ``fts_only=True`` would discard an active dense index, the call fails
+    closed unless ``accept_dense_loss=True`` is explicit.
     """
     if not _index_limiter.is_allowed("sync_vault"):
         remaining = _index_limiter.remaining("sync_vault")
@@ -227,6 +230,7 @@ async def sync_vault(
                 sync_embeddings=not fts_only,
                 force_rebuild=force_rebuild,
                 allow_partial=allow_partial,
+                accept_dense_loss=accept_dense_loss,
             )
         except IndexGenerationError as exc:
             raise ToolError(f"Vault sync failed; previous index remains active: {exc}") from exc

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -673,24 +673,24 @@ class TestFtsOnlyDenseGuard:
     def test_fts_only_refuses_to_discard_an_existing_dense_index(self, tmp_path, caplog):
         import logging
 
-        from power_framework.core.cli import _active_chunk_count
+        from power_framework.core.generation_index import active_dense_chunk_count
 
         vault, note = self._vault_with_dense(tmp_path)
-        assert _active_chunk_count(vault) > 0
+        assert active_dense_chunk_count(vault) > 0
 
         note.write_text(self.NOTE.format(body="Body EDITED."), encoding="utf-8")
         with caplog.at_level(logging.INFO):
             assert self._sync(vault, fts_only=True) == 1
         assert any("Refusing --fts-only" in r.getMessage() for r in caplog.records)
-        assert _active_chunk_count(vault) > 0, "the dense index must survive a refusal"
+        assert active_dense_chunk_count(vault) > 0, "the dense index must survive a refusal"
 
     def test_explicit_opt_in_still_allows_the_downgrade(self, tmp_path):
-        from power_framework.core.cli import _active_chunk_count
+        from power_framework.core.generation_index import active_dense_chunk_count
 
         vault, note = self._vault_with_dense(tmp_path)
         note.write_text(self.NOTE.format(body="Body EDITED."), encoding="utf-8")
         assert self._sync(vault, fts_only=True, accept_dense_loss=True) == 0
-        assert _active_chunk_count(vault) == 0
+        assert active_dense_chunk_count(vault) == 0
 
     def test_fts_only_is_unaffected_when_there_is_no_dense_index(self, tmp_path):
         import argparse

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -626,3 +626,80 @@ def test_ingest_duplicate_returns_1(tmp_path: Path) -> None:
     ):
         main()
     assert exc2.value.code == 1
+
+
+class TestFtsOnlyDenseGuard:
+    """`--fts-only` must not silently discard an existing dense index.
+
+    Reproduced on a real vault: an fts-only refresh after editing notes replaced
+    a 19 893-chunk generation with a chunkless one, and every dense search mode
+    then raised DenseIndexUnavailableError.
+    """
+
+    NOTE = (
+        '---\ntype: Resource\ntitle: "N"\ndescription: "note"\n'
+        "timestamp: 2026-01-01T00:00:00\n---\n\n{body}\n"
+    )
+
+    @staticmethod
+    def _sync(vault, *, fts_only, accept_dense_loss=False):
+        import argparse
+
+        from power_framework.core.cli import _cmd_sync
+
+        return _cmd_sync(
+            argparse.Namespace(
+                path=str(vault),
+                fts_only=fts_only,
+                force=False,
+                strict=False,
+                allow_partial=True,
+                accept_dense_loss=accept_dense_loss,
+            )
+        )
+
+    def _vault_with_dense(self, tmp_path):
+        import argparse
+
+        from power_framework.core.cli import _cmd_init
+
+        vault = tmp_path / "vault"
+        _cmd_init(argparse.Namespace(path=str(vault)))
+        note = vault / "03_Resources" / "n.md"
+        note.write_text(self.NOTE.format(body="Body one."), encoding="utf-8")
+        self._sync(vault, fts_only=False)
+        return vault, note
+
+    def test_fts_only_refuses_to_discard_an_existing_dense_index(self, tmp_path, caplog):
+        import logging
+
+        from power_framework.core.cli import _active_chunk_count
+
+        vault, note = self._vault_with_dense(tmp_path)
+        assert _active_chunk_count(vault) > 0
+
+        note.write_text(self.NOTE.format(body="Body EDITED."), encoding="utf-8")
+        with caplog.at_level(logging.INFO):
+            assert self._sync(vault, fts_only=True) == 1
+        assert any("Refusing --fts-only" in r.getMessage() for r in caplog.records)
+        assert _active_chunk_count(vault) > 0, "the dense index must survive a refusal"
+
+    def test_explicit_opt_in_still_allows_the_downgrade(self, tmp_path):
+        from power_framework.core.cli import _active_chunk_count
+
+        vault, note = self._vault_with_dense(tmp_path)
+        note.write_text(self.NOTE.format(body="Body EDITED."), encoding="utf-8")
+        assert self._sync(vault, fts_only=True, accept_dense_loss=True) == 0
+        assert _active_chunk_count(vault) == 0
+
+    def test_fts_only_is_unaffected_when_there_is_no_dense_index(self, tmp_path):
+        import argparse
+
+        from power_framework.core.cli import _cmd_init
+
+        vault = tmp_path / "fresh"
+        _cmd_init(argparse.Namespace(path=str(vault)))
+        (vault / "03_Resources" / "n.md").write_text(
+            self.NOTE.format(body="Body."), encoding="utf-8"
+        )
+        assert self._sync(vault, fts_only=True) == 0

--- a/tests/test_generation_index.py
+++ b/tests/test_generation_index.py
@@ -412,3 +412,44 @@ def test_chunk_identity_is_content_addressed_and_path_independent() -> None:
     assert first != changed_source
     assert first != changed_section
     assert "::chunk_" not in first
+
+
+def test_library_fts_only_requires_explicit_dense_loss_acceptance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The shared library boundary must enforce the same fail-closed policy as CLI/MCP."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    vault = _vault(tmp_path, "library-guard", "stable-token")
+    sync_vault_atomically(vault, sync_embeddings=False)
+
+    from power_framework.core import generation_index
+
+    monkeypatch.setattr(generation_index, "active_dense_chunk_count", lambda _: 7)
+    with pytest.raises(IndexGenerationError, match=r"Refusing --fts-only.*7 chunks"):
+        sync_vault_atomically(vault, sync_embeddings=False)
+
+    report = sync_vault_atomically(vault, sync_embeddings=False, accept_dense_loss=True)
+    assert report.actual_files == 1
+
+
+def test_legacy_dense_state_is_also_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pre-generation dense DBs must not bypass the downgrade guard during migration."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    vault = _vault(tmp_path, "legacy-guard", "legacy-token")
+    legacy = vault_db_path(vault)
+    with closing(sqlite3.connect(legacy)) as conn:
+        _init_db(conn)
+        conn.execute(
+            "INSERT INTO chunk_embeddings(chunk_id, rel_path, embedding, content, mtime) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("legacy", "01_Projects/Test.md", b"\\x00\\x00\\x80?", "legacy", 0.0),
+        )
+        conn.commit()
+
+    from power_framework.core.generation_index import active_dense_chunk_count
+
+    assert active_dense_chunk_count(vault) == 1
+    with pytest.raises(IndexGenerationError, match=r"Refusing --fts-only.*1 chunks"):
+        sync_vault_atomically(vault, sync_embeddings=False)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -305,6 +305,21 @@ async def test_sync_vault_fails_closed_and_can_explicitly_allow_partial(
     assert "not searchable" in report
 
 
+async def test_sync_vault_dense_loss_requires_explicit_acceptance(
+    sample_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MCP must expose the shared dense-loss refusal and explicit opt-in."""
+    from power_framework.core import generation_index
+
+    monkeypatch.setattr(power_server._index_limiter, "is_allowed", lambda _: True)
+    monkeypatch.setattr(generation_index, "active_dense_chunk_count", lambda _: 3)
+    with pytest.raises(ToolError, match=r"Refusing --fts-only.*3 chunks"):
+        await sync_vault(fts_only=True, vault_path=str(sample_vault))
+
+    report = await sync_vault(fts_only=True, accept_dense_loss=True, vault_path=str(sample_vault))
+    assert "Mode: FTS only" in report
+
+
 async def test_synthesize_session_serializes_write_and_stores_candidate_triplets(
     sample_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Supersedes the contributor-side implementation in #259 with the same user-facing
fail-closed contract enforced in the shared generation core.

A dense index must not be silently discarded by an FTS-only sync. The explicit
opt-in is now available consistently as:

- CLI: `--accept-dense-loss`
- MCP: `accept_dense_loss=true`
- Python/library: `accept_dense_loss=True`

Unreadable active state fails closed instead of being treated as zero dense
chunks. Legacy pre-generation `search.db` is covered before migration too.

## Verification

- `804 passed, 10 skipped`, coverage `80.99%`
- focused dense-loss parity: 6 passed
- Ruff check and format
- MyPy (40 source files)
- documentation drift and release contract
- benchmark manifest
- pip-audit
- wheel/sdist build and exact package smoke (16 queries)

The branch carries contributor commit `691fbed` and maintainer hardening commit
`ca9d917`.
