### PR TITLE
fix(lint): align system-page coverage scope

### DIFF
--- a/src/power_framework/core/linter.py
+++ b/src/power_framework/core/linter.py
@@ -332,6 +332,11 @@ def _resolve_internal_link(
     return basename_map.get(clean_note_name(Path(normalized).name), [])
 
 
+def _is_system_page(filename: str) -> bool:
+    """Return whether *filename* is a reserved or generated vault page."""
+    return filename in {"index.md", "log.md"} or is_catalog_filename(filename)
+
+
 def run_lint_vault(vault_dir: Path) -> LintResult:
     """
     Run full health lint on the vault.
@@ -357,12 +362,18 @@ def run_lint_vault(vault_dir: Path) -> LintResult:
         all_files[rel_path] = filepath
         basename_map.setdefault(clean_note_name(filepath.name), []).append(rel_path)
 
-    result.total_notes = sum(not is_catalog_filename(Path(rel_path).name) for rel_path in all_files)
+    result.total_notes = sum(not _is_system_page(Path(rel_path).name) for rel_path in all_files)
 
     for rel_path, abs_path in all_files.items():
         try:
             content = read_file_content(abs_path)
         except Exception:  # noqa: S112
+            continue
+
+        if _is_system_page(Path(rel_path).name):
+            # Generated catalogs still contribute inbound links, but are not
+            # user notes and must not raise metadata findings themselves.
+            links[rel_path] = _extract_links(content)
             continue
 
         if not has_frontmatter(content):

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -69,6 +69,26 @@ class TestRunLintVault:
         result = run_lint_vault(sample_vault)
         assert result.total_notes == 5
 
+    def test_generated_system_log_is_not_counted_or_linted(self, tmp_path: Path):
+        resources = tmp_path / "03_Resources"
+        resources.mkdir()
+        (resources / "log.md").write_text("# Generated log\n", encoding="utf-8")
+        (resources / "Note.md").write_text(
+            "---\n"
+            "type: Resource\n"
+            'title: "Note"\n'
+            'description: "A real note"\n'
+            "timestamp: 2026-01-01T00:00:00Z\n"
+            "---\n\n"
+            "# Note\n",
+            encoding="utf-8",
+        )
+
+        result = run_lint_vault(tmp_path)
+
+        assert result.total_notes == 1
+        assert not any(path == "03_Resources/log.md" for path, _ in result.untyped_files)
+
     def test_daily_logs_excluded_from_orphans(self, sample_vault: Path):
         result = run_lint_vault(sample_vault)
         orphan_paths = result.orphans


### PR DESCRIPTION
## Problem
power lint counted nested log.md as a note while sync, doctor, indexer, and search excluded reserved system pages. This caused a false coverage mismatch (702 vs 701) and could lint generated pages as user notes.

## Change
- exclude index.md, log.md, and paginated _index-N.md from note count and metadata findings;
- retain their extracted links as graph sources so catalog navigation still prevents false orphan reports;
- add a regression test for a nested generated log.md.

## Validation
- focused linter/indexer: 89 passed;
- full suite: 890 passed, 10 skipped;
- coverage: 81.31%;
- Ruff, format, mypy, and diff check passed;
- real Brain readback: power lint reports 701 notes, zero errors; coverage boundary is 665 indexed and 701 total.