### PR TITLE
fix(utils): write files byte-faithfully so byte bounds hold on Windows

### DIFF
--- a/src/power_framework/core/utils.py
+++ b/src/power_framework/core/utils.py
@@ -77,6 +77,13 @@ def atomic_write(filepath: Path, content: str, encoding: str = "utf-8") -> None:
     Write content to file atomically using temp file + rename.
 
     Prevents corruption from interrupted writes (0-byte files).
+
+    ``newline=""`` disables newline translation so the file on disk is exactly
+    ``content.encode(encoding)`` on every platform. Without it, text mode maps
+    each "\\n" to ``os.linesep``, and on Windows a caller that bounded its
+    content by byte length -- such as the INDEX_MAX_BYTES catalog contract --
+    writes an artifact larger than the bound it just enforced, by one byte per
+    line.
     """
     filepath = Path(filepath)
     filepath.parent.mkdir(parents=True, exist_ok=True)
@@ -87,7 +94,7 @@ def atomic_write(filepath: Path, content: str, encoding: str = "utf-8") -> None:
         suffix=".tmp",
     )
     try:
-        file_obj = os.fdopen(fd, "w", encoding=encoding)
+        file_obj = os.fdopen(fd, "w", encoding=encoding, newline="")
         fd = -1
         with file_obj as f:
             f.write(content)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,58 @@
+"""Tests for shared filesystem helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+
+from power_framework.core.constants import INDEX_MAX_BYTES
+from power_framework.core.indexer import _generate_catalog_pages
+from power_framework.core.utils import atomic_write
+
+
+class TestAtomicWrite:
+    """A byte-bounded caller can only trust a byte-faithful writer."""
+
+    def test_write_is_byte_identical_to_content(self, tmp_path: Path):
+        content = "---\ntype: Resource\n---\n\n# Title\n\nbody\n"
+        target = tmp_path / "note.md"
+
+        atomic_write(target, content)
+
+        # Text mode with the default newline=None maps each "\n" to os.linesep,
+        # so on Windows the artifact is one byte per line larger than what the
+        # caller measured. Every byte-length contract in the codebase depends on
+        # this equality holding.
+        assert target.read_bytes() == content.encode("utf-8")
+
+    def test_written_catalog_page_respects_the_declared_limit(self, tmp_path: Path):
+        notes = [
+            {
+                "rel_path": f"03_Resources/wiki/batch/Note {index}.md",
+                "title": "N" * (1 + index % 37),
+                "description": "d" * (1 + index % 53),
+                "note_type": "Resource",
+                "tags": [],
+                "timestamp": "2026-01-01",
+                "filename": f"Note {index}.md",
+                "owner": "",
+                "status": "",
+                "expiry": "",
+                "related": [],
+            }
+            for index in range(2_000)
+        ]
+
+        pages = _generate_catalog_pages("03_Resources/wiki/batch", notes)
+        assert len(pages) > 1, "fixture must paginate for the bound to mean anything"
+
+        oversized = {}
+        for filename, content in pages.items():
+            target = tmp_path / filename
+            atomic_write(target, content)
+            size = target.stat().st_size
+            if size > INDEX_MAX_BYTES:
+                oversized[filename] = size
+
+        # The in-memory bound is already asserted by the renderer; this checks
+        # the artifact that actually lands on disk.
+        assert not oversized, f"pages exceed INDEX_MAX_BYTES on disk: {oversized}"


### PR DESCRIPTION
The 3.4.0 catalog boundary contract is enforced against a representation that
never reaches the disk on Windows.

### Symptom

Measured on a real 2 800-note vault, immediately after a clean `power index`
run on `05652b6`:

```
_index-27.md on disk : 33 129 bytes
CRLF pairs           :      481
same content as LF   : 32 648      <= INDEX_MAX_BYTES (32 768)
```

41 of 42 generated pages are over the limit. Every one carries a fresh
`timestamp` from that run, so these are pages the fixed renderer had just
written — not leftovers from the pre-#261 bug.

### Cause

`_generate_catalog_pages` bounds `len(content.encode("utf-8"))` and raises
`catalog_page_exceeds_limit` for anything over. The check passes. Then
`atomic_write` opens the temp file as

```python
os.fdopen(fd, "w", encoding=encoding)
```

Text mode with the default `newline=None` translates every `"\n"` to
`os.linesep`. On Windows the file grows by exactly one byte per line — 481
here, which is precisely the 33 129 − 32 648 gap.

So the renderer measures LF and the filesystem stores CRLF. The bound is real,
the artifact is not bound.

### Fix

`newline=""` — the file becomes exactly `content.encode(encoding)` everywhere.

### Behaviour change, stated plainly

On Windows, files written by POWER now use LF rather than CRLF. That is the
intent, not a side effect: a byte-length contract is meaningless unless the
artifact equals the measurement, and it makes vault output byte-identical
across platforms. Markdown tooling and git handle LF natively.

### Tests

Two, in a new `tests/test_utils.py` — `atomic_write` had **no test anywhere in
the suite**, which is why this survived.

1. `test_write_is_byte_identical_to_content` — the root-cause invariant.
2. `test_written_catalog_page_respects_the_declared_limit` — the visible
   symptom: paginate 2 000 variable-width notes, write each page, assert the
   on-disk size.

Before the fix, on Windows:

```
E   AssertionError: assert b'---\r\ntype...' == b'---\ntype: ...'
E     At index 3 diff: b'\r' != b'\n'
E   AssertionError: pages exceed INDEX_MAX_BYTES on disk:
      {'_index.md': 33724, '_index-2.md': 33700, '_index-3.md': 33699, ...}
```

After: `2 passed`. Full suite on Windows: **832 passed, 14 skipped**.

### Note on CI

Both tests pass on Linux regardless of the fix — `os.linesep` is `"\n"` there,
so the defect cannot exist. The `pytest` matrix runs on `ubuntu-latest` and the
`windows-latest` job runs only the CLI lifecycle, so this class is invisible to
CI by construction. That is the same blind spot that hid the healer separator
bug until #255/#266. Running even a subset of `pytest` on the Windows job would
cover both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved exact line endings and byte content when writing files atomically.
  * Ensured generated catalog pages respect the configured maximum file size.

* **Tests**
  * Added coverage for byte-faithful file output and catalog page size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->