### PR TITLE
docs: enforce migration guide runtime conformance

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -63,6 +63,23 @@ An agent must read the relevant documents before changing data:
 These constraints are why this protocol uses a staging vault and a migration
 manifest instead of pretending that one command performs a lossless migration.
 
+## Version-stamped executable facts
+
+This guide is verified against the pinned `v3.4.0` release. CI checks these
+facts against the executable capability manifest so an agent does not inherit
+an older migration recipe:
+
+- the current surface is 19 top-level CLI commands and 18 MCP tools;
+- the default search mode is `semantic`; `reranked` is explicit opt-in;
+- database and cache paths are runtime-owned. Use `power doctor DESTINATION
+  --json` to read the active paths and state; never hard-code a vault-local
+  database filename;
+- `power heal` repairs frontmatter, not wikilinks. For foreign frontmatter
+  shapes, `power import --policy quarantine` preserves values as `x-status` or
+  `x-related` before the strict validation gate;
+- VRAM, latency, and dense/reranked readiness are target-host evidence, not a
+  fixed promise. Record `power doctor` and sync results for the actual host.
+
 ### Bounded import fast path
 
 For a source tree whose destination folder and filename mapping are already

--- a/docs/migration-guide.ua.md
+++ b/docs/migration-guide.ua.md
@@ -63,6 +63,23 @@ rollback path.
 Саме тому протокол використовує staging vault і migration manifest, а не
 видає одну команду за lossless migration.
 
+## Версійовані executable facts
+
+Цей гід перевірено проти pinned release `v3.4.0`. CI звіряє ці факти з
+executable capability manifest, щоб агент не успадковував старий migration
+recipe:
+
+- поточна surface — 19 top-level CLI commands і 18 MCP tools;
+- режим пошуку за замовчуванням — `semantic`; `reranked` є explicit opt-in;
+- database і cache paths належать runtime. Для active paths і state використовуйте
+  `power doctor DESTINATION --json`; не hard-code-ьте vault-local database
+  filename;
+- `power heal` виправляє frontmatter, але не ремонтує wikilinks. Для foreign
+  frontmatter shapes `power import --policy quarantine` зберігає values як
+  `x-status` або `x-related` до strict validation gate;
+- VRAM, latency і dense/reranked readiness — evidence конкретного host, а не
+  фіксована обіцянка. Записуйте `power doctor` і sync result для actual host.
+
 ### Обмежений fast path імпорту
 
 Якщо destination folder і mapping імен уже відомі, `power import` дає

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -451,6 +451,68 @@ def check_onboarding(documents: dict[str, str], facts: dict[str, Any]) -> list[s
             for marker in ("SHA-256", "--strict", "rollback")
             if marker.lower() not in migration_doc.lower()
         )
+    errors.extend(check_migration_guide(documents, facts))
+    return errors
+
+
+def check_migration_guide(documents: dict[str, str], facts: dict[str, Any]) -> list[str]:
+    """Keep the migration guide's versioned safety claims executable and current."""
+    errors: list[str] = []
+    version = facts["version"]
+    mcp_count = len(facts["interfaces"]["mcp_tools"])
+    default_mode = facts["search"]["default_mode"]
+    required_markers = {
+        "Migration": (
+            f"v{version}",
+            f"{mcp_count} MCP tools",
+            f"default search mode is `{default_mode}`",
+            "power doctor DESTINATION",
+            "--json",
+            "--policy quarantine",
+            "x-status",
+            "x-related",
+            "does not promise a complete rewrite",
+            "not wikilinks",
+        ),
+        "Migration UA": (
+            f"v{version}",
+            f"{mcp_count} MCP tools",
+            f"режим пошуку за замовчуванням — `{default_mode}`",
+            "power doctor DESTINATION",
+            "--json",
+            "--policy quarantine",
+            "x-status",
+            "x-related",
+            "не гарантує повний rewrite",
+            "але не ремонтує wikilinks",
+        ),
+    }
+    for label, markers in required_markers.items():
+        document = documents[label]
+        errors.extend(
+            f"{label} is missing versioned executable migration fact `{marker}`."
+            for marker in markers
+            if marker not in document
+        )
+
+    stale_claims = {
+        r"\b(?:12|17) MCP tools?\b": "stale MCP tool count",
+        r"\b(?:12|17) MCP[- ]інструмент": "stale MCP tool count",
+        r"reranked.{0,40}(?:canonical|default|канонічн|за замовчуванням)": (
+            "reranked presented as the default"
+        ),
+        r"\.power_search\.db": "hard-coded legacy database path",
+        r"HF_HUB_DISABLE_SYMLINKS": "obsolete manual symlink workaround",
+        r"(?:3-6|3\u20136)\s*KB": "unbounded catalog-size promise",
+        r"(?:2-3|2\u20133)\s*GB": "unverified VRAM promise",
+    }
+    for label in ("Migration", "Migration UA"):
+        document = documents[label]
+        errors.extend(
+            f"{label} contains {description} (matched /{pattern}/)."
+            for pattern, description in stale_claims.items()
+            if re.search(pattern, document, flags=re.IGNORECASE)
+        )
     return errors
 
 

--- a/tests/test_doc_drift.py
+++ b/tests/test_doc_drift.py
@@ -48,6 +48,33 @@ def test_current_docs_match_executable_interfaces_and_safe_onboarding() -> None:
     assert gate["check_links"](documents, facts) == []
 
 
+def test_current_migration_guides_match_versioned_runtime_facts() -> None:
+    gate = _load_gate()
+    facts = gate["_load_code_facts"]()
+    documents = gate["_read_current_documents"]()
+
+    assert gate["check_migration_guide"](documents, facts) == []
+
+
+def test_migration_gate_rejects_stale_runtime_claims() -> None:
+    gate = _load_gate()
+    facts = gate["_load_code_facts"]()
+    documents = gate["_read_current_documents"]()
+    documents["Migration"] = documents["Migration"].replace(
+        "default search mode is `semantic`", "default search mode is `reranked`", 1
+    )
+    documents["Migration UA"] = documents["Migration UA"].replace(
+        "режим пошуку за замовчуванням — `semantic`",
+        "режим пошуку за замовчуванням — `reranked`",
+        1,
+    )
+
+    errors = gate["check_migration_guide"](documents, facts)
+
+    assert any("Migration" in error and "semantic" in error for error in errors)
+    assert any("Migration UA" in error and "semantic" in error for error in errors)
+
+
 def test_interface_gate_rejects_stale_architecture_count() -> None:
     gate = _load_gate()
     facts = gate["_load_code_facts"]()


### PR DESCRIPTION
## Summary

Closes the executable portion of #242 without adding runtime features.

- add version-stamped runtime facts to both migration guides
- make CI derive the release version, MCP count, and default search mode from the capability manifest
- require the safe import/quarantine, doctor-owned path, and link-repair boundaries
- reject the stale claims called out by #242: old tool counts, reranked-as-default, legacy database paths, manual symlink workarounds, catalog-size promises, and fixed VRAM promises

## Validation

- full pytest: 831 passed, 10 skipped, 80.69% coverage
- focused doc-drift suite: 12 passed
- ruff check
- ruff format --check
- mypy
- check_doc_drift.py
- git diff --check

Signed commit: 9d8577d974f56fc66e9db756f7d0141536672425