### PR TITLE
perf(search): fetch chunk text only for the results that use it

### DIFF
--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -1120,25 +1120,32 @@ def _semantic_search(
     if q_norm == 0:
         _dense_failure("zero query embedding")
 
-    chunk_scores: list[tuple[float, str, str]] = []
-    for rel_path, blob, content in rows:
-        try:
-            dim = len(blob) // 4
-            chunk_vec = np.frombuffer(blob, dtype=np.float32)
-            if chunk_vec.shape[0] != dim:
-                continue
-        except Exception:  # noqa: S112
-            continue
+    # One matmul over the whole corpus instead of a Python loop over rows. The
+    # previous form vectorized the inner dimension but still paid interpreter
+    # and numpy-dispatch overhead per chunk, three calls at a time.
+    #
+    # Rows of another width are dropped rather than scored, so that `reshape`
+    # cannot raise on a ragged corpus. `validate_dense_index` already rejects a
+    # mixed-width index earlier, so this is a guard on the invariant rather than
+    # a reachable code path -- unlike the `chunk_vec.shape[0] != dim` check it
+    # replaces, which compared a value with itself and could never fire.
+    dim = int(q_arr.shape[0])
+    expected_bytes = dim * 4
+    usable = [row for row in rows if len(row[1]) == expected_bytes]
+    if not usable:
+        _dense_failure(f"no dense vectors of width {dim}")
 
-        # Vectorized cosine similarity (Performance Plan §5): one dot + norm
-        # instead of a Python loop over every dimension.
-        d_norm = float(np.linalg.norm(chunk_vec))
-        if d_norm == 0:
-            continue
-        similarity = float(np.dot(q_arr, chunk_vec) / (q_norm * d_norm))
-        if similarity <= 0:
-            continue
-        chunk_scores.append((similarity, rel_path, content))
+    matrix = np.frombuffer(b"".join(row[1] for row in usable), dtype=np.float32).reshape(
+        len(usable), dim
+    )
+    norms = np.linalg.norm(matrix, axis=1)
+    similarities = np.zeros(len(usable), dtype=np.float32)
+    np.divide(matrix @ q_arr, norms * q_norm, out=similarities, where=norms > 0)
+
+    chunk_scores: list[tuple[float, str, str]] = [
+        (float(similarities[i]), usable[i][0], usable[i][2])
+        for i in np.nonzero(similarities > 0)[0]
+    ]
 
     if not chunk_scores:
         return []

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -1102,7 +1102,11 @@ def _semantic_search(
         conn = _open_readonly_db(db_path)
 
         cursor = conn.cursor()
-        cursor.execute("SELECT rel_path, embedding, content FROM chunk_embeddings")
+        # Chunk text is only ever needed for the handful of chunks that end up
+        # as snippets, but reading it here pulls the whole corpus body through
+        # sqlite and into Python on every query. Measured on a 22 117-chunk
+        # index: 0.293 s with `content`, 0.173 s without.
+        cursor.execute("SELECT chunk_id, rel_path, embedding FROM chunk_embeddings")
         rows = cursor.fetchall()
     except Exception as exc:
         _dense_failure(f"db error: {type(exc).__name__}")
@@ -1131,11 +1135,11 @@ def _semantic_search(
     # replaces, which compared a value with itself and could never fire.
     dim = int(q_arr.shape[0])
     expected_bytes = dim * 4
-    usable = [row for row in rows if len(row[1]) == expected_bytes]
+    usable = [row for row in rows if len(row[2]) == expected_bytes]
     if not usable:
         _dense_failure(f"no dense vectors of width {dim}")
 
-    matrix = np.frombuffer(b"".join(row[1] for row in usable), dtype=np.float32).reshape(
+    matrix = np.frombuffer(b"".join(row[2] for row in usable), dtype=np.float32).reshape(
         len(usable), dim
     )
     norms = np.linalg.norm(matrix, axis=1)
@@ -1143,7 +1147,7 @@ def _semantic_search(
     np.divide(matrix @ q_arr, norms * q_norm, out=similarities, where=norms > 0)
 
     chunk_scores: list[tuple[float, str, str]] = [
-        (float(similarities[i]), usable[i][0], usable[i][2])
+        (float(similarities[i]), usable[i][1], usable[i][0])
         for i in np.nonzero(similarities > 0)[0]
     ]
 
@@ -1151,12 +1155,33 @@ def _semantic_search(
         return []
 
     doc_best: dict[str, tuple[float, str]] = {}
-    for similarity, rel_path, content in chunk_scores:
+    for similarity, rel_path, chunk_id in chunk_scores:
         if rel_path not in doc_best or similarity > doc_best[rel_path][0]:
-            doc_best[rel_path] = (similarity, content)
+            doc_best[rel_path] = (similarity, chunk_id)
 
     scored_docs = sorted(doc_best.items(), key=lambda x: -x[1][0])
     top_paths = [rel for rel, _ in scored_docs[:max_results]]
+
+    # Only the winning chunk of each returned document needs its text.
+    snippets: dict[str, str] = {}
+    wanted = [doc_best[rel][1] for rel in top_paths]
+    if wanted:
+        conn = None
+        try:
+            conn = _open_readonly_db(db_path)
+            placeholders = ",".join("?" * len(wanted))
+            snippets = dict(
+                conn.execute(
+                    f"SELECT chunk_id, content FROM chunk_embeddings "  # noqa: S608
+                    f"WHERE chunk_id IN ({placeholders})",
+                    wanted,
+                ).fetchall()
+            )
+        except Exception as exc:
+            _dense_failure(f"db error: {type(exc).__name__}")
+        finally:
+            if conn is not None:
+                conn.close()
 
     results: list[SearchResult] = []
     for rel_path in top_paths:
@@ -1166,7 +1191,8 @@ def _semantic_search(
             metadata = validate_metadata(content)
             if metadata is None:
                 continue
-            similarity, snippet = doc_best[rel_path]
+            similarity, chunk_id = doc_best[rel_path]
+            snippet = snippets.get(chunk_id, "")
             results.append(
                 SearchResult(
                     rel_path=rel_path,

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -256,6 +256,70 @@ class TestSearchModeContract:
             tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master")}
         assert "dense_index_manifest" in tables
 
+    def test_dense_scan_ranks_by_cosine_and_drops_non_positive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        import struct
+
+        db_path = tmp_path / "index.db"
+        monkeypatch.setattr(
+            "power_framework.core.searcher._read_db_path", lambda _vault=None: db_path
+        )
+        monkeypatch.setattr(
+            "power_framework.core.searcher.configured_embedding_identity",
+            lambda: ("PinnedProvider", "example/model@revision"),
+        )
+
+        class _Embedder:
+            def embed(self, _query):
+                return [1.0, 0.0, 0.0, 0.0]
+
+        monkeypatch.setattr(
+            "power_framework.core.searcher.get_embedding_manager", lambda: _Embedder()
+        )
+
+        for name in ("near.md", "far.md", "orthogonal.md"):
+            (tmp_path / name).write_text(
+                "---\n"
+                "type: Resource\n"
+                f'title: "{name}"\n'
+                'description: "d"\n'
+                "timestamp: 2026-07-21T00:00:00Z\n"
+                "---\n\nbody\n",
+                encoding="utf-8",
+            )
+
+        def vec(*values):
+            return struct.pack("<%df" % len(values), *values)
+
+        with closing(sqlite3.connect(db_path)) as conn:
+            _init_db(conn)
+            conn.executemany(
+                "INSERT INTO chunk_embeddings VALUES (?, ?, ?, ?, ?)",
+                [
+                    ("c1", "near.md", vec(1.0, 0.0, 0.0, 0.0), "near", 0.0),
+                    ("c2", "far.md", vec(0.3, 0.95, 0.0, 0.0), "far", 0.0),
+                    # Non-positive similarity is dropped, as before.
+                    ("c3", "orthogonal.md", vec(0.0, 0.0, 1.0, 0.0), "orth", 0.0),
+                ],
+            )
+            conn.executemany(
+                "INSERT INTO dense_index_manifest VALUES (?, ?)",
+                [
+                    ("schema_version", "2"),
+                    ("embedding_dimension", "4"),
+                    ("chunk_count", "3"),
+                    ("embedding_provider", "PinnedProvider"),
+                    ("embedding_model", "example/model@revision"),
+                ],
+            )
+            conn.commit()
+
+        results = _semantic_search(tmp_path, "query", max_results=5)
+
+        assert [result.rel_path for result in results] == ["near.md", "far.md"]
+        assert results[0].score > results[1].score
+
     def test_dense_index_validation_requires_matching_manifest(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -319,6 +319,9 @@ class TestSearchModeContract:
 
         assert [result.rel_path for result in results] == ["near.md", "far.md"]
         assert results[0].score > results[1].score
+        # The snippet must still be the text of the winning chunk, even though
+        # chunk text is no longer carried through the scan.
+        assert [result.snippet for result in results] == ["near", "far"]
 
     def test_dense_index_validation_requires_matching_manifest(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
> **Builds on #280.** That PR is the first commit here; review it first. Once
> #280 lands this diff reduces to the second commit.

The dense scan reads `content` for every chunk, pulling the whole corpus body
through sqlite and into Python on every query. Only the winning chunk of each
returned document ever becomes a snippet — a few rows out of tens of thousands
at the default page size.

### Measured

22 117-chunk index, warm cache:

| query | time |
|---|---|
| `SELECT rel_path, embedding, content` | 0.293 s |
| `SELECT chunk_id, rel_path, embedding` | **0.173 s** |

Payload split: 90.6 MB of vectors against 17.7 MB of chunk text. So this drops
about a sixth of the bytes read, plus the Python objects built for them — and it
scales with note *length*, not note count, so it grows on prose-heavy vaults.

### Change

Scan selects `chunk_id, rel_path, embedding`. After the top documents are known,
one `WHERE chunk_id IN (...)` fetches exactly the snippets that will be
returned.

### Behaviour

Unchanged. The dense test from #280 now also asserts each result's snippet is
still the text of its winning chunk — that is the property this could plausibly
break, so it is pinned rather than argued.

Full suite on Windows: **831 passed, 14 skipped**.

### Not done here

The scan still reads all vectors on every query. Since generations are
immutable, the stacked matrix could be built once per generation and reused —
which matters most for the long-lived MCP server, where it currently re-reads
90 MB per query. That is a caching change with a lifetime question attached, so
it does not belong in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
