### PR TITLE
fix(mcp): restore health endpoint and wire discovery coverage

### DIFF
--- a/src/power_framework/mcp/power_server.py
+++ b/src/power_framework/mcp/power_server.py
@@ -32,9 +32,13 @@ from typing import TYPE_CHECKING
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+from starlette.responses import JSONResponse
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from starlette.requests import Request
+    from starlette.responses import Response
 
 from power_framework.core import (
     DEFAULT_SEARCH_MODE,
@@ -153,6 +157,16 @@ def _get_http_transport_config() -> tuple[str, int]:
         raise ValueError("POWER_MCP_PORT must be an integer between 1 and 65535")
 
     return host, port
+
+
+@mcp.custom_route("/health", methods=["GET"], include_in_schema=False)
+async def health_check(_request: Request) -> Response:
+    """Report whether the configured vault boundary is ready for HTTP clients."""
+    try:
+        _require_configured_vault_root()
+    except RuntimeError as exc:
+        return JSONResponse({"status": "error", "detail": str(exc)}, status_code=503)
+    return JSONResponse({"status": "ok"})
 
 
 @mcp.tool(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -13,7 +13,9 @@ from contextlib import closing
 from pathlib import Path
 from unittest.mock import Mock
 
+import httpx
 import pytest
+from fastmcp import Client
 from fastmcp.exceptions import ToolError
 
 from power_framework.core.capabilities import manifest
@@ -56,6 +58,52 @@ async def test_mcp_tools_publish_standard_and_power_risk_annotations() -> None:
     assert search.annotations is not None
     assert search.annotations.readOnlyHint is True
     assert search.meta["power.risk"]["egress"] == "model_download"
+
+
+async def test_mcp_wire_discovery_preserves_tool_contract_and_empty_collections() -> None:
+    async with Client(power_server.mcp) as client:
+        tools = await client.list_tools()
+        resources = await client.list_resources()
+        resource_templates = await client.list_resource_templates()
+        prompts = await client.list_prompts()
+        tools_again = await client.list_tools()
+
+    expected_names = manifest()["interfaces"]["mcp_tools"]
+    assert [tool.name for tool in tools] == expected_names
+    assert [tool.name for tool in tools_again] == expected_names
+    assert [tool.name for tool in tools_again] == [tool.name for tool in tools]
+    assert resources == []
+    assert resource_templates == []
+    assert prompts == []
+    assert all(tool.outputSchema for tool in tools)
+    assert all(tool.annotations for tool in tools)
+    assert all(tool.meta and tool.meta.get("power.risk") for tool in tools)
+
+
+async def test_http_health_route_reports_vault_readiness(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("POWER_VAULT_DIR", str(tmp_path))
+
+    transport = httpx.ASGITransport(app=power_server.mcp.http_app(transport="http"))
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+async def test_http_health_route_fails_closed_without_vault(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("POWER_VAULT_DIR", str(tmp_path / "missing-vault"))
+
+    transport = httpx.ASGITransport(app=power_server.mcp.http_app(transport="http"))
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/health")
+
+    assert response.status_code == 503
+    assert response.json()["status"] == "error"
 
 
 async def test_read_sub_index_existing_category(sample_vault: Path) -> None:


### PR DESCRIPTION
## Summary

- restore the documented `/health` endpoint on the HTTP transport
- return 503 when the configured vault boundary is unavailable instead of reporting false readiness
- verify real FastMCP Client discovery for all manifest tools, output schemas, standard annotations, risk metadata, and empty resources/prompts collections

## Why

The repository documented `/health` and shipped it in the Docker HEALTHCHECK, but no custom route was registered, so the endpoint returned 404. The existing metadata checks did not exercise the MCP wire contract.

## Validation

- `pytest --no-cov tests/test_mcp_server.py -q -o addopts=`: 36 passed
- full `pytest`: 829 passed, 10 skipped, 80.69% coverage
- `ruff check src tests scripts`
- `ruff format --check src tests scripts`
- `mypy src/power_framework`
- `python scripts/check_doc_drift.py`
- `git diff --check`

Signed commit: `c4df96f5c5418f7b2f78e30ec633b2d8c2c3b079`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health check endpoint to report service readiness.
  * Returns a successful status when the configured vault is available.
  * Returns an HTTP 503 error when the vault is unavailable.

* **Bug Fixes**
  * Improved MCP discovery verification for tool names, schemas, annotations, and risk metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->