### PR TITLE
perf(search): score the dense corpus with one matmul

### DIFF
--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -1120,25 +1120,32 @@ def _semantic_search(
     if q_norm == 0:
         _dense_failure("zero query embedding")
 
-    chunk_scores: list[tuple[float, str, str]] = []
-    for rel_path, blob, content in rows:
-        try:
-            dim = len(blob) // 4
-            chunk_vec = np.frombuffer(blob, dtype=np.float32)
-            if chunk_vec.shape[0] != dim:
-                continue
-        except Exception:  # noqa: S112
-            continue
+    # One matmul over the whole corpus instead of a Python loop over rows. The
+    # previous form vectorized the inner dimension but still paid interpreter
+    # and numpy-dispatch overhead per chunk, three calls at a time.
+    #
+    # Rows of another width are dropped rather than scored, so that `reshape`
+    # cannot raise on a ragged corpus. `validate_dense_index` already rejects a
+    # mixed-width index earlier, so this is a guard on the invariant rather than
+    # a reachable code path -- unlike the `chunk_vec.shape[0] != dim` check it
+    # replaces, which compared a value with itself and could never fire.
+    dim = int(q_arr.shape[0])
+    expected_bytes = dim * 4
+    usable = [row for row in rows if len(row[1]) == expected_bytes]
+    if not usable:
+        _dense_failure(f"no dense vectors of width {dim}")
 
-        # Vectorized cosine similarity (Performance Plan §5): one dot + norm
-        # instead of a Python loop over every dimension.
-        d_norm = float(np.linalg.norm(chunk_vec))
-        if d_norm == 0:
-            continue
-        similarity = float(np.dot(q_arr, chunk_vec) / (q_norm * d_norm))
-        if similarity <= 0:
-            continue
-        chunk_scores.append((similarity, rel_path, content))
+    matrix = np.frombuffer(b"".join(row[1] for row in usable), dtype=np.float32).reshape(
+        len(usable), dim
+    )
+    norms = np.linalg.norm(matrix, axis=1)
+    similarities = np.zeros(len(usable), dtype=np.float32)
+    np.divide(matrix @ q_arr, norms * q_norm, out=similarities, where=norms > 0)
+
+    chunk_scores: list[tuple[float, str, str]] = [
+        (float(similarities[i]), usable[i][0], usable[i][2])
+        for i in np.nonzero(similarities > 0)[0]
+    ]
 
     if not chunk_scores:
         return []

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -256,6 +256,70 @@ class TestSearchModeContract:
             tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master")}
         assert "dense_index_manifest" in tables
 
+    def test_dense_scan_ranks_by_cosine_and_drops_non_positive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        import struct
+
+        db_path = tmp_path / "index.db"
+        monkeypatch.setattr(
+            "power_framework.core.searcher._read_db_path", lambda _vault=None: db_path
+        )
+        monkeypatch.setattr(
+            "power_framework.core.searcher.configured_embedding_identity",
+            lambda: ("PinnedProvider", "example/model@revision"),
+        )
+
+        class _Embedder:
+            def embed(self, _query):
+                return [1.0, 0.0, 0.0, 0.0]
+
+        monkeypatch.setattr(
+            "power_framework.core.searcher.get_embedding_manager", lambda: _Embedder()
+        )
+
+        for name in ("near.md", "far.md", "orthogonal.md"):
+            (tmp_path / name).write_text(
+                "---\n"
+                "type: Resource\n"
+                f'title: "{name}"\n'
+                'description: "d"\n'
+                "timestamp: 2026-07-21T00:00:00Z\n"
+                "---\n\nbody\n",
+                encoding="utf-8",
+            )
+
+        def vec(*values):
+            return struct.pack("<%df" % len(values), *values)
+
+        with closing(sqlite3.connect(db_path)) as conn:
+            _init_db(conn)
+            conn.executemany(
+                "INSERT INTO chunk_embeddings VALUES (?, ?, ?, ?, ?)",
+                [
+                    ("c1", "near.md", vec(1.0, 0.0, 0.0, 0.0), "near", 0.0),
+                    ("c2", "far.md", vec(0.3, 0.95, 0.0, 0.0), "far", 0.0),
+                    # Non-positive similarity is dropped, as before.
+                    ("c3", "orthogonal.md", vec(0.0, 0.0, 1.0, 0.0), "orth", 0.0),
+                ],
+            )
+            conn.executemany(
+                "INSERT INTO dense_index_manifest VALUES (?, ?)",
+                [
+                    ("schema_version", "2"),
+                    ("embedding_dimension", "4"),
+                    ("chunk_count", "3"),
+                    ("embedding_provider", "PinnedProvider"),
+                    ("embedding_model", "example/model@revision"),
+                ],
+            )
+            conn.commit()
+
+        results = _semantic_search(tmp_path, "query", max_results=5)
+
+        assert [result.rel_path for result in results] == ["near.md", "far.md"]
+        assert results[0].score > results[1].score
+
     def test_dense_index_validation_requires_matching_manifest(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):


### PR DESCRIPTION
The dense scan loops over every chunk in Python. The comment above it says the
work is vectorized, but only the inner dimension is — the outer loop still runs
once per chunk with three numpy calls each.

```python
for rel_path, blob, content in rows:
    chunk_vec = np.frombuffer(blob, dtype=np.float32)
    d_norm = float(np.linalg.norm(chunk_vec))
    similarity = float(np.dot(q_arr, chunk_vec) / (q_norm * d_norm))
```

Stacking the corpus once and taking `matrix @ query` moves the scan into a
single BLAS call.

### Measured

Real index, 22 117 chunks × 1024 dims, warm cache:

| | |
|---|---|
| per-row Python loop | 0.097 s |
| one matmul | **0.008 s** |
| speedup | **11.4×** |
| identical top-10 | ✅ |

For scale: 22 117 × 1024 is ~45 MFLOP. The arithmetic was never the cost — the
per-row dispatch was.

### A guard that could not fire

The old code did:

```python
dim = len(blob) // 4
chunk_vec = np.frombuffer(blob, dtype=np.float32)
if chunk_vec.shape[0] != dim:
    continue
```

`chunk_vec.shape[0]` **is** `len(blob) // 4`, so the condition compared a value
with itself and never skipped anything. The replacement filters on the query
width instead. To be precise about its value: `validate_dense_index` already
rejects a mixed-width index (`min_size != max_size`) before the scan runs, so
the new filter guards the invariant and keeps `reshape` total — it is not
fixing a reachable bug. I checked this by trying to write a test that reaches
it, and could not.

### Behaviour

Unchanged: same cosine, same `> 0` filter, same per-document best chunk, same
ordering. The added test pins ranking order and the non-positive drop, and
**passes on both implementations** — it is there to keep the optimization
honest, not to demonstrate a defect.

Full suite on Windows: **831 passed, 14 skipped**.

### Context

This is one of three related changes. The other two are #279 (catalog pages
should not be in the index at all — they are 22.6% of chunks) and a follow-up
that stops reading chunk `content` during the scan pass. They are independent;
this one is the smallest.

Worth noting for #240: with the scan at 8 ms, an ANN index would be optimizing
well under 1% of a semantic query's latency here. On this corpus an end-to-end
CLI query measures 2.04 s, of which the DB read and scan together are 0.39 s and
the rest is process start and ONNX session creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
