### PR TITLE
fix(healer): normalize failure paths on Windows

### DIFF
--- a/src/power_framework/core/healer.py
+++ b/src/power_framework/core/healer.py
@@ -68,6 +68,11 @@ class HealValidationError(ValueError):
     """Raised when an existing frontmatter block cannot be parsed safely."""
 
 
+def _report_path(path: Path) -> str:
+    """Render a vault-relative path with stable POSIX separators."""
+    return path.as_posix()
+
+
 @dataclass(frozen=True)
 class HealFailure:
     """One note that could not be healed, including the failed operation."""
@@ -388,7 +393,9 @@ def heal_vault_report(
             content = read_file_content(filepath)
         except Exception as exc:
             logger.warning("Cannot read %s: %s: %s", rel, type(exc).__name__, exc)
-            report.failures.append(HealFailure(str(rel), "read", type(exc).__name__, str(exc)))
+            report.failures.append(
+                HealFailure(_report_path(rel), "read", type(exc).__name__, str(exc))
+            )
             continue
         if not content.strip():
             continue
@@ -398,12 +405,14 @@ def heal_vault_report(
         except HealValidationError as exc:
             logger.warning("Cannot validate %s: %s", rel, exc)
             report.failures.append(
-                HealFailure(str(rel), "validation", type(exc).__name__, str(exc))
+                HealFailure(_report_path(rel), "validation", type(exc).__name__, str(exc))
             )
             continue
         except Exception as exc:
             logger.warning("Cannot heal %s: %s: %s", rel, type(exc).__name__, exc)
-            report.failures.append(HealFailure(str(rel), "transform", type(exc).__name__, str(exc)))
+            report.failures.append(
+                HealFailure(_report_path(rel), "transform", type(exc).__name__, str(exc))
+            )
             continue
         if not changes:
             continue
@@ -418,14 +427,16 @@ def heal_vault_report(
             except Exception as exc:
                 logger.warning("Cannot back up %s: %s: %s", rel, type(exc).__name__, exc)
                 report.failures.append(
-                    HealFailure(str(rel), "backup", type(exc).__name__, str(exc))
+                    HealFailure(_report_path(rel), "backup", type(exc).__name__, str(exc))
                 )
                 continue
             try:
                 atomic_write(filepath, healed)
             except Exception as exc:
                 logger.warning("Cannot write %s: %s: %s", rel, type(exc).__name__, exc)
-                report.failures.append(HealFailure(str(rel), "write", type(exc).__name__, str(exc)))
+                report.failures.append(
+                    HealFailure(_report_path(rel), "write", type(exc).__name__, str(exc))
+                )
                 continue
 
         report.healed += 1

--- a/tests/test_healer.py
+++ b/tests/test_healer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -11,6 +11,7 @@ from power_framework.core.cli import _cmd_heal
 from power_framework.core.healer import (
     _extract_first_paragraph,
     _infer_title_from_filename,
+    _report_path,
     heal_frontmatter,
     heal_vault,
     heal_vault_report,
@@ -233,6 +234,13 @@ def test_heal_report_isolates_transform_failures_and_returns_nonzero(
     assert "No notes needed healing" not in report.format()
     assert "type: Project" in good.read_text(encoding="utf-8")
     assert "type: Project" not in bad.read_text(encoding="utf-8")
+
+
+def test_heal_failure_paths_use_posix_separators_on_windows() -> None:
+    """Failure receipts remain portable when the vault runs on Windows."""
+    rel = PureWindowsPath(r"01_Projects\unreadable.md")
+
+    assert _report_path(rel) == "01_Projects/unreadable.md"
 
 
 def test_heal_report_isolates_invalid_frontmatter_as_validation_failure(tmp_path: Path):


### PR DESCRIPTION
## Scope

Follow-up to #255: promotes only the narrow Windows healer contract. The `power doctor` portion of #255 remains separate and is not included here.

## Change

- render all `HealFailure.path` values with stable POSIX separators;
- cover the contract with an explicit `PureWindowsPath` regression;
- preserve the existing per-note isolation and failure stages.

## Validation

- focused healer suite: 29 passed;
- full suite: 805 passed, 10 skipped, coverage 80.99%;
- Ruff check/format and MyPy passed;
- doc-drift and release-contract checks passed;
- benchmark manifest, pip-audit, wheel/sdist build and exact package smoke (16 queries) passed;
- signed commit: `9585a09`.

Physical Windows execution remains a repository CI gate; this patch models the Windows path contract directly and leaves the broader doctor design out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved healing failure reports by consistently using normalized POSIX-style paths.
  * Fixed path handling for Windows-style file paths across validation, transformation, backup, and write error reporting.

* **Tests**
  * Added regression coverage to verify consistent path formatting on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->