### PR TITLE
perf(search): add retrieval latency attribution receipt

### DIFF
--- a/scripts/benchmark_retrieval_latency.py
+++ b/scripts/benchmark_retrieval_latency.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Produce a content-free retrieval latency attribution receipt.
+
+The benchmark deliberately reports timings and counts only. It never writes
+queries, note paths, snippets, or note content to the receipt.
+
+Examples:
+    python scripts/benchmark_retrieval_latency.py --vault /path/to/vault
+    python scripts/benchmark_retrieval_latency.py --vault /path/to/vault \
+        --modes fts --rounds 5 --output latency.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import math
+import os
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from power_framework.core.metrics.udcg_real import _load_semantic_gt
+from power_framework.core.searcher import search_vault
+from power_framework.core.timing import collect_timings
+
+DEFAULT_MODES = ("fts", "semantic", "hybrid", "reranked")
+MCP_WORKER = Path(__file__).with_name("benchmark_retrieval_mcp_worker.py")
+
+
+def _percentile(values: list[float], quantile: float) -> float | None:
+    """Return a deterministic nearest-rank percentile."""
+    if not values:
+        return None
+    rank = max(0, min(len(values) - 1, math.ceil(quantile * len(values)) - 1))
+    return round(sorted(values)[rank], 3)
+
+
+def _summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize wall and inclusive component timings without content."""
+    wall = [float(sample["wall_ms"]) for sample in samples]
+    components: dict[str, list[float]] = {}
+    for sample in samples:
+        for name, value in sample.get("timings_ms", {}).items():
+            components.setdefault(name, []).append(float(value))
+
+    return {
+        "samples": len(samples),
+        "wall_ms": {
+            "p50": _percentile(wall, 0.50),
+            "p95": _percentile(wall, 0.95),
+            "mean": round(statistics.mean(wall), 3) if wall else None,
+        },
+        "components_ms": {
+            name: {
+                "samples": len(values),
+                "p50": _percentile(values, 0.50),
+                "p95": _percentile(values, 0.95),
+                "mean": round(statistics.mean(values), 3),
+            }
+            for name, values in sorted(components.items())
+        },
+    }
+
+
+def _load_queries(fixture: Path | None, limit: int) -> list[str]:
+    queries = list(_load_semantic_gt(fixture))
+    if not queries:
+        raise ValueError("the benchmark query fixture is empty")
+    return queries[:limit]
+
+
+def _local_sample(vault: Path, query: str, mode: str, max_results: int) -> dict[str, Any]:
+    started = time.perf_counter()
+    with collect_timings() as receipt:
+        results = search_vault(vault, query, max_results=max_results, mode=mode)
+    return {
+        "wall_ms": (time.perf_counter() - started) * 1000,
+        "timings_ms": receipt.as_dict()["components_ms"],
+        "result_count": len(results),
+    }
+
+
+def _subprocess_sample(vault: Path, query: str, mode: str, max_results: int) -> dict[str, Any]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--worker",
+        "--vault",
+        str(vault),
+        "--query",
+        query,
+        "--mode",
+        mode,
+        "--max-results",
+        str(max_results),
+    ]
+    completed = subprocess.run(  # noqa: S603 - executable and arguments are local constants
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env=os.environ.copy(),
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip().splitlines()[-1:] or ["worker failed"]
+        raise RuntimeError(f"cold worker failed for mode {mode}: {detail[0]}")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("cold worker returned a non-JSON receipt") from exc
+    if not isinstance(payload, dict) or "wall_ms" not in payload:
+        raise RuntimeError("cold worker returned an invalid receipt")
+    return payload
+
+
+async def _mcp_samples(
+    vault: Path,
+    queries: list[str],
+    mode: str,
+    rounds: int,
+    max_results: int,
+) -> list[dict[str, Any]]:
+    try:
+        from fastmcp import Client
+    except ImportError as exc:  # pragma: no cover - packaging gate covers this
+        raise RuntimeError("fastmcp is required for the MCP latency shape") from exc
+
+    with tempfile.TemporaryDirectory(prefix="power-timing-") as receipt_dir:
+        receipt_path = Path(receipt_dir) / "receipt.json"
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "POWER_VAULT_DIR": str(vault),
+                "POWER_MCP_TRANSPORT": "stdio",
+                "POWER_BENCHMARK_RECEIPT": str(receipt_path),
+            }
+        )
+        config = {
+            "mcpServers": {
+                "power": {
+                    "command": sys.executable,
+                    "args": [str(MCP_WORKER.resolve())],
+                    "env": environment,
+                }
+            }
+        }
+        samples: list[dict[str, Any]] = []
+        async with Client(config) as client:
+            warmup_query = queries[0]
+            await client.call_tool(
+                "search_vault_tool",
+                {"query": warmup_query, "max_results": max_results, "search_mode": mode},
+            )
+            for _ in range(rounds):
+                for query in queries:
+                    started = time.perf_counter()
+                    await client.call_tool(
+                        "search_vault_tool",
+                        {"query": query, "max_results": max_results, "search_mode": mode},
+                    )
+                    elapsed = (time.perf_counter() - started) * 1000
+                    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+                    samples.append(
+                        {
+                            "wall_ms": elapsed,
+                            "timings_ms": receipt["components_ms"],
+                        }
+                    )
+        return samples
+
+
+async def _run(args: argparse.Namespace) -> dict[str, Any]:
+    vault = args.vault.expanduser().resolve()
+    queries = _load_queries(args.fixture, args.query_limit)
+    query_set_hash = hashlib.sha256("\0".join(queries).encode("utf-8")).hexdigest()
+    receipt: dict[str, Any] = {
+        "schema_version": "power.retrieval-latency.v1",
+        "content_free": True,
+        "query_set_sha256": query_set_hash,
+        "controls": {
+            "query_count": len(queries),
+            "rounds": args.rounds,
+            "max_results": args.max_results,
+            "modes": args.modes,
+        },
+        "results": {},
+        "errors": [],
+    }
+
+    for mode in args.modes:
+        mode_result: dict[str, Any] = {}
+        try:
+            # One unrecorded request removes first-use sparse initialization from
+            # the warm-process sample while preserving the cold-process shape.
+            _local_sample(vault, queries[0], mode, args.max_results)
+            warm = [
+                _local_sample(vault, query, mode, args.max_results)
+                for _ in range(args.rounds)
+                for query in queries
+            ]
+            mode_result["warm_process"] = _summary(warm)
+        except Exception as exc:
+            receipt["errors"].append(f"{mode}/warm_process: {type(exc).__name__}: {exc}")
+
+        try:
+            cold = [
+                _subprocess_sample(vault, query, mode, args.max_results)
+                for _ in range(args.cold_rounds)
+                for query in queries
+            ]
+            mode_result["cold_process"] = _summary(cold)
+        except Exception as exc:
+            receipt["errors"].append(f"{mode}/cold_process: {type(exc).__name__}: {exc}")
+
+        try:
+            mcp = await _mcp_samples(vault, queries, mode, args.rounds, args.max_results)
+            mode_result["long_lived_mcp"] = _summary(mcp)
+        except Exception as exc:
+            receipt["errors"].append(f"{mode}/long_lived_mcp: {type(exc).__name__}: {exc}")
+
+        receipt["results"][mode] = mode_result
+
+    if receipt["errors"] and not receipt["results"]:
+        raise RuntimeError("all retrieval latency modes failed")
+    return receipt
+
+
+def _worker(args: argparse.Namespace) -> int:
+    started = time.perf_counter()
+    with collect_timings() as receipt:
+        results = search_vault(
+            args.vault.expanduser().resolve(),
+            args.query,
+            max_results=args.max_results,
+            mode=args.mode,
+        )
+    json.dump(
+        {
+            "wall_ms": (time.perf_counter() - started) * 1000,
+            "timings_ms": receipt.as_dict()["components_ms"],
+            "result_count": len(results),
+        },
+        sys.stdout,
+        sort_keys=True,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault", type=Path, required=True)
+    parser.add_argument("--fixture", type=Path)
+    parser.add_argument("--modes", nargs="+", choices=DEFAULT_MODES, default=list(DEFAULT_MODES))
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--cold-rounds", type=int, default=1)
+    parser.add_argument("--query-limit", type=int, default=4)
+    parser.add_argument("--max-results", type=int, default=20)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--query", help=argparse.SUPPRESS)
+    parser.add_argument("--mode", choices=DEFAULT_MODES, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    if args.worker:
+        if not args.query or not args.mode:
+            parser.error("--worker requires --query and --mode")
+        return _worker(args)
+    if args.rounds < 1 or args.cold_rounds < 1 or args.query_limit < 1:
+        parser.error("rounds and query-limit must be positive")
+
+    payload = asyncio.run(_run(args))
+    serialized = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(serialized, encoding="utf-8")
+    else:
+        sys.stdout.write(serialized)
+    return 0 if not payload["errors"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_retrieval_mcp_worker.py
+++ b/scripts/benchmark_retrieval_mcp_worker.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Benchmark-only MCP worker that attaches a content-free timing receipt."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from time import perf_counter
+
+from power_framework.core.timing import collect_timings
+from power_framework.mcp import power_server
+
+_original_search = power_server.search_vault
+_original_format = power_server.format_untrusted_search_envelope
+_last_receipt = None
+
+
+def _timed_search(*args: object, **kwargs: object):
+    global _last_receipt
+    with collect_timings() as receipt:
+        results = _original_search(*args, **kwargs)
+    _last_receipt = receipt
+    return results
+
+
+def _format_with_receipt(*args: object, **kwargs: object) -> str:
+    if _last_receipt is None:
+        raise RuntimeError("timing receipt was not produced by search")
+    started = perf_counter()
+    serialized = _original_format(*args, **kwargs)
+    _last_receipt.add("mcp_result_materialization", (perf_counter() - started) * 1000)
+    payload = json.loads(serialized)
+    timing_payload = _last_receipt.as_dict()
+    payload["timings_ms"] = timing_payload["components_ms"]
+    Path(os.environ["POWER_BENCHMARK_RECEIPT"]).write_text(
+        json.dumps(timing_payload, sort_keys=True), encoding="utf-8"
+    )
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+power_server.search_vault = _timed_search
+power_server.format_untrusted_search_envelope = _format_with_receipt
+
+
+if __name__ == "__main__":
+    # FastMCP's startup banner is useful interactively but would pollute the
+    # benchmark operator's stdout/stderr receipt stream.
+    sys.stderr = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115
+    power_server.run()

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -42,6 +42,7 @@ from .temporal import (
     resolve_temporal_statuses,
     scan_temporal_records,
 )
+from .timing import timing_span
 from .vault_storage import existing_vault_db_path, vault_db_path
 
 if TYPE_CHECKING:
@@ -82,7 +83,8 @@ def _db_path(vault_dir: Path | None = None) -> Path:
 
 def _read_db_path(vault_dir: Path) -> Path | None:
     """Resolve the immutable active DB, retaining legacy fallback only before migration."""
-    return resolve_active_generation_path(vault_dir) or existing_vault_db_path(vault_dir)
+    with timing_span("generation_resolve"):
+        return resolve_active_generation_path(vault_dir) or existing_vault_db_path(vault_dir)
 
 
 def _open_readonly_db(db_path: Path) -> sqlite3.Connection:
@@ -878,43 +880,44 @@ def _fts_search(
         conn = _open_readonly_db(db_path)
 
         cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT
-                rel_path,
-                title,
-                description,
-                note_type,
-                -bm25(fts_notes, 10.0, 5.0, 3.0, 1.0) as score,
-                snippet(fts_notes, 3, '...', '...', '...', 15) as snippet_text,
-                tags
-            FROM fts_notes
-            WHERE fts_notes MATCH ?
-            ORDER BY score DESC
-            LIMIT ?
-            """,
-            (fts_query, max_results),
-        )
-
-        rows = cursor.fetchall()
+        with timing_span("sqlite_read"):
+            cursor.execute(
+                """
+                SELECT
+                    rel_path,
+                    title,
+                    description,
+                    note_type,
+                    -bm25(fts_notes, 10.0, 5.0, 3.0, 1.0) as score,
+                    snippet(fts_notes, 3, '...', '...', '...', 15) as snippet_text,
+                    tags
+                FROM fts_notes
+                WHERE fts_notes MATCH ?
+                ORDER BY score DESC
+                LIMIT ?
+                """,
+                (fts_query, max_results),
+            )
+            rows = cursor.fetchall()
 
         results: list[SearchResult] = []
-        for row in rows:
-            rel_path, title, description, note_type, score, snippet, tags_str = row
-            tags = tags_str.split(" ") if tags_str else []
-            match_count = 1
-            results.append(
-                SearchResult(
-                    rel_path=rel_path,
-                    title=title,
-                    description=description,
-                    note_type=note_type,
-                    score=float(score),
-                    snippet=snippet,
-                    match_count=match_count,
-                    tags=tags,
+        with timing_span("result_materialization"):
+            for row in rows:
+                rel_path, title, description, note_type, score, snippet, tags_str = row
+                tags = tags_str.split(" ") if tags_str else []
+                match_count = 1
+                results.append(
+                    SearchResult(
+                        rel_path=rel_path,
+                        title=title,
+                        description=description,
+                        note_type=note_type,
+                        score=float(score),
+                        snippet=snippet,
+                        match_count=match_count,
+                        tags=tags,
+                    )
                 )
-            )
 
         return results
     except ActiveGenerationError:
@@ -1001,20 +1004,21 @@ def _vector_search(
             _init_db(conn)
 
         cursor = conn.cursor()
-        cursor.execute("SELECT COUNT(*) FROM tf_vectors")
-        if cursor.fetchone()[0] == 0:
-            if active_generation_path is not None:
-                return []
-            # Materialize TF vectors (cheap FTS-only sync) so direct
-            # _vector_search calls work even before an explicit index.
-            _sync_vault_to_db(vault_dir, conn, sync_embeddings=False)
+        with timing_span("sqlite_read"):
+            cursor.execute("SELECT COUNT(*) FROM tf_vectors")
+            if cursor.fetchone()[0] == 0:
+                if active_generation_path is not None:
+                    return []
+                # Materialize TF vectors (cheap FTS-only sync) so direct
+                # _vector_search calls work even before an explicit index.
+                _sync_vault_to_db(vault_dir, conn, sync_embeddings=False)
 
-        cursor.execute("""
-            SELECT t.rel_path, t.tf_data, f.title, f.description, f.note_type, f.tags, f.content
-            FROM tf_vectors t
-            JOIN fts_notes f ON t.rel_path = f.rel_path
-        """)
-        rows = cursor.fetchall()
+            cursor.execute("""
+                SELECT t.rel_path, t.tf_data, f.title, f.description, f.note_type, f.tags, f.content
+                FROM tf_vectors t
+                JOIN fts_notes f ON t.rel_path = f.rel_path
+            """)
+            rows = cursor.fetchall()
     except ActiveGenerationError:
         raise
     except Exception:
@@ -1025,39 +1029,40 @@ def _vector_search(
 
     scored: list[tuple[float, SearchResult]] = []
 
-    for rel_path, tf_data_str, title, description, note_type, tags_str, content in rows:
-        try:
-            filepath = vault_dir / rel_path
-            if not filepath.is_file():
-                continue
-            if should_skip(vault_dir, rel_path):
-                continue
+    with timing_span("scoring"):
+        for rel_path, tf_data_str, title, description, note_type, tags_str, content in rows:
+            try:
+                filepath = vault_dir / rel_path
+                if not filepath.is_file():
+                    continue
+                if should_skip(vault_dir, rel_path):
+                    continue
 
-            doc_vec = json.loads(tf_data_str)
-            similarity = _cosine_similarity(query_vec, doc_vec)
+                doc_vec = json.loads(tf_data_str)
+                similarity = _cosine_similarity(query_vec, doc_vec)
 
-            if similarity == 0:
-                continue
+                if similarity == 0:
+                    continue
 
-            tags = tags_str.split(" ") if tags_str else []
-            snippet = _make_snippet(content, query_tokens)
-            scored.append(
-                (
-                    similarity,
-                    SearchResult(
-                        rel_path=rel_path,
-                        title=title,
-                        description=description,
-                        note_type=note_type,
-                        score=similarity,
-                        snippet=snippet,
-                        match_count=len(query_tokens),
-                        tags=tags,
-                    ),
+                tags = tags_str.split(" ") if tags_str else []
+                snippet = _make_snippet(content, query_tokens)
+                scored.append(
+                    (
+                        similarity,
+                        SearchResult(
+                            rel_path=rel_path,
+                            title=title,
+                            description=description,
+                            note_type=note_type,
+                            score=similarity,
+                            snippet=snippet,
+                            match_count=len(query_tokens),
+                            tags=tags,
+                        ),
+                    )
                 )
-            )
-        except Exception:  # noqa: S112
-            continue
+            except Exception:  # noqa: S112
+                continue
 
     scored.sort(key=lambda x: (-x[0], x[1].title))
     return [r for _, r in scored[:max_results]]
@@ -1136,8 +1141,10 @@ def _semantic_search(
         )
 
     try:
-        embedder = get_embedding_manager()
-        query_vec = embedder.embed(query)
+        with timing_span("embedding_session_startup"):
+            embedder = get_embedding_manager()
+        with timing_span("query_embedding"):
+            query_vec = embedder.embed(query)
     except Exception as exc:
         _dense_failure(f"embedder error: {type(exc).__name__}")
 
@@ -1153,8 +1160,9 @@ def _semantic_search(
         cursor = conn.cursor()
         # Chunk text is needed only for the few winners that become snippets.
         # Avoid pulling the whole corpus body through SQLite on every query.
-        cursor.execute("SELECT chunk_id, rel_path, embedding FROM chunk_embeddings")
-        rows = cursor.fetchall()
+        with timing_span("sqlite_read"):
+            cursor.execute("SELECT chunk_id, rel_path, embedding FROM chunk_embeddings")
+            rows = cursor.fetchall()
     except Exception as exc:
         _dense_failure(f"db error: {type(exc).__name__}")
     finally:
@@ -1166,31 +1174,32 @@ def _semantic_search(
 
     import numpy as np
 
-    q_arr = np.asarray(query_vec, dtype=np.float32)
-    q_norm = float(np.linalg.norm(q_arr))
-    if q_norm == 0:
-        _dense_failure("zero query embedding")
+    with timing_span("scoring"):
+        q_arr = np.asarray(query_vec, dtype=np.float32)
+        q_norm = float(np.linalg.norm(q_arr))
+        if q_norm == 0:
+            _dense_failure("zero query embedding")
 
-    # Score the complete corpus in one matrix multiplication. The former code
-    # vectorized only the inner dimension and still paid Python/NumPy dispatch
-    # once per chunk.
-    dim = int(q_arr.shape[0])
-    expected_bytes = dim * 4
-    usable = [row for row in rows if len(row[2]) == expected_bytes]
-    if not usable:
-        _dense_failure(f"no dense vectors of width {dim}")
+        # Score the complete corpus in one matrix multiplication. The former code
+        # vectorized only the inner dimension and still paid Python/NumPy dispatch
+        # once per chunk.
+        dim = int(q_arr.shape[0])
+        expected_bytes = dim * 4
+        usable = [row for row in rows if len(row[2]) == expected_bytes]
+        if not usable:
+            _dense_failure(f"no dense vectors of width {dim}")
 
-    matrix = np.frombuffer(b"".join(row[2] for row in usable), dtype=np.float32).reshape(
-        len(usable), dim
-    )
-    norms = np.linalg.norm(matrix, axis=1)
-    similarities = np.zeros(len(usable), dtype=np.float32)
-    np.divide(matrix @ q_arr, norms * q_norm, out=similarities, where=norms > 0)
+        matrix = np.frombuffer(b"".join(row[2] for row in usable), dtype=np.float32).reshape(
+            len(usable), dim
+        )
+        norms = np.linalg.norm(matrix, axis=1)
+        similarities = np.zeros(len(usable), dtype=np.float32)
+        np.divide(matrix @ q_arr, norms * q_norm, out=similarities, where=norms > 0)
 
-    chunk_scores: list[tuple[float, str, str]] = [
-        (float(similarities[i]), usable[i][1], usable[i][0])
-        for i in np.nonzero(similarities > 0)[0]
-    ]
+        chunk_scores: list[tuple[float, str, str]] = [
+            (float(similarities[i]), usable[i][1], usable[i][0])
+            for i in np.nonzero(similarities > 0)[0]
+        ]
 
     if not chunk_scores:
         return []
@@ -1210,13 +1219,14 @@ def _semantic_search(
         try:
             conn = _open_readonly_db(db_path)
             placeholders = ",".join("?" * len(wanted))
-            snippets = dict(
-                conn.execute(
-                    f"SELECT chunk_id, content FROM chunk_embeddings "  # noqa: S608
-                    f"WHERE chunk_id IN ({placeholders})",
-                    wanted,
-                ).fetchall()
-            )
+            with timing_span("sqlite_read"):
+                snippets = dict(
+                    conn.execute(
+                        f"SELECT chunk_id, content FROM chunk_embeddings "  # noqa: S608
+                        f"WHERE chunk_id IN ({placeholders})",
+                        wanted,
+                    ).fetchall()
+                )
         except Exception as exc:
             _dense_failure(f"db error: {type(exc).__name__}")
         finally:
@@ -1224,28 +1234,29 @@ def _semantic_search(
                 conn.close()
 
     results: list[SearchResult] = []
-    for rel_path in top_paths:
-        filepath = vault_dir / rel_path
-        try:
-            content = read_file_content(filepath)
-            metadata = validate_metadata(content)
-            if metadata is None:
-                continue
-            similarity, chunk_id = doc_best[rel_path]
-            results.append(
-                SearchResult(
-                    rel_path=rel_path,
-                    title=metadata.title,
-                    description=metadata.description,
-                    note_type=metadata.type,
-                    score=similarity,
-                    snippet=snippets.get(chunk_id, ""),
-                    match_count=1,
-                    tags=metadata.tags,
+    with timing_span("result_materialization"):
+        for rel_path in top_paths:
+            filepath = vault_dir / rel_path
+            try:
+                content = read_file_content(filepath)
+                metadata = validate_metadata(content)
+                if metadata is None:
+                    continue
+                similarity, chunk_id = doc_best[rel_path]
+                results.append(
+                    SearchResult(
+                        rel_path=rel_path,
+                        title=metadata.title,
+                        description=metadata.description,
+                        note_type=metadata.type,
+                        score=similarity,
+                        snippet=snippets.get(chunk_id, ""),
+                        match_count=1,
+                        tags=metadata.tags,
+                    )
                 )
-            )
-        except Exception:  # noqa: S112
-            continue
+            except Exception:  # noqa: S112
+                continue
 
     return results
 
@@ -1485,8 +1496,11 @@ def _filter_temporal_results(
     max_results: int,
 ) -> list[SearchResult]:
     """Attach resolved status and filter ranked results at the retrieval boundary."""
-    indexed_records = load_temporal_records(_read_db_path(vault_dir))
-    records = indexed_records if indexed_records is not None else scan_temporal_records(vault_dir)
+    with timing_span("temporal_metadata"):
+        indexed_records = load_temporal_records(_read_db_path(vault_dir))
+        records = (
+            indexed_records if indexed_records is not None else scan_temporal_records(vault_dir)
+        )
     statuses = resolve_temporal_statuses(records, as_of)
     filtered: list[SearchResult] = []
     for result in results:
@@ -1553,8 +1567,10 @@ def _hybrid_reranked_search(
         except Exception:
             documents.append("")
 
-    reranker = _get_reranker()
-    reranked_scores = reranker.rerank(query, documents)
+    with timing_span("reranker_session_startup"):
+        reranker = _get_reranker()
+    with timing_span("reranker_scoring"):
+        reranked_scores = reranker.rerank(query, documents)
 
     for result, score in zip(rerank_pool, reranked_scores, strict=False):
         result.score = score

--- a/src/power_framework/core/temporal.py
+++ b/src/power_framework/core/temporal.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from .ignore import should_skip
 from .models import MemoryMetadata
 from .parser import read_file_content, validate_metadata
+from .timing import timing_span
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -93,9 +94,12 @@ def load_temporal_records(db_path: Path | None) -> dict[str, TemporalRecord] | N
     if db_path is None or not db_path.is_file():
         return None
     try:
-        with closing(
-            sqlite3.connect(f"file:{db_path.as_posix()}?mode=ro", uri=True, timeout=30)
-        ) as conn:
+        with (
+            closing(
+                sqlite3.connect(f"file:{db_path.as_posix()}?mode=ro", uri=True, timeout=30)
+            ) as conn,
+            timing_span("sqlite_read"),
+        ):
             table = conn.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'temporal_records'"
             ).fetchone()

--- a/src/power_framework/core/timing.py
+++ b/src/power_framework/core/timing.py
@@ -1,0 +1,67 @@
+"""Opt-in, content-free timing spans for retrieval diagnostics."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from time import perf_counter
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@dataclass
+class TimingReceipt:
+    """Aggregate inclusive component timings without query or note content."""
+
+    totals_ms: dict[str, float] = field(default_factory=lambda: defaultdict(float))
+    counts: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+
+    def add(self, name: str, elapsed_ms: float) -> None:
+        """Record one inclusive span."""
+        self.totals_ms[name] += elapsed_ms
+        self.counts[name] += 1
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a stable, content-free diagnostic object."""
+        return {
+            "schema_version": "power.retrieval-timings.v1",
+            "inclusive": True,
+            "components_ms": {
+                name: round(self.totals_ms[name], 3) for name in sorted(self.totals_ms)
+            },
+            "span_counts": {name: self.counts[name] for name in sorted(self.counts)},
+        }
+
+
+_CURRENT: ContextVar[TimingReceipt | None] = ContextVar("power_timing_receipt", default=None)
+
+
+@contextmanager
+def collect_timings() -> Iterator[TimingReceipt]:
+    """Collect timing spans in the current execution context."""
+    receipt = TimingReceipt()
+    token = _CURRENT.set(receipt)
+    try:
+        yield receipt
+    finally:
+        _CURRENT.reset(token)
+
+
+@contextmanager
+def timing_span(name: str) -> Iterator[None]:
+    """Record an inclusive span when a diagnostic collector is active."""
+    receipt = _CURRENT.get()
+    if receipt is None:
+        yield
+        return
+
+    started = perf_counter()
+    try:
+        yield
+    finally:
+        receipt.add(name, (perf_counter() - started) * 1000)

--- a/tests/test_retrieval_latency_benchmark.py
+++ b/tests/test_retrieval_latency_benchmark.py
@@ -1,0 +1,34 @@
+"""Hermetic tests for the content-free retrieval latency benchmark."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "benchmark_retrieval_latency.py"
+SPEC = importlib.util.spec_from_file_location("benchmark_retrieval_latency", SCRIPT)
+assert SPEC is not None
+assert SPEC.loader is not None
+benchmark = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(benchmark)
+
+
+def test_percentile_is_nearest_rank() -> None:
+    assert benchmark._percentile([3.0, 1.0, 2.0], 0.50) == 2.0
+    assert benchmark._percentile([], 0.95) is None
+
+
+def test_summary_contains_only_timings_and_counts() -> None:
+    result = benchmark._summary(
+        [
+            {"wall_ms": 10.0, "timings_ms": {"sqlite_read": 2.0}},
+            {"wall_ms": 20.0, "timings_ms": {"sqlite_read": 4.0}},
+        ]
+    )
+
+    assert result["samples"] == 2
+    assert result["wall_ms"]["p50"] == 10.0
+    assert result["components_ms"]["sqlite_read"]["p95"] == 4.0
+    assert "query" not in result
+    assert "snippet" not in result
+    assert "path" not in result

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -39,6 +39,7 @@ from power_framework.core.searcher import (
     search_vault,
     validate_dense_index,
 )
+from power_framework.core.timing import collect_timings
 
 
 def test_search_temporal_views_filter_one_shared_corpus(
@@ -125,6 +126,16 @@ def test_temporal_filter_uses_complete_indexed_metadata_projection(
 
     assert second[0].rel_path == "03_Resources/indexed-temporal.md"
     assert second[0].temporal_status == "current"
+
+
+def test_search_timing_collector_records_content_free_components(sample_vault: Path) -> None:
+    with collect_timings() as receipt:
+        assert search_vault(sample_vault, "test", mode="fts")
+
+    components = receipt.as_dict()["components_ms"]
+    assert {"generation_resolve", "sqlite_read", "temporal_metadata"} <= set(components)
+    assert "snippet" not in components
+    assert "query" not in components
 
 
 class TestTokenize:

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,22 @@
+"""Tests for opt-in, content-free retrieval timing receipts."""
+
+from power_framework.core.timing import collect_timings, timing_span
+
+
+def test_timing_receipt_is_stable_and_content_free() -> None:
+    with collect_timings() as receipt:
+        with timing_span("sqlite_read"):
+            pass
+        with timing_span("sqlite_read"):
+            pass
+
+    payload = receipt.as_dict()
+    assert payload["schema_version"] == "power.retrieval-timings.v1"
+    assert payload["inclusive"] is True
+    assert payload["span_counts"] == {"sqlite_read": 2}
+    assert set(payload) == {"schema_version", "inclusive", "components_ms", "span_counts"}
+
+
+def test_timing_span_is_noop_without_a_collector() -> None:
+    with timing_span("not_recorded"):
+        pass


### PR DESCRIPTION
## Summary
- add opt-in, content-free retrieval timing spans for generation resolution, temporal metadata, SQLite reads, scoring, embedding startup/query embedding, reranker and result materialization
- add a benchmark harness for warm in-process, cold subprocess and long-lived MCP shapes
- keep MCP production tool schema unchanged; the benchmark-only worker attaches its receipt out of band

## Validation
- full local suite: 887 passed, 10 skipped; coverage 81.28%
- focused timing/search suite: 86 passed
- Ruff format/check and source mypy pass
- real FTS smoke: warm/cold/MCP receipts generated with no errors and no query/note content
- signed commit: ae85d0a

This is 3.4.4b.2 attribution tooling. It does not claim real-vault p50/p95, ANN benefit, or reranker quality; those remain evidence gates.

Refs #283