### PR TITLE
fix(coverage): exclude paginated catalog pages

### DIFF
--- a/src/power_framework/core/coverage.py
+++ b/src/power_framework/core/coverage.py
@@ -7,6 +7,7 @@ import sqlite3
 from contextlib import closing
 from pathlib import Path
 
+from .constants import is_catalog_filename
 from .ignore import should_skip
 from .vault_storage import existing_vault_db_path
 
@@ -24,7 +25,7 @@ def get_index_coverage(vault_dir: Path) -> tuple[int, int]:
     total = 0
     try:
         for filepath in root.rglob("*.md"):
-            if filepath.name in ("index.md", "log.md", "_index.md"):
+            if filepath.name in ("index.md", "log.md") or is_catalog_filename(filepath.name):
                 continue
             if should_skip(root, filepath.relative_to(root).as_posix()):
                 continue

--- a/tests/test_perf_optimizations.py
+++ b/tests/test_perf_optimizations.py
@@ -96,6 +96,17 @@ class TestExplicitIndexing:
         assert total > 0
         assert indexed == total
 
+    def test_coverage_excludes_paginated_catalog_pages(self, tmp_path):
+        resources = tmp_path / "03_Resources"
+        resources.mkdir()
+        (resources / "real-note.md").write_text("# Real note\n", encoding="utf-8")
+        (resources / "_index-2.md").write_text("# Generated catalog page\n", encoding="utf-8")
+
+        indexed, total = get_index_coverage(tmp_path)
+
+        assert indexed == 0
+        assert total == 1
+
 
 class TestSemanticNumpy:
     """Semantic search requires a compatible dense index before model loading."""


### PR DESCRIPTION
## Problem
`power doctor` counted generated paginated `_index-N.md` catalog pages as indexable notes, while `power sync` correctly excludes them. On the real Brain this produced a false coverage mismatch (`708` vs `700`) and an incorrect doctor error.

## Change
Reuse `is_catalog_filename()` in `get_index_coverage()` and add a regression test covering `_index-2.md`.

## Validation
- focused: `20 passed`
- full: `889 passed, 10 skipped`
- coverage: `81.30%`
- Ruff check/format: pass
- mypy: pass
- signed commit: `23f840c4101e3d275b4eda8278d55d361ebdb94a`

Refs #283


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vault coverage calculations to exclude generated catalog pages, including paginated catalog files.
  * Ensured coverage totals and indexed file counts reflect only relevant notes and documents.

* **Tests**
  * Added coverage to verify generated catalog pages are excluded from coverage results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->