### PR TITLE
perf(search): keep dense retrieval exact and lean

### DIFF
--- a/src/power_framework/core/generation_index.py
+++ b/src/power_framework/core/generation_index.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from .constants import is_catalog_filename
 from .db import _init_db
 from .ignore import should_skip
 from .parser import read_file_content, validate_metadata
@@ -172,7 +173,7 @@ def _source_inventory(vault_dir: Path) -> SourceInventory:
     invalid_sources: dict[str, str] = {}
     total_scanned = 0
     for path in sorted(vault_dir.rglob("*.md")):
-        if path.name in {"index.md", "log.md", "_index.md"}:
+        if path.name in {"index.md", "log.md"} or is_catalog_filename(path.name):
             continue
         rel_path = path.relative_to(vault_dir).as_posix()
         if should_skip(vault_dir, rel_path):

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .chunker import SemanticChunker
+from .constants import is_catalog_filename
 from .db import _init_db
 from .domains import DomainConfigError, resolve_search_policy
 from .embeddings import configured_embedding_identity, get_embedding_manager
@@ -357,7 +358,7 @@ def _scan_and_search(vault_dir: Path, terms: list[str]) -> list[SearchResult]:
     results: list[SearchResult] = []
 
     for filepath in vault_dir.rglob("*.md"):
-        if filepath.name in ("index.md", "log.md", "_index.md"):
+        if filepath.name in ("index.md", "log.md") or is_catalog_filename(filepath.name):
             continue
         if should_skip(vault_dir, filepath.relative_to(vault_dir).as_posix()):
             continue
@@ -434,7 +435,9 @@ def _sync_vault_to_db(
 
     disk_files: dict[str, float] = {}
     for filepath in vault_dir.rglob("*.md"):
-        if filepath.name in ("index.md", "log.md", "_index.md"):
+        # Generated catalogs are navigation, not knowledge. Keep every page
+        # out of both sparse and dense indexes, including `_index-N.md` pages.
+        if filepath.name in ("index.md", "log.md") or is_catalog_filename(filepath.name):
             continue
         if should_skip(vault_dir, filepath.relative_to(vault_dir).as_posix()):
             continue
@@ -1102,7 +1105,9 @@ def _semantic_search(
         conn = _open_readonly_db(db_path)
 
         cursor = conn.cursor()
-        cursor.execute("SELECT rel_path, embedding, content FROM chunk_embeddings")
+        # Chunk text is needed only for the few winners that become snippets.
+        # Avoid pulling the whole corpus body through SQLite on every query.
+        cursor.execute("SELECT chunk_id, rel_path, embedding FROM chunk_embeddings")
         rows = cursor.fetchall()
     except Exception as exc:
         _dense_failure(f"db error: {type(exc).__name__}")
@@ -1120,36 +1125,57 @@ def _semantic_search(
     if q_norm == 0:
         _dense_failure("zero query embedding")
 
-    chunk_scores: list[tuple[float, str, str]] = []
-    for rel_path, blob, content in rows:
-        try:
-            dim = len(blob) // 4
-            chunk_vec = np.frombuffer(blob, dtype=np.float32)
-            if chunk_vec.shape[0] != dim:
-                continue
-        except Exception:  # noqa: S112
-            continue
+    # Score the complete corpus in one matrix multiplication. The former code
+    # vectorized only the inner dimension and still paid Python/NumPy dispatch
+    # once per chunk.
+    dim = int(q_arr.shape[0])
+    expected_bytes = dim * 4
+    usable = [row for row in rows if len(row[2]) == expected_bytes]
+    if not usable:
+        _dense_failure(f"no dense vectors of width {dim}")
 
-        # Vectorized cosine similarity (Performance Plan §5): one dot + norm
-        # instead of a Python loop over every dimension.
-        d_norm = float(np.linalg.norm(chunk_vec))
-        if d_norm == 0:
-            continue
-        similarity = float(np.dot(q_arr, chunk_vec) / (q_norm * d_norm))
-        if similarity <= 0:
-            continue
-        chunk_scores.append((similarity, rel_path, content))
+    matrix = np.frombuffer(b"".join(row[2] for row in usable), dtype=np.float32).reshape(
+        len(usable), dim
+    )
+    norms = np.linalg.norm(matrix, axis=1)
+    similarities = np.zeros(len(usable), dtype=np.float32)
+    np.divide(matrix @ q_arr, norms * q_norm, out=similarities, where=norms > 0)
+
+    chunk_scores: list[tuple[float, str, str]] = [
+        (float(similarities[i]), usable[i][1], usable[i][0])
+        for i in np.nonzero(similarities > 0)[0]
+    ]
 
     if not chunk_scores:
         return []
 
     doc_best: dict[str, tuple[float, str]] = {}
-    for similarity, rel_path, content in chunk_scores:
+    for similarity, rel_path, chunk_id in chunk_scores:
         if rel_path not in doc_best or similarity > doc_best[rel_path][0]:
-            doc_best[rel_path] = (similarity, content)
+            doc_best[rel_path] = (similarity, chunk_id)
 
     scored_docs = sorted(doc_best.items(), key=lambda x: -x[1][0])
     top_paths = [rel for rel, _ in scored_docs[:max_results]]
+
+    snippets: dict[str, str] = {}
+    wanted = [doc_best[rel][1] for rel in top_paths]
+    if wanted:
+        conn = None
+        try:
+            conn = _open_readonly_db(db_path)
+            placeholders = ",".join("?" * len(wanted))
+            snippets = dict(
+                conn.execute(
+                    f"SELECT chunk_id, content FROM chunk_embeddings "  # noqa: S608
+                    f"WHERE chunk_id IN ({placeholders})",
+                    wanted,
+                ).fetchall()
+            )
+        except Exception as exc:
+            _dense_failure(f"db error: {type(exc).__name__}")
+        finally:
+            if conn is not None:
+                conn.close()
 
     results: list[SearchResult] = []
     for rel_path in top_paths:
@@ -1159,7 +1185,7 @@ def _semantic_search(
             metadata = validate_metadata(content)
             if metadata is None:
                 continue
-            similarity, snippet = doc_best[rel_path]
+            similarity, chunk_id = doc_best[rel_path]
             results.append(
                 SearchResult(
                     rel_path=rel_path,
@@ -1167,7 +1193,7 @@ def _semantic_search(
                     description=metadata.description,
                     note_type=metadata.type,
                     score=similarity,
-                    snippet=snippet,
+                    snippet=snippets.get(chunk_id, ""),
                     match_count=1,
                     tags=metadata.tags,
                 )

--- a/tests/test_generation_index.py
+++ b/tests/test_generation_index.py
@@ -249,6 +249,34 @@ def test_invalid_sources_are_explicitly_recorded(
     assert (invalid_count, reason) == (1, "invalid_metadata")
 
 
+def test_generated_catalog_pages_are_outside_generation_coverage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    vault = _vault(tmp_path, "catalog-boundary", "valid-token")
+    catalog = (
+        "---\n"
+        "type: System Guide\n"
+        'title: "Generated catalog"\n'
+        'description: "Navigation only"\n'
+        "timestamp: 2026-07-27T00:00:00Z\n"
+        "x-generated-by: power\n"
+        "---\n\n# catalog\n"
+    )
+    catalog_dir = vault / "03_Resources"
+    catalog_dir.mkdir(parents=True)
+    for name in ("_index.md", "_index-2.md", "_index-17.md"):
+        (catalog_dir / name).write_text(catalog, encoding="utf-8")
+
+    report = sync_vault_atomically(vault, sync_embeddings=False)
+
+    assert (report.total_scanned, report.expected_files, report.actual_files) == (1, 1, 1)
+    assert report.excluded_sources == {}
+    with closing(sqlite3.connect(_active_db(vault))) as conn:
+        indexed = {row[0] for row in conn.execute("SELECT rel_path FROM file_metadata")}
+    assert indexed == {"01_Projects/Test.md"}
+
+
 def test_sync_can_fail_closed_before_publishing_excluded_sources(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -256,6 +256,70 @@ class TestSearchModeContract:
             tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master")}
         assert "dense_index_manifest" in tables
 
+    def test_dense_scan_ranks_by_cosine_and_preserves_winner_snippets(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        import struct
+
+        db_path = tmp_path / "index.db"
+        monkeypatch.setattr(
+            "power_framework.core.searcher._read_db_path", lambda _vault=None: db_path
+        )
+        monkeypatch.setattr(
+            "power_framework.core.searcher.configured_embedding_identity",
+            lambda: ("PinnedProvider", "example/model@revision"),
+        )
+
+        class _Embedder:
+            def embed(self, _query):
+                return [1.0, 0.0, 0.0, 0.0]
+
+        monkeypatch.setattr(
+            "power_framework.core.searcher.get_embedding_manager", lambda: _Embedder()
+        )
+
+        for name in ("near.md", "far.md", "orthogonal.md"):
+            (tmp_path / name).write_text(
+                "---\n"
+                "type: Resource\n"
+                f'title: "{name}"\n'
+                'description: "d"\n'
+                "timestamp: 2026-07-21T00:00:00Z\n"
+                "---\n\nbody\n",
+                encoding="utf-8",
+            )
+
+        def vec(*values):
+            return struct.pack(f"<{len(values)}f", *values)
+
+        with closing(sqlite3.connect(db_path)) as conn:
+            _init_db(conn)
+            conn.executemany(
+                "INSERT INTO chunk_embeddings VALUES (?, ?, ?, ?, ?)",
+                [
+                    ("c1", "near.md", vec(1.0, 0.0, 0.0, 0.0), "near", 0.0),
+                    ("c2", "far.md", vec(0.3, 0.95, 0.0, 0.0), "far", 0.0),
+                    ("c3", "orthogonal.md", vec(0.0, 0.0, 1.0, 0.0), "orth", 0.0),
+                ],
+            )
+            conn.executemany(
+                "INSERT INTO dense_index_manifest VALUES (?, ?)",
+                [
+                    ("schema_version", "2"),
+                    ("embedding_dimension", "4"),
+                    ("chunk_count", "3"),
+                    ("embedding_provider", "PinnedProvider"),
+                    ("embedding_model", "example/model@revision"),
+                ],
+            )
+            conn.commit()
+
+        results = _semantic_search(tmp_path, "query", max_results=5)
+
+        assert [result.rel_path for result in results] == ["near.md", "far.md"]
+        assert results[0].score > results[1].score
+        assert [result.snippet for result in results] == ["near", "far"]
+
     def test_dense_index_validation_requires_matching_manifest(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -919,6 +983,37 @@ class TestVectorSearch:
         assert conn.execute("SELECT COUNT(*) FROM chunk_embeddings").fetchone()[0] == 0
         assert conn.execute("SELECT COUNT(*) FROM dense_index_manifest").fetchone()[0] == 0
         conn.close()
+
+    def test_generated_catalog_pages_never_enter_the_index(self, tmp_path: Path):
+        folder = tmp_path / "03_Resources"
+        folder.mkdir(parents=True)
+        catalog = (
+            "---\n"
+            "type: System Guide\n"
+            'title: "03 Resources Sub-Index"\n'
+            'description: "Detailed catalog of all notes in 03 Resources"\n'
+            "timestamp: 2026-07-21T00:00:00Z\n"
+            "x-generated-by: power\n"
+            "---\n\n# catalog\n"
+        )
+        for name in ("_index.md", "_index-2.md", "_index-17.md"):
+            (folder / name).write_text(catalog, encoding="utf-8")
+        (folder / "Real Note.md").write_text(
+            "---\n"
+            "type: Resource\n"
+            'title: "Real Note"\n'
+            'description: "Actual knowledge"\n'
+            "timestamp: 2026-07-21T00:00:00Z\n"
+            "---\n\nbody\n",
+            encoding="utf-8",
+        )
+
+        with closing(sqlite3.connect(tmp_path / "search.db")) as conn:
+            _init_db(conn)
+            _sync_vault_to_db(tmp_path, conn, sync_embeddings=False)
+            indexed = {row[0] for row in conn.execute("SELECT rel_path FROM file_metadata")}
+
+        assert indexed == {"03_Resources/Real Note.md"}
 
     def test_finds_relevant_note(self, sample_vault: Path):
         results = _vector_search(sample_vault, "project architecture")


### PR DESCRIPTION
## Summary

Implements the first evidence-backed 3.4.4 retrieval slice from #240 and #283.

- excludes every generated catalog page (`_index.md` and `_index-N.md`) from sparse/dense search and generation coverage;
- scores dense vectors with one exact cosine matmul while preserving the existing positive-similarity and per-note-max semantics;
- fetches chunk content only for winning snippets instead of loading the full corpus body during scoring;
- adds exact ranking/snippet and generation-coverage regressions.

ANN and reranker changes are intentionally not included: the current field report measures the dense scan at about 0.39 s of an approximately 18 s real query, so the next slice must measure temporal/cold-start overhead first.

## Validation

- `tests/test_searcher.py` + `tests/test_generation_index.py`: 98 passed
- full local suite before the final generation-inventory consistency addition: 878 passed, 10 skipped
- synthetic 22,117 x 1,024 dense benchmark: 0.2445–0.2794 s/query; exact top-10 match
- Ruff format/check, mypy for changed source, `git diff --check`
- signed commit: `f8e7238`

Refs #240
Refs #283


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated catalog pages, including `_index*.md` files, are now excluded from note scanning, coverage checks, and search indexing.
  * Search results remain accurate when stored embeddings have incompatible dimensions.

* **Performance**
  * Dense semantic search now processes rankings more efficiently and retrieves content only for the highest-ranked results.

* **Search Improvements**
  * Improved semantic result ranking while preserving relevant result snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->