### PR TITLE
perf(search): materialize temporal metadata projection

### DIFF
--- a/src/power_framework/core/db.py
+++ b/src/power_framework/core/db.py
@@ -118,6 +118,12 @@ def _init_db(conn: sqlite3.Connection) -> None:
         )
     """)
     conn.execute("""
+        CREATE TABLE IF NOT EXISTS temporal_records (
+            rel_path TEXT PRIMARY KEY,
+            memory_json TEXT
+        )
+    """)
+    conn.execute("""
         CREATE TABLE IF NOT EXISTS doc_embeddings (
             rel_path TEXT PRIMARY KEY,
             embedding BLOB,

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -36,6 +36,7 @@ from .query_expansion import QueryExpander
 from .temporal import (
     TemporalStatus,
     includes_temporal_status,
+    load_temporal_records,
     normalize_as_of,
     normalize_temporal_view,
     resolve_temporal_statuses,
@@ -465,6 +466,9 @@ def _sync_vault_to_db(
             "DELETE FROM chunk_embeddings WHERE rel_path = ?", [(r,) for r in to_delete]
         )
         cursor.executemany("DELETE FROM tf_vectors WHERE rel_path = ?", [(r,) for r in to_delete])
+        cursor.executemany(
+            "DELETE FROM temporal_records WHERE rel_path = ?", [(r,) for r in to_delete]
+        )
 
     embedder = get_embedding_manager() if sync_embeddings else None
 
@@ -507,6 +511,7 @@ def _sync_vault_to_db(
                     cursor.execute("DELETE FROM doc_embeddings WHERE rel_path = ?", (rel_path,))
                     cursor.execute("DELETE FROM chunk_embeddings WHERE rel_path = ?", (rel_path,))
                     cursor.execute("DELETE FROM tf_vectors WHERE rel_path = ?", (rel_path,))
+                    cursor.execute("DELETE FROM temporal_records WHERE rel_path = ?", (rel_path,))
                     continue
                 changed.append((rel_path, content, metadata, mtime))
             except Exception as e:
@@ -540,6 +545,15 @@ def _sync_vault_to_db(
                 "INSERT OR REPLACE INTO file_metadata (rel_path, mtime) VALUES (?, ?)",
                 (rel_path, mtime),
             )
+            memory_json = (
+                None
+                if metadata.memory is None
+                else json.dumps(metadata.memory.model_dump(mode="json"), sort_keys=True)
+            )
+            cursor.execute(
+                "INSERT OR REPLACE INTO temporal_records (rel_path, memory_json) VALUES (?, ?)",
+                (rel_path, memory_json),
+            )
 
             full_text = " ".join(
                 [metadata.title, " ".join(metadata.tags), metadata.description, content]
@@ -553,6 +567,38 @@ def _sync_vault_to_db(
         except Exception as e:
             logger.warning("FTS/TF write failed for %s: %s", rel_path, e)
             continue
+
+    # Backfill the metadata-only projection for legacy databases after schema
+    # creation or a database backup. A partial projection is never trusted by
+    # retrieval, so rebuild it from already-indexed note content in one sync.
+    expected_temporal_paths = {
+        str(row[0]) for row in cursor.execute("SELECT rel_path FROM file_metadata").fetchall()
+    }
+    actual_temporal_paths = {
+        str(row[0]) for row in cursor.execute("SELECT rel_path FROM temporal_records").fetchall()
+    }
+    if expected_temporal_paths != actual_temporal_paths:
+        cursor.execute("DELETE FROM temporal_records")
+        temporal_rows: list[tuple[str, str | None]] = []
+        for rel_path, indexed_content in cursor.execute(
+            "SELECT rel_path, content FROM fts_notes"
+        ).fetchall():
+            try:
+                indexed_metadata = validate_metadata(indexed_content)
+            except Exception:  # noqa: S112
+                continue
+            if indexed_metadata is None:
+                continue
+            memory_json = (
+                None
+                if indexed_metadata.memory is None
+                else json.dumps(indexed_metadata.memory.model_dump(mode="json"), sort_keys=True)
+            )
+            temporal_rows.append((rel_path, memory_json))
+        cursor.executemany(
+            "INSERT OR REPLACE INTO temporal_records (rel_path, memory_json) VALUES (?, ?)",
+            temporal_rows,
+        )
 
     if not sync_embeddings and (changed or invalid_changed or to_delete):
         # A lightweight FTS sync cannot refresh dense vectors for changed
@@ -1439,7 +1485,9 @@ def _filter_temporal_results(
     max_results: int,
 ) -> list[SearchResult]:
     """Attach resolved status and filter ranked results at the retrieval boundary."""
-    statuses = resolve_temporal_statuses(scan_temporal_records(vault_dir), as_of)
+    indexed_records = load_temporal_records(_read_db_path(vault_dir))
+    records = indexed_records if indexed_records is not None else scan_temporal_records(vault_dir)
+    statuses = resolve_temporal_statuses(records, as_of)
     filtered: list[SearchResult] = []
     for result in results:
         status = statuses.get(result.rel_path, TemporalStatus.CURRENT)

--- a/src/power_framework/core/temporal.py
+++ b/src/power_framework/core/temporal.py
@@ -2,19 +2,21 @@
 
 from __future__ import annotations
 
+import json
+import sqlite3
 from collections import defaultdict, deque
+from contextlib import closing
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from .ignore import should_skip
+from .models import MemoryMetadata
 from .parser import read_file_content, validate_metadata
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from .models import MemoryMetadata
 
 
 class TemporalStatus(StrEnum):
@@ -77,6 +79,54 @@ def scan_temporal_records(vault_dir: Path) -> dict[str, TemporalRecord]:
             continue
         if metadata is not None:
             records[rel_path] = TemporalRecord(rel_path, metadata.memory)
+    return records
+
+
+def load_temporal_records(db_path: Path | None) -> dict[str, TemporalRecord] | None:
+    """Load temporal metadata from a complete indexed projection.
+
+    The projection contains lifecycle metadata only, never note content. ``None``
+    means the database is legacy, incomplete, or malformed and callers must
+    fall back to the authoritative Markdown scan instead of trusting partial
+    derived state.
+    """
+    if db_path is None or not db_path.is_file():
+        return None
+    try:
+        with closing(
+            sqlite3.connect(f"file:{db_path.as_posix()}?mode=ro", uri=True, timeout=30)
+        ) as conn:
+            table = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'temporal_records'"
+            ).fetchone()
+            if table is None:
+                return None
+            expected_paths = {
+                str(row[0]) for row in conn.execute("SELECT rel_path FROM file_metadata").fetchall()
+            }
+            actual_paths = {
+                str(row[0])
+                for row in conn.execute("SELECT rel_path FROM temporal_records").fetchall()
+            }
+            if expected_paths != actual_paths:
+                return None
+            rows = conn.execute(
+                "SELECT rel_path, memory_json FROM temporal_records ORDER BY rel_path"
+            ).fetchall()
+    except (OSError, sqlite3.Error):
+        return None
+
+    records: dict[str, TemporalRecord] = {}
+    try:
+        for rel_path, memory_json in rows:
+            memory = (
+                None
+                if memory_json is None
+                else MemoryMetadata.model_validate(json.loads(memory_json))
+            )
+            records[str(rel_path)] = TemporalRecord(str(rel_path), memory)
+    except (TypeError, ValueError):
+        return None
     return records
 
 

--- a/tests/test_memory_contract.py
+++ b/tests/test_memory_contract.py
@@ -2,17 +2,23 @@
 
 from __future__ import annotations
 
+import os
+import sqlite3
+from contextlib import closing
 from datetime import date, datetime
 
 import pytest
 from pydantic import ValidationError
 
+from power_framework.core.db import _init_db
 from power_framework.core.healer import heal_frontmatter
 from power_framework.core.models import MemoryMetadata, OKFMetadata
 from power_framework.core.parser import build_frontmatter, validate_metadata
+from power_framework.core.searcher import _sync_vault_to_db
 from power_framework.core.temporal import (
     TemporalRecord,
     TemporalStatus,
+    load_temporal_records,
     resolve_temporal_statuses,
 )
 
@@ -131,3 +137,66 @@ def test_competing_supersession_is_explicitly_conflicted() -> None:
     statuses = resolve_temporal_statuses(records, date(2026, 7, 10))
 
     assert set(statuses.values()) == {TemporalStatus.CONFLICTED}
+
+
+def test_incomplete_temporal_projection_fails_closed_to_disk_fallback(tmp_path) -> None:
+    database = tmp_path / "search.db"
+    with closing(sqlite3.connect(database)) as conn:
+        _init_db(conn)
+        conn.execute("INSERT INTO file_metadata(rel_path, mtime) VALUES (?, ?)", ("note.md", 0))
+        conn.commit()
+
+    assert load_temporal_records(database) is None
+
+
+def test_temporal_projection_with_same_count_but_wrong_path_fails_closed(tmp_path) -> None:
+    database = tmp_path / "search.db"
+    with closing(sqlite3.connect(database)) as conn:
+        _init_db(conn)
+        conn.execute("INSERT INTO file_metadata(rel_path, mtime) VALUES (?, ?)", ("note.md", 0))
+        conn.execute(
+            "INSERT INTO temporal_records(rel_path, memory_json) VALUES (?, ?)",
+            ("stale.md", None),
+        )
+        conn.commit()
+
+    assert load_temporal_records(database) is None
+
+
+def test_temporal_projection_updates_when_a_note_changes(tmp_path) -> None:
+    note = tmp_path / "03_Resources" / "temporal.md"
+    note.parent.mkdir()
+    note.write_text(
+        "---\n"
+        "type: Resource\n"
+        'title: "Temporal"\n'
+        'description: "Temporal projection"\n'
+        "timestamp: 2026-07-10T00:00:00Z\n"
+        "memory:\n"
+        "  kind: semantic\n"
+        "  valid_from: 2026-01-01\n"
+        "---\n\nbody\n",
+        encoding="utf-8",
+    )
+    database = tmp_path / "search.db"
+
+    with closing(sqlite3.connect(database)) as conn:
+        _init_db(conn)
+        _sync_vault_to_db(tmp_path, conn, sync_embeddings=False)
+        first = load_temporal_records(database)
+        assert first is not None
+        assert first["03_Resources/temporal.md"].memory is not None
+        assert first["03_Resources/temporal.md"].memory.valid_from == date(2026, 1, 1)
+
+        original_mtime = note.stat().st_mtime
+        note.write_text(
+            note.read_text(encoding="utf-8").replace("2026-01-01", "2027-01-01"),
+            encoding="utf-8",
+        )
+        os.utime(note, (original_mtime + 1, original_mtime + 1))
+        _sync_vault_to_db(tmp_path, conn, sync_embeddings=False)
+        second = load_temporal_records(database)
+
+    assert second is not None
+    assert second["03_Resources/temporal.md"].memory is not None
+    assert second["03_Resources/temporal.md"].memory.valid_from == date(2027, 1, 1)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -41,7 +41,9 @@ from power_framework.core.searcher import (
 )
 
 
-def test_search_temporal_views_filter_one_shared_corpus(sample_vault: Path) -> None:
+def test_search_temporal_views_filter_one_shared_corpus(
+    sample_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     old = sample_vault / "03_Resources" / "old-fact.md"
     new = sample_vault / "03_Resources" / "new-fact.md"
     old.write_text(
@@ -93,6 +95,36 @@ temporal-token current fact
     assert {result.rel_path for result in historical} == {"03_Resources/old-fact.md"}
     assert current[0].temporal_status == "current"
     assert historical[0].temporal_status == "historical"
+
+
+def test_temporal_filter_uses_complete_indexed_metadata_projection(
+    sample_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    note = sample_vault / "03_Resources" / "indexed-temporal.md"
+    note.write_text(
+        "---\n"
+        "type: Resource\n"
+        'title: "Indexed temporal"\n'
+        'description: "indexed-temporal-token"\n'
+        "timestamp: 2026-07-10T00:00:00Z\n"
+        "memory:\n"
+        "  kind: semantic\n"
+        "  valid_from: 2026-01-01\n"
+        "---\n\nindexed-temporal-token\n",
+        encoding="utf-8",
+    )
+
+    first = search_vault(sample_vault, "indexed-temporal-token", mode="fts")
+    assert first
+
+    monkeypatch.setattr(
+        "power_framework.core.searcher.scan_temporal_records",
+        lambda _vault: pytest.fail("complete temporal projection should avoid disk scan"),
+    )
+    second = search_vault(sample_vault, "indexed-temporal-token", mode="fts")
+
+    assert second[0].rel_path == "03_Resources/indexed-temporal.md"
+    assert second[0].temporal_status == "current"
 
 
 class TestTokenize:


### PR DESCRIPTION
## Summary
- materialize lifecycle metadata in each immutable generation DB without storing note content
- use the complete projection for temporal filtering, with fail-closed disk fallback for legacy, partial, mismatched, or malformed state
- update/delete projection rows during incremental sync and cover note-change invalidation

## Validation
- focused: 107 passed
- full: 883 passed, 10 skipped; coverage 81.15%
- ruff format/check and source mypy pass
- signed commit 4dad312

This is the temporal-metadata sub-slice of the 3.4.4b retrieval-latency program. It does not claim real-vault cold/warm p50/p95 or MCP attribution.

Refs #283