### PR TITLE
docs(readme): clarify Linux and macOS quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,14 @@ the role-specific guides before touching a vault:
 - **[Documentation inventory](docs/documentation-inventory.ua.md)** — audited
   entry points, linked documents, corrected drift, and evidence boundaries
 
-## Quick Start
+## Quick Start (Linux/macOS)
+
+The commands below are the shortest supported path for Linux and macOS. They
+assume Python 3.11+ and a terminal shell; `~/my-vault` is the vault directory
+you want POWER to manage.
 
 ```bash
-pip install https://github.com/weby-homelab/power-framework/releases/download/v3.4.0/power_framework-3.4.0-py3-none-any.whl
+python3 -m pip install https://github.com/weby-homelab/power-framework/releases/download/v3.4.0/power_framework-3.4.0-py3-none-any.whl
 
 power init ~/my-vault          # Create vault structure
 power lint ~/my-vault          # Check for broken links & missing metadata
@@ -68,11 +72,12 @@ power heal ~/my-vault          # Auto-fix missing/invalid frontmatter
 power markdown-check ~/my-vault  # Check markdown quality issues
 ```
 
-## Development install
+## Development install (Linux/macOS)
 
-Contributors should clone into a durable development directory, create a venv,
-and follow [CONTRIBUTING.md](CONTRIBUTING.md). Inspect local changes before
-pulling; documentation does not provide an updater that resets a working tree.
+Contributors on Linux or macOS should clone into a durable development
+directory, create a venv, and follow [CONTRIBUTING.md](CONTRIBUTING.md). Inspect
+local changes before pulling; documentation does not provide an updater that
+resets a working tree.
 
 ```bash
 git clone https://github.com/weby-homelab/power-framework.git
@@ -86,11 +91,12 @@ power --version
 
 ## Windows 11 25H2 installation
 
-Use the dedicated [Windows 11 25H2 guide](docs/windows-11-installation.md).
-It covers Python/Visual C++ prerequisites, an isolated venv without mandatory
-script activation, the immutable release wheel, exact PowerShell syntax, clean
-vault acceptance checks, dense-search evidence boundaries, MCP configuration
-with the venv interpreter, troubleshooting, rollback, and uninstall.
+Windows users should use the dedicated [Windows 11 25H2
+guide](docs/windows-11-installation.md) instead of the Linux/macOS shell
+commands above. It contains the complete PowerShell installation, Python and
+Visual C++ prerequisites, isolated venv setup, immutable release wheel,
+acceptance checks, MCP configuration, troubleshooting, rollback, and uninstall
+steps.
 
 Direct Windows runtime execution was not part of the `v3.4.0` Linux release
 pipeline; the guide explicitly separates automated cross-platform regression

--- a/README.ua.md
+++ b/README.ua.md
@@ -53,10 +53,14 @@ P.O.W.E.R. створений для роботи як людьми, так і A
 - **[Інвентаризація документації](docs/documentation-inventory.ua.md)** — перевірені
   точки входу, пов'язані документи, виправлений дрейф і межі доказів
 
-## Швидкий старт
+## Швидкий старт (Linux/macOS)
+
+Наведені нижче команди — найкоротший підтримуваний шлях для Linux і macOS.
+Потрібен Python 3.11+ і terminal shell; `~/my-vault` — каталог vault, яким
+керуватиме POWER.
 
 ```bash
-pip install https://github.com/weby-homelab/power-framework/releases/download/v3.4.0/power_framework-3.4.0-py3-none-any.whl
+python3 -m pip install https://github.com/weby-homelab/power-framework/releases/download/v3.4.0/power_framework-3.4.0-py3-none-any.whl
 
 power init ~/my-vault      # Створити структуру vault
 power lint ~/my-vault      # Перевірити биті посилання та метадані
@@ -65,11 +69,12 @@ power heal ~/my-vault      # Автовиправлення відсутньог
 power markdown-check ~/my-vault  # Перевірка якості Markdown
 ```
 
-## Розробницька установка
+## Розробницька установка (Linux/macOS)
 
-Contributors мають clone у durable development directory, створити venv і
-виконати [CONTRIBUTING.md](CONTRIBUTING.md). Перед pull перевіряйте local
-changes; документація не пропонує updater, який reset робоче дерево.
+Учасникам на Linux або macOS слід clone у durable development directory,
+створити venv і виконати [CONTRIBUTING.md](CONTRIBUTING.md). Перед pull
+перевіряйте local changes; документація не пропонує updater, який reset робоче
+дерево.
 
 ```bash
 git clone https://github.com/weby-homelab/power-framework.git
@@ -83,12 +88,12 @@ power --version
 
 ## Встановлення на Windows 11 25H2
 
-Використовуйте окремий
-[гід Windows 11 25H2](docs/windows-11-installation.ua.md). Він описує
-Python/Visual C++ prerequisites, isolated venv без обов'язкової script
-activation, immutable release wheel, точний PowerShell syntax, clean-vault
-acceptance checks, dense-search evidence boundaries, MCP configuration через
-venv interpreter, troubleshooting, rollback і uninstall.
+Користувачам Windows слід використовувати окремий детальний
+[гід Windows 11 25H2](docs/windows-11-installation.ua.md), а не наведені вище
+Linux/macOS shell-команди. Гід описує Python/Visual C++ prerequisites,
+isolated venv, immutable release wheel, точний PowerShell syntax, clean-vault
+acceptance checks, MCP configuration через venv interpreter, troubleshooting,
+rollback і uninstall.
 
 Прямий Windows runtime запуск не входив у Linux release pipeline `v3.4.0`;
 гід явно розділяє автоматизований cross-platform regression і checks, які


### PR DESCRIPTION
## Summary
- make the main README quick start explicitly target Linux and macOS
- use `python3 -m pip` for the Linux/macOS release-wheel install
- direct Windows users to the dedicated Windows 11 25H2 guide
- label the contributor setup as Linux/macOS shell instructions

## Validation
- `pytest --no-cov tests/test_doc_drift.py -q` — 8 passed
- `python scripts/check_doc_drift.py` — passed
- `git diff --check` — passed

The full Python/platform/security/package gates are left to GitHub CI.
