### PR TITLE
fix(search): rerank body-centered note text

### DIFF
--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -31,7 +31,7 @@ from .embeddings import configured_embedding_identity, get_embedding_manager
 from .generation_index import ActiveGenerationError, resolve_active_generation_path
 from .ignore import should_skip
 from .models import OKFMetadata  # noqa: TC001
-from .parser import read_file_content, validate_metadata
+from .parser import FRONTMATTER_PATTERN, read_file_content, validate_metadata
 from .query_expansion import QueryExpander
 from .temporal import (
     TemporalStatus,
@@ -163,6 +163,17 @@ CANONICAL_SEARCH_MODES = frozenset(
     {"fts", "vector", "hybrid", "semantic", "reranked", "graph_assisted"}
 )
 SEARCH_MODE_ALIASES = {"hybrid_reranked": "reranked"}
+
+
+def _reranker_document_text(text: str, title: str = "") -> str:
+    """Return title plus note body, excluding YAML frontmatter from reranking."""
+    match = FRONTMATTER_PATTERN.match(text)
+    body = text[match.end() :] if match else text
+    body = body.lstrip()
+    title = title.strip()
+    if not title:
+        return body
+    return f"{title}\n\n{body}" if body else title
 
 
 @dataclass(frozen=True)
@@ -1550,22 +1561,27 @@ def _hybrid_reranked_search(
 
     # Performance Plan §4: bound the reranker to the top-K RRF candidates
     # (default 20) instead of reranking all 150 full-document texts, AND rerank
-    # only the leading excerpt (truncated to RERANK_TEXT_CHARS) of each doc.
-    # Cross-encoders on CPU are dominated by token count, so truncating slashes
-    # latency ~10x with negligible nDCG loss (MAR@5 preserved).
+    # only a title plus body-centered excerpt (truncated to RERANK_TEXT_CHARS).
+    # YAML frontmatter is governance metadata, not note meaning; feeding it as
+    # the leading excerpt can make the cross-encoder score fields instead of the
+    # user's body content.
     rerank_pool = candidates[: min(len(candidates), RERANK_CANDIDATE_LIMIT)]
 
     documents: list[str] = []
     for result in rerank_pool:
-        if result.snippet:
-            documents.append(result.snippet[:RERANK_TEXT_CHARS])
-            continue
         filepath = vault_dir / result.rel_path
         try:
+            # Search snippets may be synthetic, frontmatter-heavy, or chunk
+            # headers rather than the note's meaning.  Read the source note so
+            # the reranker always sees the same body-centered representation.
             text = read_file_content(filepath)
-            documents.append(text[:RERANK_TEXT_CHARS])
+            documents.append(_reranker_document_text(text, result.title)[:RERANK_TEXT_CHARS])
         except Exception:
-            documents.append("")
+            # Preserve a bounded degraded path for an unreadable source file;
+            # the snippet is still better than dropping the candidate.
+            documents.append(
+                _reranker_document_text(result.snippet, result.title)[:RERANK_TEXT_CHARS]
+            )
 
     with timing_span("reranker_session_startup"):
         reranker = _get_reranker()

--- a/tests/test_perf_optimizations.py
+++ b/tests/test_perf_optimizations.py
@@ -15,6 +15,7 @@ from power_framework.core.coverage import get_index_coverage
 from power_framework.core.searcher import (
     RERANK_CANDIDATE_LIMIT,
     DenseIndexUnavailableError,
+    SearchResult,
     _hybrid_reranked_search,
     _init_db,
     _semantic_search,
@@ -151,6 +152,53 @@ class TestBoundedRerank:
         results = _hybrid_reranked_search(indexed_vault, "test project", max_results=5)
         assert isinstance(results, list)
         assert len(results) <= 5
+
+    def test_reranker_receives_body_centered_text(self, tmp_path, monkeypatch):
+        from power_framework.core import searcher
+
+        vault = tmp_path / "vault"
+        note = vault / "01_Projects" / "Body.md"
+        note.parent.mkdir(parents=True)
+        note.write_text(
+            "---\n"
+            "type: Project\n"
+            'title: "Visible title"\n'
+            'description: "metadata-only phrase"\n'
+            "status: active\n"
+            "timestamp: 2026-01-01T00:00:00Z\n"
+            "---\n\n"
+            "body-only phrase\n",
+            encoding="utf-8",
+        )
+        candidate = SearchResult(
+            rel_path="01_Projects/Body.md",
+            title="Visible title",
+            description="metadata-only phrase",
+            note_type="Project",
+            score=1.0,
+            snippet="[Document: Visible title | Description: metadata-only phrase]",
+            match_count=1,
+        )
+        captured: list[str] = []
+
+        monkeypatch.setattr(searcher, "_fts_search", lambda *args, **kwargs: [candidate])
+        monkeypatch.setattr(searcher, "_vector_search", lambda *args, **kwargs: [])
+        monkeypatch.setattr(searcher, "_semantic_search", lambda *args, **kwargs: [])
+
+        class CaptureReranker:
+            def rerank(self, query: str, documents: list[str]) -> list[float]:
+                del query
+                captured.extend(documents)
+                return [1.0] * len(documents)
+
+        monkeypatch.setattr(searcher, "_get_reranker", lambda: CaptureReranker())
+
+        _hybrid_reranked_search(vault, "body-only phrase", max_results=1)
+
+        assert len(captured) == 1
+        assert captured[0].startswith("Visible title\n\nbody-only phrase")
+        assert "metadata-only phrase" not in captured[0]
+        assert "status: active" not in captured[0]
 
 
 class TestPragmaTuning:


### PR DESCRIPTION
## Summary

- feed the reranker a title plus the source note body, excluding YAML frontmatter
- treat search snippets as a degraded fallback because FTS/vector snippets may contain synthetic headers or metadata
- add a regression fixture proving metadata-only text is not passed to the reranker

## Scope

This is an input-hygiene experiment for the hypothesis in #240/#283. It does not claim improved MRR, latency, canonical reranked quality, or resolution of the dense/ANN gate. Those remain gated on a frozen real-vault receipt.

## Validation

- full suite: 894 passed, 10 skipped; coverage 81.37%
- ruff check and format check
- mypy src/power_framework
- doc-drift and release-contract tests
- frozen benchmark: 111 passed, 1 skipped

Refs #240
Refs #283