### PR TITLE
docs(security): publish disclosure contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -88,7 +88,7 @@ deliberately enables a risky integration.
 ## Report a vulnerability
 
 **Do not create a public GitHub issue for a suspected vulnerability.** Report it
-privately by email to **rekvizitor.ua@gmail.com**.
+privately by email to **contact@weby.guru**.
 
 Do not attach a full vault, credentials, tokens, private keys, model caches, or
 unredacted logs. Use a minimal reproduction with synthetic data and redact


### PR DESCRIPTION
## Summary

- replace the private disclosure address in `SECURITY.md` with the public contact `contact@weby.guru`
- keep the security policy and reporting instructions otherwise unchanged

## Validation

- `pytest tests/test_security_policy.py tests/test_threat_model.py tests/test_security.py -q --no-cov` — 49 passed
- Ruff check/format and `git diff --check`
- signed commit verified with GPG key `DD92FC45BD1D6C30`
