### PR TITLE
fix(docs): enforce agent skill contract across copies

### DIFF
--- a/.agents/skills/power/SKILL.md
+++ b/.agents/skills/power/SKILL.md
@@ -28,44 +28,39 @@ description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + O
 
 Скілл містить автоматизовані скрипти у каталозі `scripts/` та CLI:
 
-### Scripts
-
-1.  **`lint_brain.py`** — скрипт лінтера + ROT аудиту (v3.3.2):
-
-```bash
-python3 .agents/skills/power/scripts/lint_brain.py
-```
-
-2.  **`generate_index.py`** — скрипт автоматичної побудови ієрархічного індексу:
-
-```bash
-python3 .agents/skills/power/scripts/generate_index.py
-```
-
-### CLI (power, 15 команд)
+### CLI (power, 17 команд)
 
 1. `power init <path>` — створити структуру vault
 2. `power lint <path>` — перевірка метаданих, посилань, orphan
-3. `power index <path>` — генерація ієрархічного індексу
+3. `power index <path> [--strict]` — генерація рекурсивних каталогів
 4. `power ingest <path>` — створення нотатки з OKF метаданими
-5. `power search <path> <query>` — повнотекстовий пошук
-6. `power sync <path>` — побудова FTS і dense-індексу
-7. `power rot <path>` — ROT аудит (дублікати, застарілі, тривіальні)
-8. `power archive <path>` — архівування застарілих нотаток
-9. `power status <path>` — панель стану vault
-10. `power cron <path>` — автоматичне обслуговування
-11. `power heal <path>` — автовиправлення frontmatter
-12. `power markdown-check <path>` — перевірка якості Markdown
-13. `power suggest-related <path>` — пропозиції зв'язків Graph RAG
-14. `power synthesize <path>` — створення підсумкової нотатки сесії
-15. `power rename <path> --old <old_path> --new <new_path>` — перейменування нотатки з оновленням зв'язків Graph RAG
+5. `power import <source> --into <folder>` — preflight-імпорт наявного дерева Markdown
+6. `power search <path> <query>` — пошук (`semantic` за замовчуванням)
+7. `power memory <sub> <path>` — керована транзакційна пам'ять
+8. `power sync <path> [--fts-only] [--accept-dense-loss] [--strict|--allow-partial]` — побудова індексу пошуку
+9. `power rot <path>` — ROT аудит (дублікати, застарілі, тривіальні)
+10. `power archive <path>` — архівування застарілих нотаток
+11. `power status <path>` — панель стану vault
+12. `power cron <path>` — автоматичне обслуговування
+13. `power heal <path>` — автовиправлення frontmatter
+14. `power markdown-check <path>` — перевірка якості Markdown
+15. `power suggest-related <path>` — пропозиції зв'язків Graph RAG
+16. `power synthesize <path>` — створення підсумкової нотатки сесії
+17. `power rename <path> --old <old> --new <new>` — перейменування з оновленням зв'язків
 
-### MCP Tools (12) — FastMCP 3.x (v3.3.2)
+### MCP Tools (18) — FastMCP 3.x (v3.3.2)
 
-- `lint_vault`, `generate_index`, `read_sub_index`, `ensure_sub_index`, `ingest_note`
-- `search_vault_tool`, `synthesize_session`
-- `rot_audit`, `archive_notes`, `suggest_related_tool`
-- `heal_frontmatter_tool`, `check_markdown_tool`
+- Індекси й каталог: `generate_index`, `read_sub_index`, `ensure_sub_index`
+- Запис: `ingest_note`, `synthesize_session`
+- Пошук: `search_vault_tool`, `sync_vault`, `suggest_related_tool`
+- Здоров'я: `lint_vault`, `heal_frontmatter_tool`, `check_markdown_tool`
+- Обслуговування: `rot_audit`, `archive_notes`
+- Керована пам'ять: `get_memory_context`, `propose_memory_change`,
+  `apply_memory_change`, `validate_memory_state`, `read_memory_history`
+
+**Записав нотатку — виклич `sync_vault`.** `ingest_note` і `synthesize_session`
+оновлюють ієрархічний каталог, але база пошуку — окремий артефакт: доти
+`search_vault_tool` щойно збережену нотатку не поверне.
 
 ### Конфігурація (v3.3.2)
 
@@ -77,7 +72,12 @@ python3 .agents/skills/power/scripts/generate_index.py
   - `POWER_EMBED_COMMIT_EVERY` (за замовчуванням `50`) — частота збереження векторів у SQLite для зниження навантаження на диск.
   - `POWER_SYNC_VMEM_LIMIT_MB` (за замовчуванням `0` = вимкнено) — опціональний ліміт віртуальної пам'яті (RLIMIT_AS) процесу синхронізації.
 - **ROT аудит (A2)** — паралельна перевірка посилань через `ThreadPoolExecutor(max_workers=16)`.
-- **MCP ентрі-поінт** — `/root/geminicli/.agents/mcp_servers/power_server.py` → `power_framework.mcp`
+- **MCP ентрі-поінт** — `python -m power_framework.mcp`, запущений тим самим
+  інтерпретатором, у якому встановлено пакет; `POWER_VAULT_DIR` обов'язковий
+  і задає єдиний доступний vault.
+- **Пристрій ONNX** — `POWER_EMBED_DEVICE` / `POWER_RERANKER_DEVICE`
+  (`auto`, `cpu`, `cuda`, `rocm`, `directml`). `auto` може лягти на CPU;
+  явний прискорювач fail-closed, якщо сесія не прив'язала запитаний провайдер.
 
 ---
 
@@ -89,7 +89,7 @@ P.O.W.E.R. використовує **ієрархічну індексацію*
 vault/
 ├── index.md              # Navigation map (small, ~2KB)
 ├── 01_Projects/
-│   └── _index.md         # Detailed entries for Projects
+│   └── _index.md         # Detailed entries; nested folders have their own catalogs
 ├── 02_Areas/
 │   └── _index.md         # Detailed entries for Areas
 ├── 03_Resources/
@@ -110,7 +110,7 @@ vault/
 | --------------------------------- | ---------- | --------------------- |
 | Read all `.md` files              | 🔴 ~50K+   | Full but wasteful     |
 | Read only `index.md`              | 🟢 ~2K     | Insufficient          |
-| `index.md` + relevant `_index.md` | 🟡 ~5-8K   | **Optimal balance**   |
+| `index.md` + relevant catalog pages | 🟡 bounded | **Read only the needed page; each generated page is ≤32 KiB** |
 | + specific notes                  | 🟡 ~10-15K | **Precise, targeted** |
 
 ---
@@ -135,10 +135,12 @@ timestamp: YYYY-MM-DDTHH:MM:SS+TZ
 
 ### Крок 2. Автоматична генерація ієрархічного каталогу (Index)
 
-Після додавання/зміни файлу виконайте скрипт генерації індексу. Він автоматично оновить `index.md` та всі `_index.md` файли:
+Після додавання/зміни файлу виконайте генерацію індексу. Вона автоматично
+оновить `index.md`, рекурсивні `_index.md` каталоги та сторінки `_index-N.md`
+у межах 32 KiB:
 
 ```bash
-python3 .agents/skills/power/scripts/generate_index.py
+power index <path>
 ```
 
 ### Крок 3. Додавання запису у Change Log
@@ -157,7 +159,7 @@ python3 .agents/skills/power/scripts/generate_index.py
 Запустіть скрипт лінтера, щоб перевірити, чи не з'явилися нові биті посилання чи сторінки-сироти:
 
 ```bash
-python3 .agents/skills/power/scripts/lint_brain.py
+power lint <path>
 ```
 
 _Якщо лінтер звітує про помилки (наприклад, broken links у Home.md), негайно виправте їх._

--- a/README.ua.md
+++ b/README.ua.md
@@ -29,7 +29,7 @@ P.O.W.E.R. — це гібридна система, створена для п�
 - **Knowledge Graph** — поле `related` зв'язує нотатки між собою для Graph RAG
 - **Freshness Monitoring** — лінтер виявляє застарілі нотатки за полем `expiry`
 - **Agent Auto-Ingest** — MCP інструмент `synthesize_session` для автономного створення нотаток агентами з governance + graph links + index
-- **MCP-нативний** — 17 інструментів доступні MCP-сумісним AI-клієнтам через FastMCP 3.x
+- **MCP-нативний** — 18 інструментів доступні MCP-сумісним AI-клієнтам через FastMCP 3.x
 - **Windows-safe rename** — `power rename` використовує `os.replace()` для
   фізичного переміщення, тому перейменування на існуючу ціль працює у Windows
   замість помилки `FileExistsError`
@@ -99,7 +99,7 @@ venv interpreter, troubleshooting, rollback і uninstall.
 | Функція                          | Що робить                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **CLI**                          | 17 команд, включно з `power import` для preflighted Markdown migration та `power memory` для явного proposal, approval, validation та history                                                                                                                                                                                                                                                                                                                                     |
-| **MCP Server**                   | 17 інструментів, включно з керованими операціями memory context, proposal, apply, validation та history                                                                                                                                                                                                                                                                                                                                                                              |
+| **MCP Server**                   | 18 інструментів, включно з керованими операціями memory context, proposal, apply, validation та history                                                                                                                                                                                                                                                                                                                                                                              |
 | **OKF Validation**               | Pydantic v2 схеми забезпечують строгі OKF-метадані на кожній нотатці з governance-полями (`owner`, `status`, `expiry`)                                                                                                                                                                                                                                                                                                                                                               |
 | **Knowledge Graph (Graph RAG)**  | Поле `related` в OKF frontmatter з підтримкою `TypedRelation` (path, relation, confidence), BFS обходом та експортом підграфів у Mermaid-діаграми (`to_mermaid`)                                                                                                                                                                                                                                                                                                                     |
 | **Freshness Monitoring**         | Лінтер виявляє застарілі нотатки за полем `expiry`                                                                                                                                                                                                                                                                                                                                                                                                                                   |
@@ -406,7 +406,7 @@ flowchart TD
     end
 
     subgraph AI ["🤖 AI-Агент (FastMCP 3.x)"]
-        Tools[["🔌 17 асинхронних інструментів MCP"]]:::agent
+        Tools[["🔌 18 асинхронних інструментів MCP"]]:::agent
         Search[["🔍 Гібридний / Reranked пошук"]]:::agent
         ROT{{"🛠️ Аудит ROT та суперечностей (Semantic/LLM)"}}:::agent
     end

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -55,6 +55,7 @@ HIERARCHICAL_UA = REPO_ROOT / "docs" / "hierarchical-index-migration.ua.md"
 INVENTORY_UA = REPO_ROOT / "docs" / "documentation-inventory.ua.md"
 AGENT_INSTRUCTIONS = REPO_ROOT / ".agents" / "AGENTS.md"
 AGENT_SKILL = REPO_ROOT / "skills" / "power" / "SKILL.md"
+WORKSPACE_AGENT_SKILL = REPO_ROOT / ".agents" / "skills" / "power" / "SKILL.md"
 CURRENT_DOCUMENTS = {
     "README": README,
     "README.ua": README_UA,
@@ -75,6 +76,7 @@ CURRENT_DOCUMENTS = {
     "Documentation inventory UA": INVENTORY_UA,
     "Agent instructions": AGENT_INSTRUCTIONS,
     "Agent skill": AGENT_SKILL,
+    "Workspace agent skill": WORKSPACE_AGENT_SKILL,
 }
 
 # Canonical provider -> the human-readable token(s) the README MUST contain to
@@ -292,38 +294,80 @@ def check_interfaces(documents: dict[str, str], facts: dict[str, Any]) -> list[s
         if f"`{tool}`" not in documents["MCP"]
     )
 
-    for label in ("README", "Docs index"):
-        if not re.search(rf"(?:all )?{len(cli_commands)} .*commands", documents[label], re.I):
+    for label in ("README", "README.ua", "Docs index"):
+        cli_count = re.search(rf"(?:all )?{len(cli_commands)} .*commands", documents[label], re.I)
+        cli_count = cli_count or f"{len(cli_commands)} команд" in documents[label]
+        if not cli_count:
             errors.append(f"{label} does not declare all {len(cli_commands)} CLI commands.")
-        if not re.search(rf"{len(mcp_tools)} .*tools", documents[label], re.I):
+        mcp_count = re.search(rf"{len(mcp_tools)} .*tools", documents[label], re.I)
+        mcp_count = mcp_count or f"{len(mcp_tools)} інструмент" in documents[label]
+        if not mcp_count:
             errors.append(f"{label} does not declare all {len(mcp_tools)} MCP tools.")
+        if label == "README.ua" and re.search(
+            rf"\b(?!{len(mcp_tools)}\b)\d+ інструмент", documents[label]
+        ):
+            errors.append(f"{label} contains a stale MCP tools count.")
     if f"{len(mcp_tools)} tools" not in documents["Agent instructions"]:
         errors.append(f"Agent instructions do not declare `{len(mcp_tools)} tools`.")
 
-    # The bundled skill is what an agent actually loads, so it drifts with the
-    # same consequences as the reference docs and is checked the same way.
-    skill = documents["Agent skill"]
+    for label in ("Agent skill", "Workspace agent skill"):
+        errors.extend(
+            _check_agent_skill(
+                label,
+                documents[label],
+                cli_commands,
+                mcp_tools,
+                facts["version"],
+            )
+        )
+    return errors
+
+
+def _check_agent_skill(
+    label: str,
+    skill: str,
+    cli_commands: tuple[str, ...],
+    mcp_tools: tuple[str, ...],
+    version: str,
+) -> list[str]:
+    """Check every agent-loaded skill copy against the executable contract."""
+    errors: list[str] = []
+    prefix = f"{label}"
+    cli_section = skill.split("### MCP Tools", 1)[0]
+    mcp_section = skill.split("### MCP Tools", 1)[1].split("**Записав", 1)[0]
     if f"{len(mcp_tools)} tools" not in skill and f"MCP Tools ({len(mcp_tools)})" not in skill:
-        errors.append(f"Agent skill does not declare `{len(mcp_tools)} tools`.")
-    # The skill is authored in Ukrainian, so match the count next to the "CLI"
-    # marker rather than an English noun.
+        errors.append(f"{prefix} does not declare `{len(mcp_tools)} tools`.")
     if not re.search(rf"CLI[^\n]*\b{len(cli_commands)}\b", skill):
-        errors.append(f"Agent skill does not declare all {len(cli_commands)} CLI commands.")
+        errors.append(f"{prefix} does not declare all {len(cli_commands)} CLI commands.")
     errors.extend(
-        f"Agent skill is missing executable tool `{tool}`."
-        for tool in mcp_tools
-        if f"`{tool}`" not in skill
+        f"{prefix} is missing executable CLI command `power {command}`."
+        for command in cli_commands
+        if f"`power {command}" not in cli_section
     )
-    # Pin the frontmatter field itself: "3.3.2 appears somewhere in the body"
-    # would still pass while the declared skill version rots.
-    if not re.search(rf"^version:\s*{re.escape(facts['version'])}\s*$", skill, re.M):
-        errors.append(f"Agent skill frontmatter does not declare version {facts['version']}.")
+    errors.extend(
+        f"{prefix} is missing executable tool `{tool}`."
+        for tool in mcp_tools
+        if f"`{tool}`" not in mcp_section
+    )
+    if not re.search(rf"^version:\s*{re.escape(version)}\s*$", skill, re.M):
+        errors.append(f"{prefix} frontmatter does not declare version {version}.")
     for pattern, description in {
         r"/root/": "absolute path from a foreign machine",
         r"POWER_VAULT_PATH": "legacy MCP vault variable",
     }.items():
         if re.search(pattern, skill):
-            errors.append(f"Agent skill contains a forbidden {description}.")
+            errors.append(f"{prefix} contains a forbidden {description}.")
+    for pattern, description, marker in (
+        (r"### Крок 2.*?```bash\s*power index\b", "index command", "power index"),
+        (r"### Крок 4.*?```bash\s*power lint\b", "lint command", "power lint"),
+        (
+            r"power sync[^\n]*--accept-dense-loss",
+            "explicit dense-loss policy",
+            "--accept-dense-loss",
+        ),
+    ):
+        if not re.search(pattern, skill, re.DOTALL):
+            errors.append(f"{prefix} is missing the current {description} marker `{marker}`.")
     return errors
 
 

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -54,6 +54,7 @@ HIERARCHICAL = REPO_ROOT / "docs" / "hierarchical-index-migration.md"
 HIERARCHICAL_UA = REPO_ROOT / "docs" / "hierarchical-index-migration.ua.md"
 INVENTORY_UA = REPO_ROOT / "docs" / "documentation-inventory.ua.md"
 AGENT_INSTRUCTIONS = REPO_ROOT / ".agents" / "AGENTS.md"
+AGENT_SKILL = REPO_ROOT / "skills" / "power" / "SKILL.md"
 CURRENT_DOCUMENTS = {
     "README": README,
     "README.ua": README_UA,
@@ -73,6 +74,7 @@ CURRENT_DOCUMENTS = {
     "Hierarchical report UA": HIERARCHICAL_UA,
     "Documentation inventory UA": INVENTORY_UA,
     "Agent instructions": AGENT_INSTRUCTIONS,
+    "Agent skill": AGENT_SKILL,
 }
 
 # Canonical provider -> the human-readable token(s) the README MUST contain to
@@ -297,6 +299,31 @@ def check_interfaces(documents: dict[str, str], facts: dict[str, Any]) -> list[s
             errors.append(f"{label} does not declare all {len(mcp_tools)} MCP tools.")
     if f"{len(mcp_tools)} tools" not in documents["Agent instructions"]:
         errors.append(f"Agent instructions do not declare `{len(mcp_tools)} tools`.")
+
+    # The bundled skill is what an agent actually loads, so it drifts with the
+    # same consequences as the reference docs and is checked the same way.
+    skill = documents["Agent skill"]
+    if f"{len(mcp_tools)} tools" not in skill and f"MCP Tools ({len(mcp_tools)})" not in skill:
+        errors.append(f"Agent skill does not declare `{len(mcp_tools)} tools`.")
+    # The skill is authored in Ukrainian, so match the count next to the "CLI"
+    # marker rather than an English noun.
+    if not re.search(rf"CLI[^\n]*\b{len(cli_commands)}\b", skill):
+        errors.append(f"Agent skill does not declare all {len(cli_commands)} CLI commands.")
+    errors.extend(
+        f"Agent skill is missing executable tool `{tool}`."
+        for tool in mcp_tools
+        if f"`{tool}`" not in skill
+    )
+    # Pin the frontmatter field itself: "3.3.2 appears somewhere in the body"
+    # would still pass while the declared skill version rots.
+    if not re.search(rf"^version:\s*{re.escape(facts['version'])}\s*$", skill, re.M):
+        errors.append(f"Agent skill frontmatter does not declare version {facts['version']}.")
+    for pattern, description in {
+        r"/root/": "absolute path from a foreign machine",
+        r"POWER_VAULT_PATH": "legacy MCP vault variable",
+    }.items():
+        if re.search(pattern, skill):
+            errors.append(f"Agent skill contains a forbidden {description}.")
     return errors
 
 

--- a/skills/power/SKILL.md
+++ b/skills/power/SKILL.md
@@ -34,10 +34,10 @@ description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + O
 2. `power lint <path>` — перевірка метаданих, посилань, orphan
 3. `power index <path> [--strict]` — генерація рекурсивних каталогів
 4. `power ingest <path>` — створення нотатки з OKF метаданими
-5. `power import <source> --into <folder>` — préflight-імпорт наявного дерева Markdown
+5. `power import <source> --into <folder>` — preflight-імпорт наявного дерева Markdown
 6. `power search <path> <query>` — пошук (`semantic` за замовчуванням)
 7. `power memory <sub> <path>` — керована транзакційна пам'ять
-8. `power sync <path> [--fts-only] [--strict|--allow-partial]` — побудова індексу пошуку
+8. `power sync <path> [--fts-only] [--accept-dense-loss] [--strict|--allow-partial]` — побудова індексу пошуку
 9. `power rot <path>` — ROT аудит (дублікати, застарілі, тривіальні)
 10. `power archive <path>` — архівування застарілих нотаток
 11. `power status <path>` — панель стану vault
@@ -135,10 +135,12 @@ timestamp: YYYY-MM-DDTHH:MM:SS+TZ
 
 ### Крок 2. Автоматична генерація ієрархічного каталогу (Index)
 
-Після додавання/зміни файлу виконайте скрипт генерації індексу. Він автоматично оновить `index.md`, рекурсивні `_index.md` каталоги та сторінки `_index-N.md` у межах 32 KiB:
+Після додавання/зміни файлу виконайте генерацію індексу. Вона автоматично
+оновить `index.md`, рекурсивні `_index.md` каталоги та сторінки `_index-N.md`
+у межах 32 KiB:
 
 ```bash
-power lint <path>
+power index <path>
 ```
 
 ### Крок 3. Додавання запису у Change Log

--- a/skills/power/SKILL.md
+++ b/skills/power/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: power
-version: 3.2.7
+version: 3.3.2
 description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + OKF v0.1 + Graph RAG + LLM-Wiki + Execution Rules).
 ---
 
@@ -28,46 +28,41 @@ description: Maintains and validates the P.O.W.E.R. knowledge base (P.A.R.A. + O
 
 Скілл містить автоматизовані скрипти у каталозі `scripts/` та CLI:
 
-### Scripts
-
-1.  **`lint_brain.py`** — скрипт лінтера + ROT аудиту (v3.2.7):
-
-```bash
-python3 .agents/skills/power/scripts/lint_brain.py
-```
-
-2.  **`generate_index.py`** — скрипт автоматичної побудови ієрархічного індексу:
-
-```bash
-python3 .agents/skills/power/scripts/generate_index.py
-```
-
-### CLI (power, 15 команд)
+### CLI (power, 17 команд)
 
 1. `power init <path>` — створити структуру vault
 2. `power lint <path>` — перевірка метаданих, посилань, orphan
-3. `power index <path>` — генерація ієрархічного індексу
+3. `power index <path> [--strict]` — генерація рекурсивних каталогів
 4. `power ingest <path>` — створення нотатки з OKF метаданими
-5. `power search <path> <query>` — повнотекстовий пошук
-6. `power sync <path>` — побудова FTS і dense-індексу
-7. `power rot <path>` — ROT аудит (дублікати, застарілі, тривіальні)
-8. `power archive <path>` — архівування застарілих нотаток
-9. `power status <path>` — панель стану vault
-10. `power cron <path>` — автоматичне обслуговування
-11. `power heal <path>` — автовиправлення frontmatter
-12. `power markdown-check <path>` — перевірка якості Markdown
-13. `power suggest-related <path>` — пропозиції зв'язків Graph RAG
-14. `power synthesize <path>` — створення підсумкової нотатки сесії
-15. `power rename <path> --old <old_path> --new <new_path>` — перейменування нотатки з оновленням зв'язків Graph RAG
+5. `power import <source> --into <folder>` — préflight-імпорт наявного дерева Markdown
+6. `power search <path> <query>` — пошук (`semantic` за замовчуванням)
+7. `power memory <sub> <path>` — керована транзакційна пам'ять
+8. `power sync <path> [--fts-only] [--strict|--allow-partial]` — побудова індексу пошуку
+9. `power rot <path>` — ROT аудит (дублікати, застарілі, тривіальні)
+10. `power archive <path>` — архівування застарілих нотаток
+11. `power status <path>` — панель стану vault
+12. `power cron <path>` — автоматичне обслуговування
+13. `power heal <path>` — автовиправлення frontmatter
+14. `power markdown-check <path>` — перевірка якості Markdown
+15. `power suggest-related <path>` — пропозиції зв'язків Graph RAG
+16. `power synthesize <path>` — створення підсумкової нотатки сесії
+17. `power rename <path> --old <old> --new <new>` — перейменування з оновленням зв'язків
 
-### MCP Tools (12) — FastMCP 3.x (v3.2.7)
+### MCP Tools (18) — FastMCP 3.x (v3.3.2)
 
-- `lint_vault`, `generate_index`, `read_sub_index`, `ensure_sub_index`, `ingest_note`
-- `search_vault_tool`, `synthesize_session`
-- `rot_audit`, `archive_notes`, `suggest_related_tool`
-- `heal_frontmatter_tool`, `check_markdown_tool`
+- Індекси й каталог: `generate_index`, `read_sub_index`, `ensure_sub_index`
+- Запис: `ingest_note`, `synthesize_session`
+- Пошук: `search_vault_tool`, `sync_vault`, `suggest_related_tool`
+- Здоров'я: `lint_vault`, `heal_frontmatter_tool`, `check_markdown_tool`
+- Обслуговування: `rot_audit`, `archive_notes`
+- Керована пам'ять: `get_memory_context`, `propose_memory_change`,
+  `apply_memory_change`, `validate_memory_state`, `read_memory_history`
 
-### Конфігурація (v3.2.7)
+**Записав нотатку — виклич `sync_vault`.** `ingest_note` і `synthesize_session`
+оновлюють ієрархічний каталог, але база пошуку — окремий артефакт: доти
+`search_vault_tool` щойно збережену нотатку не поверне.
+
+### Конфігурація (v3.3.2)
 
 - **Модель ембеддінгів** — канонічно `BAAI/bge-m3` (1024 dim) через direct ONNX Runtime. BGE-M3 natively підтримує **dense + sparse + ColBERT** в одній моделі, що дозволяє гібридний пошук (RRF) без окремого BM25. Провайдер змінюється через `POWER_EMBED_PROVIDER`; `fastembed`/MiniLM лишається полегшеним opt-in fallback.
 - **Реранкер за замовчуванням** — `onnx-community/bge-reranker-v2-m3-ONNX` (SHA-pinned, Apache-2.0, UA+EN). `jinaai/jina-reranker-v2-base-multilingual` (CC-BY-NC) лишається явним opt-in.
@@ -77,7 +72,12 @@ python3 .agents/skills/power/scripts/generate_index.py
   - `POWER_EMBED_COMMIT_EVERY` (за замовчуванням `50`) — частота збереження векторів у SQLite для зниження навантаження на диск.
   - `POWER_SYNC_VMEM_LIMIT_MB` (за замовчуванням `0` = вимкнено) — опціональний ліміт віртуальної пам'яті (RLIMIT_AS) процесу синхронізації.
 - **ROT аудит (A2)** — паралельна перевірка посилань через `ThreadPoolExecutor(max_workers=16)`.
-- **MCP ентрі-поінт** — `/root/geminicli/.agents/mcp_servers/power_server.py` → `power_framework.mcp`
+- **MCP ентрі-поінт** — `python -m power_framework.mcp`, запущений тим самим
+  інтерпретатором, у якому встановлено пакет; `POWER_VAULT_DIR` обов'язковий
+  і задає єдиний доступний vault.
+- **Пристрій ONNX** — `POWER_EMBED_DEVICE` / `POWER_RERANKER_DEVICE`
+  (`auto`, `cpu`, `cuda`, `rocm`, `directml`). `auto` може лягти на CPU;
+  явний прискорювач fail-closed, якщо сесія не прив'язала запитаний провайдер.
 
 ---
 
@@ -138,7 +138,7 @@ timestamp: YYYY-MM-DDTHH:MM:SS+TZ
 Після додавання/зміни файлу виконайте скрипт генерації індексу. Він автоматично оновить `index.md`, рекурсивні `_index.md` каталоги та сторінки `_index-N.md` у межах 32 KiB:
 
 ```bash
-python3 .agents/skills/power/scripts/generate_index.py
+power lint <path>
 ```
 
 ### Крок 3. Додавання запису у Change Log
@@ -157,7 +157,7 @@ python3 .agents/skills/power/scripts/generate_index.py
 Запустіть скрипт лінтера, щоб перевірити, чи не з'явилися нові биті посилання чи сторінки-сироти:
 
 ```bash
-python3 .agents/skills/power/scripts/lint_brain.py
+power lint <path>
 ```
 
 _Якщо лінтер звітує про помилки (наприклад, broken links у Home.md), негайно виправте їх._

--- a/tests/test_doc_drift.py
+++ b/tests/test_doc_drift.py
@@ -47,6 +47,36 @@ def test_current_docs_match_executable_interfaces_and_safe_onboarding() -> None:
     assert gate["check_links"](documents, facts) == []
 
 
+def test_agent_skill_gate_rejects_wrong_index_workflow() -> None:
+    gate = _load_gate()
+    facts = gate["_load_code_facts"]()
+    documents = gate["_read_current_documents"]()
+    marker = "```bash\npower index <path>\n```"
+    assert marker in documents["Agent skill"]
+    documents["Agent skill"] = documents["Agent skill"].replace(
+        marker, "```bash\npower lint <path>\n```", 1
+    )
+
+    errors = gate["check_interfaces"](documents, facts)
+
+    assert any("Agent skill" in error and "index command" in error for error in errors)
+
+
+def test_agent_skill_gate_covers_workspace_copy_and_readme_ua() -> None:
+    gate = _load_gate()
+    facts = gate["_load_code_facts"]()
+    documents = gate["_read_current_documents"]()
+    documents["Workspace agent skill"] = documents["Workspace agent skill"].replace(
+        "`sync_vault`", "`missing_tool`", 1
+    )
+    documents["README.ua"] = documents["README.ua"].replace("18 інструментів", "17 інструментів", 1)
+
+    errors = gate["check_interfaces"](documents, facts)
+
+    assert any("Workspace agent skill" in error and "sync_vault" in error for error in errors)
+    assert any("README.ua" in error and "MCP tools" in error for error in errors)
+
+
 def test_onboarding_gate_rejects_unsafe_windows_launcher() -> None:
     gate = _load_gate()
     facts = gate["_load_code_facts"]()


### PR DESCRIPTION
## Scope

Maintainer promotion/follow-up to #256 and #242 on current `main` (`95fe0516`). The contributor's useful Skill refresh is retained, but the scope is corrected before merge.

## What this closes

- synchronize both agent-facing copies: `skills/power/SKILL.md` and `.agents/skills/power/SKILL.md`;
- refresh the executable inventory to 17 CLI commands and 18 MCP tools;
- correct the workflow command so catalog generation uses `power index`, while validation uses `power lint`;
- document `--accept-dense-loss` and the `sync_vault` post-write boundary;
- correct the remaining 17-tool claims in `README.ua`;
- make `check_doc_drift.py` derive and check both Skill copies, all CLI/MCP names, frontmatter version, forbidden paths, workflow markers, and Ukrainian README counts;
- add mutation regressions for wrong index command, stale workspace Skill, and stale `README.ua` count.

The broader `power doctor` design remains a separate 3.4.1 manifest/JSON/no-download gate.

## Validation

- full suite: `807 passed, 10 skipped`, coverage `80.99%`;
- doc-drift mutation suite: 7 passed;
- Ruff check/format, MyPy, release contract, benchmark manifest and pip-audit pass;
- signed maintainer commit: `de8d324`.
