### PR TITLE
fix(release): bind candidate baseline to reachable main source

### DIFF
--- a/release/evidence/baselines/v3.4.0.json
+++ b/release/evidence/baselines/v3.4.0.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "release": "3.4.0",
   "source": {
-    "commit": "fd01a084b449af3e319b267dc020980c72beb5ac",
-    "tree": "6ba1b8fe7aeb095ccca172269e81b0e8fb80df2f",
+    "commit": "98c33340cef96409bc7e49d3174a97efbde8f7ac",
+    "tree": "97d8019ce2f07633e9ada9e214fad4f19a0d69c2",
     "tag": "v3.4.0",
     "clean": true
   },


### PR DESCRIPTION
## Summary

The merged 3.4.0 preparation PR used a baseline source commit from its pre-squash branch. Because GitHub squash merge does not retain that branch commit in `main`, the post-merge release-contract gate correctly rejected the unreachable object.

This follow-up binds the candidate baseline to the reachable `v3.3.2`-successor main commit/tree. The final tag workflow still regenerates the release baseline against the exact `v3.4.0` tag.

## Validation

- `./.venv/bin/python scripts/verify_release_contract.py`
- `./.venv/bin/ruff check src tests scripts`
- `./.venv/bin/mypy src/power_framework`
- release baseline/contract tests — 8 passed, 1 pre-tag skip
