### PR TITLE
fix(docs): reject stale README MCP counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ flowchart TD
     end
 
     subgraph AI ["🤖 AI Agent (FastMCP 3.x)"]
-        Tools[["🔌 17 Async MCP Tools (stdio/HTTP)"]]:::agent
+        Tools[["🔌 18 Async MCP Tools (stdio/HTTP)"]]:::agent
         Search[["🔍 Hybrid / Reranked Search"]]:::agent
         ROT{{"🛠️ ROT & Contradiction Audit (Semantic/LLM)"}}:::agent
     end

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -283,10 +283,20 @@ def check_interfaces(documents: dict[str, str], facts: dict[str, Any]) -> list[s
         mcp_count = mcp_count or f"{len(mcp_tools)} інструмент" in documents[label]
         if not mcp_count:
             errors.append(f"{label} does not declare all {len(mcp_tools)} MCP tools.")
-        if label == "README.ua" and re.search(
-            rf"\b(?!{len(mcp_tools)}\b)\d+ інструмент", documents[label]
-        ):
-            errors.append(f"{label} contains a stale MCP tools count.")
+        numeric_mcp_claims = re.findall(
+            r"\b(\d+)(?:[- ]+)?(?:Async )?MCP tools?\b", documents[label], re.I
+        )
+        numeric_mcp_claims.extend(
+            re.findall(r"\b(\d+)\s+MCP[- ]?інструмент(?:ів)?", documents[label], re.I)
+        )
+        numeric_mcp_claims.extend(
+            re.findall(r"\b(\d+)\s+інструмент(?:ів)?", documents[label], re.I)
+        )
+        errors.extend(
+            f"{label} contains stale MCP tools count `{claim}`; expected `{len(mcp_tools)}`."
+            for claim in numeric_mcp_claims
+            if int(claim) != len(mcp_tools)
+        )
     for label in ("Getting Started", "Getting Started UA"):
         mcp_count = re.search(rf"{len(mcp_tools)}(?:[- ]+)?(?:MCP )?tools?", documents[label], re.I)
         mcp_count = mcp_count or f"{len(mcp_tools)} інструмент" in documents[label]

--- a/tests/test_doc_drift.py
+++ b/tests/test_doc_drift.py
@@ -86,6 +86,17 @@ def test_interface_gate_rejects_stale_architecture_count() -> None:
     assert any("Architecture" in error and "19 CLI commands" in error for error in errors)
 
 
+def test_interface_gate_rejects_stale_readme_mcp_count() -> None:
+    gate = _load_gate()
+    facts = gate["_load_code_facts"]()
+    documents = gate["_read_current_documents"]()
+    documents["README"] = documents["README"].replace("18 Async MCP Tools", "17 Async MCP Tools", 1)
+
+    errors = gate["check_interfaces"](documents, facts)
+
+    assert any("README" in error and "stale MCP tools count" in error for error in errors)
+
+
 def test_interface_gate_rejects_stale_getting_started_count() -> None:
     gate = _load_gate()
     facts = gate["_load_code_facts"]()


### PR DESCRIPTION
## Summary

- correct the remaining `17 Async MCP Tools` claim in the README architecture diagram to the current 18-tool runtime contract;
- make the documentation drift gate reject stale numeric MCP-tool counts across the current README and architecture documents;
- add a regression test for a stale README count.

This is the corrective slice for #242, which exposed the stale diagram claim after the migration-guide conformance work.

## Verification

- `./.venv/bin/pytest` — 832 passed, 10 skipped, 80.69% coverage;
- `./.venv/bin/pytest --no-cov tests/test_doc_drift.py -q -o addopts=` — 13 passed;
- `./.venv/bin/python scripts/check_doc_drift.py` — passed;
- `ruff check src tests scripts` — passed;
- `ruff format --check src tests scripts` — passed;
- `mypy src/power_framework` — passed;
- `git diff --check` — passed;
- commit `1244309` is GPG-signed by `weby-homelab <rekvizitor.ua@gmail.com>`.

Fixes #242
