### PR TITLE
perf(search): keep generated catalog pages out of the index

### DIFF
--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .chunker import SemanticChunker
+from .constants import is_catalog_filename
 from .db import _init_db
 from .domains import DomainConfigError, resolve_search_policy
 from .embeddings import configured_embedding_identity, get_embedding_manager
@@ -357,7 +358,7 @@ def _scan_and_search(vault_dir: Path, terms: list[str]) -> list[SearchResult]:
     results: list[SearchResult] = []
 
     for filepath in vault_dir.rglob("*.md"):
-        if filepath.name in ("index.md", "log.md", "_index.md"):
+        if filepath.name in ("index.md", "log.md") or is_catalog_filename(filepath.name):
             continue
         if should_skip(vault_dir, filepath.relative_to(vault_dir).as_posix()):
             continue
@@ -434,7 +435,12 @@ def _sync_vault_to_db(
 
     disk_files: dict[str, float] = {}
     for filepath in vault_dir.rglob("*.md"):
-        if filepath.name in ("index.md", "log.md", "_index.md"):
+        # A generated catalog is navigation, not knowledge. The literal
+        # "_index.md" was excluded but the paginated "_index-N.md" pages were
+        # not, so every page past the first entered the index as if it were a
+        # note. `is_catalog_filename` is the check the indexer and linter
+        # already use for exactly this distinction.
+        if filepath.name in ("index.md", "log.md") or is_catalog_filename(filepath.name):
             continue
         if should_skip(vault_dir, filepath.relative_to(vault_dir).as_posix()):
             continue

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -920,6 +920,38 @@ class TestVectorSearch:
         assert conn.execute("SELECT COUNT(*) FROM dense_index_manifest").fetchone()[0] == 0
         conn.close()
 
+    def test_generated_catalog_pages_never_enter_the_index(self, tmp_path: Path):
+        folder = tmp_path / "03_Resources"
+        folder.mkdir(parents=True)
+        catalog = (
+            "---\n"
+            "type: System Guide\n"
+            'title: "03 Resources Sub-Index"\n'
+            'description: "Detailed catalog of all notes in 03 Resources"\n'
+            "timestamp: 2026-07-21T00:00:00Z\n"
+            "x-generated-by: power\n"
+            "---\n\n# catalog\n"
+        )
+        # Page 1 was already excluded by name; the paginated pages were not.
+        for name in ("_index.md", "_index-2.md", "_index-17.md"):
+            (folder / name).write_text(catalog, encoding="utf-8")
+        (folder / "Real Note.md").write_text(
+            "---\n"
+            "type: Resource\n"
+            'title: "Real Note"\n'
+            'description: "Actual knowledge"\n'
+            "timestamp: 2026-07-21T00:00:00Z\n"
+            "---\n\nbody\n",
+            encoding="utf-8",
+        )
+
+        with closing(sqlite3.connect(tmp_path / "search.db")) as conn:
+            _init_db(conn)
+            _sync_vault_to_db(tmp_path, conn, sync_embeddings=False)
+            indexed = {row[0] for row in conn.execute("SELECT rel_path FROM file_metadata")}
+
+        assert indexed == {"03_Resources/Real Note.md"}
+
     def test_finds_relevant_note(self, sample_vault: Path):
         results = _vector_search(sample_vault, "project architecture")
         assert len(results) > 0


### PR DESCRIPTION
Generated catalog pages are indexed as if they were notes.

`_sync_vault_to_db` and `_scan_and_search` skip `index.md`, `log.md` and the
literal `_index.md` — but not the paginated `_index-N.md` pages that
`_generate_catalog_pages` produces. Page 1 of each folder is excluded, pages 2..N
are not.

### Measured

Real vault, 2 786 notes, active generation:

| table | total | catalog pages |
|---|---|---|
| `file_metadata` | 2850 | 77 (2.7%) |
| `chunk_embeddings` | 22117 | **5005 (22.6%)** |

Catalog pages are large by construction — `INDEX_MAX_BYTES` is 32 KiB and the
renderer fills them to the bound — so 2.7% of files yield 22.6% of chunks.

Cost of carrying them:

- embedded on every sync that touches them,
- scanned on every semantic query,
- eligible to be returned as search results, though they contain only links.

### Fix

Use `is_catalog_filename`, which already exists in `constants.py` and is the
check used for this exact distinction in `indexer.py` (4 call sites) and
`linter.py` (2). This makes the searcher agree with the rest of the codebase
rather than re-deriving a narrower rule inline.

```python
-if filepath.name in ("index.md", "log.md", "_index.md"):
+if filepath.name in ("index.md", "log.md") or is_catalog_filename(filepath.name):
```

### Test

A vault holding `_index.md`, `_index-2.md`, `_index-17.md` and one real note must
index only the note. On `main`:

```
E   AssertionError: assert {'03_Resources/Real Note.md', '03_Resources/_index-17.md',
E                           '03_Resources/_index-2.md'} == {'03_Resources/Real Note.md'}
```

Full suite on Windows: **831 passed, 14 skipped**.

### Note

Existing indexes keep the stale rows until the next `--force-rebuild`, since the
incremental sync only revisits files whose mtime changed. Deleting them on
upgrade would be a separate change; I did not want to widen this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
