### PR TITLE
fix(utils): preserve byte bounds across platforms

### DIFF
--- a/src/power_framework/core/utils.py
+++ b/src/power_framework/core/utils.py
@@ -77,6 +77,13 @@ def atomic_write(filepath: Path, content: str, encoding: str = "utf-8") -> None:
     Write content to file atomically using temp file + rename.
 
     Prevents corruption from interrupted writes (0-byte files).
+
+    ``newline=""`` disables newline translation so the file on disk is exactly
+    ``content.encode(encoding)`` on every platform. Without it, text mode maps
+    each "\\n" to ``os.linesep``, and on Windows a caller that bounded its
+    content by byte length -- such as the INDEX_MAX_BYTES catalog contract --
+    writes an artifact larger than the bound it just enforced, by one byte per
+    line.
     """
     filepath = Path(filepath)
     filepath.parent.mkdir(parents=True, exist_ok=True)
@@ -87,7 +94,7 @@ def atomic_write(filepath: Path, content: str, encoding: str = "utf-8") -> None:
         suffix=".tmp",
     )
     try:
-        file_obj = os.fdopen(fd, "w", encoding=encoding)
+        file_obj = os.fdopen(fd, "w", encoding=encoding, newline="")
         fd = -1
         with file_obj as f:
             f.write(content)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,58 @@
+"""Tests for shared filesystem helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+
+from power_framework.core.constants import INDEX_MAX_BYTES
+from power_framework.core.indexer import _generate_catalog_pages
+from power_framework.core.utils import atomic_write
+
+
+class TestAtomicWrite:
+    """A byte-bounded caller can only trust a byte-faithful writer."""
+
+    def test_write_is_byte_identical_to_content(self, tmp_path: Path):
+        content = "---\ntype: Resource\n---\n\n# Title\n\nbody\n"
+        target = tmp_path / "note.md"
+
+        atomic_write(target, content)
+
+        # Text mode with the default newline=None maps each "\n" to os.linesep,
+        # so on Windows the artifact is one byte per line larger than what the
+        # caller measured. Every byte-length contract in the codebase depends on
+        # this equality holding.
+        assert target.read_bytes() == content.encode("utf-8")
+
+    def test_written_catalog_page_respects_the_declared_limit(self, tmp_path: Path):
+        notes = [
+            {
+                "rel_path": f"03_Resources/wiki/batch/Note {index}.md",
+                "title": "N" * (1 + index % 37),
+                "description": "d" * (1 + index % 53),
+                "note_type": "Resource",
+                "tags": [],
+                "timestamp": "2026-01-01",
+                "filename": f"Note {index}.md",
+                "owner": "",
+                "status": "",
+                "expiry": "",
+                "related": [],
+            }
+            for index in range(2_000)
+        ]
+
+        pages = _generate_catalog_pages("03_Resources/wiki/batch", notes)
+        assert len(pages) > 1, "fixture must paginate for the bound to mean anything"
+
+        oversized = {}
+        for filename, content in pages.items():
+            target = tmp_path / filename
+            atomic_write(target, content)
+            size = target.stat().st_size
+            if size > INDEX_MAX_BYTES:
+                oversized[filename] = size
+
+        # The in-memory bound is already asserted by the renderer; this checks
+        # the artifact that actually lands on disk.
+        assert not oversized, f"pages exceed INDEX_MAX_BYTES on disk: {oversized}"


### PR DESCRIPTION
## Problem
On Windows, atomic_write opened text files with newline translation. The catalog renderer bounded UTF-8 bytes in memory, but the artifact written to disk could exceed INDEX_MAX_BYTES by one byte per line. This violates the byte-bound contract and was reported in field report issue #283 / original PR #278.

## Change
- write atomic files with newline translation disabled so disk bytes equal content.encode(encoding);
- add a byte-identity regression test;
- add an on-disk catalog-page size regression test;
- carry the original contributor attribution from PR #278 onto current main.

## Validation
- focused utils/indexer suite: 54 passed;
- full suite on current main: 892 passed, 10 skipped;
- coverage: 81.31%;
- Ruff, format, mypy, and diff check: green;
- Windows runtime smoke is required in CI because Linux cannot exercise CRLF translation.