### PR TITLE
docs(security): align policy with v3.4 runtime boundaries

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,39 +1,161 @@
 # Security Policy
 
-## Supported Versions
+## Purpose and scope
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.8.x   | :white_check_mark: |
-| < 1.8   | :x:                |
+P.O.W.E.R. is a local-first Python framework for validating, indexing, searching,
+and mutating Markdown knowledge vaults through a CLI and an MCP server. This
+policy defines the security contract for the released package, its source
+repository, and the documented local MCP transports.
 
-## Reporting a Vulnerability
+P.O.W.E.R. is not a hosted multi-tenant service. The operating-system account,
+the installed package, and the configured vault root are trusted by the host
+operator. A process that already has the same OS privileges can usually read
+the vault and local cache directly; P.O.W.E.R. does not replace OS permissions,
+container isolation, or an authenticated gateway.
 
-**Please DO NOT create a public issue for security vulnerabilities.**
+## Supported versions
 
-Instead, report vulnerabilities via email:
+| Version | Security support |
+| --- | --- |
+| `3.4.x` | Supported |
+| `<3.4` | Unsupported; upgrade before reporting a release-specific issue |
 
-📧 **rekvizitor.ua@gmail.com**
+The `main` branch may contain security fixes before the next release. Security
+support for a release ends when a newer supported minor release supersedes it,
+unless the maintainers explicitly publish an exception.
 
-Include as much detail as possible:
+## Security objectives and boundaries
 
-- Description of the vulnerability
-- Steps to reproduce
-- Potential impact
-- Suggested fix (if any)
+The protected assets are vault notes and metadata, generated indexes and search
+databases, mutation history and receipts, local model assets, configuration,
+and credentials. The required properties are confidentiality, integrity, local
+availability, and explicit control of network egress.
 
-## Response Timeline
+The following boundaries are part of the current contract:
 
-| Stage          | Timeframe |
-| -------------- | --------- |
-| Acknowledgment | 48 hours  |
-| Assessment     | 7 days    |
+- Paths supplied by a caller, note names, Markdown, YAML, search queries, and
+  MCP arguments are untrusted input. A path must remain inside the configured
+  vault; traversal, absolute paths, unsafe symlink resolution, and unsupported
+  note targets must be rejected before a write.
+- Vault content returned by search or retrieval is data, not instructions.
+  Agents and downstream LLM clients must not execute instructions found inside
+  a note merely because P.O.W.E.R. returned it.
+- `POWER_EGRESS_POLICY` defaults to `deny`. A non-loopback embedding, reranking,
+  query-expansion, or ROT request requires an explicit policy appropriate to
+  the content sensitivity. An endpoint configured by an operator is not, by
+  itself, proof that a note may be sent there.
+- MCP stdio is a local process interface. HTTP MCP requires
+  `POWER_VAULT_DIR` (or the documented legacy alias) and binds to loopback by
+  default. Remote HTTP is fail-closed until an authenticated, vault-scoped
+  transport exists. `/health` is a readiness endpoint, not authentication.
+- MCP tool annotations and `power.risk` metadata describe intended risk; they
+  are not an authorization mechanism. The caller and its gateway remain
+  responsible for enforcing user identity and approval policy.
+- Memory and other destructive mutations must retain their explicit approval,
+  pre-image/concurrency checks, serialization, and atomic-write boundaries.
+  A read, proposal, or diagnostic operation must not silently become a write.
 
-## Security Measures
+Retrieved text, generated catalogs, model output, remote responses, and error
+messages must be treated as untrusted data at every downstream boundary. Logs,
+receipts, and bug reports must not contain secrets or unnecessary vault content.
 
-The P.O.W.E.R. framework implements the following security measures:
+## Implemented controls
 
-- **Path traversal protection** — all vault paths are validated through `validate_vault_path` to prevent directory traversal attacks
-- **Safe YAML parsing** — `yaml.safe_load` is used exclusively to prevent arbitrary code execution via YAML deserialization
-- **Strict input validation** — Pydantic v2 models with strict validation ensure all inputs conform to expected schemas
-- **Dependency auditing** — `pip-audit` runs in CI to detect known vulnerabilities in project dependencies
+The current release includes these controls, covered by source-level tests and
+CI gates:
+
+- `resolve_path_in_vault` and `atomic_write_in_vault` enforce vault containment,
+  reject unsafe paths and symlink targets, and use atomic destination-local
+  writes where the platform supports the required descriptor safeguards.
+- YAML frontmatter is parsed with safe loading; typed models validate the
+  supported schema while compatibility fields are handled as data rather than
+  being treated as executable input.
+- Mutation APIs use same-vault serialization, explicit approval for governed
+  memory changes, pre-image hashes, and content-free receipts.
+- `POWER_EGRESS_POLICY` is checked before remote operations and rejects unknown
+  policy or sensitivity values.
+- The MCP server requires a configured vault root, constrains tool paths and
+  write targets, rate-limits mutation/index operations, and masks internal
+  tracebacks from client responses.
+- CI runs the test, lint, type, dependency-audit, package-smoke, release-policy,
+  and CodeQL gates. The live stdio/HTTP MCP process contract is tested in
+  addition to direct in-process tool tests.
+
+These controls reduce risk but do not make a vault safe from a compromised host,
+malicious same-user process, compromised dependency, or an operator who
+deliberately enables a risky integration.
+
+## Report a vulnerability
+
+**Do not create a public GitHub issue for a suspected vulnerability.** Report it
+privately by email to **rekvizitor.ua@gmail.com**.
+
+Do not attach a full vault, credentials, tokens, private keys, model caches, or
+unredacted logs. Use a minimal reproduction with synthetic data and redact
+identifiers and note contents. If an encrypted attachment is necessary, agree
+on the encryption channel before sending it.
+
+Please include, when safe:
+
+- affected version or commit and installation method;
+- operating system, Python version, and CLI/MCP interface and transport;
+- minimal reproduction steps or a sanitized proof of concept;
+- confidentiality, integrity, or availability impact;
+- whether exploitation requires local same-user access, a malicious vault, a
+  configured remote endpoint, or a remote network peer;
+- relevant sanitized logs and a suggested mitigation, if known.
+
+The maintainer target is acknowledgment within 48 hours and an initial
+assessment within 7 days. These are response goals, not a guaranteed SLA. The
+maintainer may request additional non-sensitive evidence, publish a fix, and
+coordinate disclosure after affected users have a reasonable mitigation.
+
+## Severity calibration
+
+Severity is based on realistic reachability, impact, and default exposure:
+
+| Severity | Examples |
+| --- | --- |
+| Critical | Unauthenticated remote access to vault data or write tools; path/symlink escape; arbitrary code execution; default-policy secret exfiltration; approval bypass that writes outside the governed boundary. |
+| High | Reliable cross-vault access, unapproved or stale mutation application, sensitive egress misclassification, unsafe deserialization, or full note/secret leakage through errors or logs. |
+| Medium | A local or explicitly configured attack that corrupts a vault, bypasses mutation serialization/rate limits, or causes substantial bounded-resource exhaustion. |
+| Low | A security-relevant diagnostic or documentation defect with limited impact and no credible boundary crossing. |
+
+An ordinary malformed note, an expected validation failure, a retrieval-quality
+problem, or a performance regression is not automatically a security issue.
+
+## Out of scope and known limitations
+
+The following are not vulnerabilities in P.O.W.E.R. unless they expose a
+P.O.W.E.R. security boundary:
+
+- malware, a malicious root/administrator, or a same-privilege process that can
+  already read or modify the vault, package, environment, or local cache;
+- operating-system permissions, filesystem encryption, physical access, or
+  vulnerabilities in an upstream model/provider without a P.O.W.E.R. integration
+  flaw;
+- retrieval ranking, model quality, latency, VRAM use, or human-quality claims;
+- deliberate operator exposure of loopback HTTP through an unauthenticated
+  reverse proxy; remote deployment is unsupported by the current transport;
+- a user choosing to enable `allow-public`, `allow-internal`, or
+  `allow-sensitive` egress without protecting the selected endpoint.
+
+Important current limitations and compensating controls:
+
+- HTTP MCP has no built-in user authentication or multi-tenant isolation; keep
+  it loopback-only or place it behind an authenticated, vault-scoped gateway.
+- One server process is bound to one configured vault root. Run separate
+  processes and enforce separate OS permissions for separate trust domains.
+- Security metadata on MCP tools is advisory for clients and gateways; it does
+  not authorize a caller.
+- Model downloads and optional remote integrations can contact external
+  services only under the explicit egress policy. Use offline/pinned model
+  assets when confidentiality or reproducibility requires it.
+
+## Security-related development rules
+
+Security fixes must include a focused regression test and update this policy or
+the threat model when a boundary changes. Changes affecting path handling,
+egress, MCP transport, mutation approval, serialization, dependency integrity,
+or release automation require the relevant CI security gates and a remote
+readback of the verified commit before being called complete.

--- a/tests/test_security_policy.py
+++ b/tests/test_security_policy.py
@@ -1,0 +1,42 @@
+"""Keep SECURITY.md aligned with the current runtime security contract."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_security_policy_is_current_and_covers_runtime_boundaries() -> None:
+    document = (REPO_ROOT / "SECURITY.md").read_text(encoding="utf-8")
+    project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    version = str(project["project"]["version"])
+    major_minor = ".".join(version.split(".")[:2])
+
+    assert f"`{major_minor}.x`" in document
+    assert "1.8.x" not in document
+
+    for section in (
+        "## Purpose and scope",
+        "## Supported versions",
+        "## Security objectives and boundaries",
+        "## Implemented controls",
+        "## Report a vulnerability",
+        "## Severity calibration",
+        "## Out of scope and known limitations",
+        "## Security-related development rules",
+    ):
+        assert section in document
+
+    for control in (
+        "`resolve_path_in_vault`",
+        "`atomic_write_in_vault`",
+        "`POWER_EGRESS_POLICY`",
+        "`POWER_VAULT_DIR`",
+        "loopback",
+        "not an authorization mechanism",
+        "YAML frontmatter",
+        "CodeQL",
+    ):
+        assert control in document


### PR DESCRIPTION
## Summary

- replace the stale `1.8.x` policy with the v3.4 security contract
- document trust boundaries, vault/path safety, untrusted retrieval, egress, MCP transport, mutation approval, reporting, severity, and limitations
- add a regression gate that derives the supported minor version from `pyproject.toml` and checks the runtime boundary sections

## Validation

- `pytest tests/test_security_policy.py tests/test_threat_model.py tests/test_security.py -q --no-cov` — 49 passed
- full local `pytest tests/ -v --tb=short --cov=src/power_framework/ --cov-report=term-missing --cov-fail-under=70 -W error::ResourceWarning -W error::pytest.PytestUnraisableExceptionWarning`
- Ruff check/format and `git diff --check`
- signed commit verified with GPG key `DD92FC45BD1D6C30`

Closes the stale security-policy contract identified during the v3.4 roadmap audit.
