### PR TITLE
fix(ci): add macOS runtime smoke and truthful coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,54 @@ jobs:
           $searchText
           uv run power status $vault
 
+  macos-runtime-smoke:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install uv==0.11.33
+          uv sync --locked
+          uv run python -m pip check
+
+      - name: Verify macOS CLI and FTS lifecycle without model download
+        env:
+          HF_HUB_OFFLINE: "1"
+          POWER_EMBED_DEVICE: cpu
+          POWER_RERANKER_DEVICE: cpu
+          XDG_CACHE_HOME: ${{ runner.temp }}/power-cache
+        run: |
+          set -euo pipefail
+          vault="${RUNNER_TEMP}/power-vault"
+
+          uv run power --version
+          uv run python -c "import power_framework.mcp, onnxruntime; print('imports: OK')"
+          uv run power init "$vault"
+          uv run power ingest "$vault" --type Resource --title "macOS smoke note" --description "macOS runtime smoke note"
+          uv run power index "$vault" --strict
+          uv run power lint "$vault"
+          uv run power markdown-check "$vault"
+          uv run power sync "$vault" --fts-only --strict
+          search_result="$(uv run power search "$vault" "macOS smoke" --mode fts)"
+          if ! grep -Fq "macOS smoke note" <<<"$search_result"; then
+            printf '%s\n' "$search_result"
+            echo "FTS acceptance check did not return macOS smoke note" >&2
+            exit 1
+          fi
+          if ! grep -Fq "Index coverage: 1/1" <<<"$search_result" || grep -Fq "pending:" <<<"$search_result"; then
+            printf '%s\n' "$search_result"
+            echo "FTS acceptance check reported stale index coverage" >&2
+            exit 1
+          fi
+          printf '%s\n' "$search_result"
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/src/power_framework/core/coverage.py
+++ b/src/power_framework/core/coverage.py
@@ -8,6 +8,7 @@ from contextlib import closing
 from pathlib import Path
 
 from .constants import is_catalog_filename
+from .generation_index import resolve_active_generation_path
 from .ignore import should_skip
 from .vault_storage import existing_vault_db_path
 
@@ -34,7 +35,11 @@ def get_index_coverage(vault_dir: Path) -> tuple[int, int]:
         logger.debug("Unable to calculate total vault coverage", exc_info=True)
 
     indexed = 0
-    db_path = existing_vault_db_path(root)
+    # A published generation is authoritative after the generation-state
+    # migration. The legacy search.db fallback is valid only for vaults that
+    # have not been migrated yet; reading it first makes a successful sync
+    # appear as 0 indexed notes in doctor/search coverage receipts.
+    db_path = resolve_active_generation_path(root) or existing_vault_db_path(root)
     if db_path is None or not db_path.exists():
         return indexed, total
     try:

--- a/tests/test_perf_optimizations.py
+++ b/tests/test_perf_optimizations.py
@@ -96,6 +96,18 @@ class TestExplicitIndexing:
         assert total > 0
         assert indexed == total
 
+    def test_coverage_reads_published_generation(self, sample_vault, monkeypatch, tmp_path):
+        monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "power-cache"))
+
+        from power_framework.core.generation_index import sync_vault_atomically
+
+        sync_vault_atomically(sample_vault, sync_embeddings=False)
+
+        indexed, total = get_index_coverage(sample_vault)
+        assert total == 5
+        assert indexed == total
+
     def test_coverage_excludes_paginated_catalog_pages(self, tmp_path):
         resources = tmp_path / "03_Resources"
         resources.mkdir()


### PR DESCRIPTION
## Summary

- add a macos-latest Python 3.13 runtime smoke for import, init, ingest, strict index, lint, markdown-check, FTS sync, and FTS search without model download
- isolate the smoke cache under the runner temp directory and fail if the search receipt reports stale coverage
- make coverage receipts read the published immutable generation before the legacy search.db fallback
- add regression coverage for active-generation counts

## Verification

- local focused suite: 39 passed
- local full suite: 893 passed, 10 skipped, coverage 81.31%
- Ruff, format, mypy, doc-drift, release contract, benchmark suite: passed
- Linux analog of the macOS smoke: passed; search reported Index coverage: 1/1 and no model cache files were created

The physical macOS runner gate remains CI evidence until the workflow completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index coverage reporting to use the currently published index, with a fallback for legacy vaults.
  * Ensured coverage remains accurate after synchronization without embeddings.

* **Tests**
  * Added validation for complete indexing and expected entry counts after synchronization.
  * Added macOS runtime checks covering startup, ingestion, indexing, search, synchronization, and quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->