### PR TITLE
feat(mcp): expose paginated sub-index navigation

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -163,21 +163,25 @@ losing semantic, hybrid, and reranked search until the next dense rebuild.
 Read an existing canonical P.A.R.A. `_index.md`; does not generate it.
 
 ```text
-read_sub_index(category: string, vault_path?: string) -> string
+read_sub_index(category: string, vault_path?: string, page?: integer) -> string
 ```
 
 `category` must be one of `00_Inbox`, `01_Projects`, `02_Areas`,
 `03_Resources`, `04_Archive`, or `06_Daily_Logs`.
+`page` is one-based and defaults to `1`; use it to read `_index-2.md` and later
+pages declared by the generated catalog's `x-index-pages` header. Requests for a
+missing or undeclared page fail closed instead of returning a partial catalog.
 
 ### 4. `ensure_sub_index`
 
 Generate and read one canonical P.A.R.A. sub-index if it has notes.
 
 ```text
-ensure_sub_index(category: string, vault_path?: string) -> string
+ensure_sub_index(category: string, vault_path?: string, page?: integer) -> string
 ```
 
 It has the same category boundary as `read_sub_index`.
+It regenerates the catalog when needed, then returns only the requested page.
 
 ### 5. `ingest_note`
 

--- a/src/power_framework/mcp/power_server.py
+++ b/src/power_framework/mcp/power_server.py
@@ -116,23 +116,50 @@ def _validate_catalog_page(page: int) -> int:
     return page
 
 
-def _declared_catalog_page_count(index_path: Path) -> int:
-    """Read the generated page count without trusting arbitrary note content."""
+def _read_catalog_prefix(index_path: Path) -> str:
+    """Read only enough catalog bytes to inspect generated frontmatter."""
     try:
-        prefix = index_path.read_text(encoding="utf-8")[:4096]
-    except OSError as exc:
+        with index_path.open("r", encoding="utf-8") as handle:
+            return handle.read(4096)
+    except (OSError, UnicodeError) as exc:
         raise ToolError("Unable to read the catalog landing page") from exc
 
-    page_line = next(
-        (line for line in prefix.splitlines() if line.startswith("x-index-pages:")),
-        "",
-    )
-    if not page_line:
-        return 1
+
+def _read_catalog_frontmatter(prefix: str) -> list[str] | None:
+    """Return only the first complete YAML frontmatter block, if present."""
+    lines = prefix.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
     try:
-        page_count = int(page_line.split(":", 1)[1].strip())
+        closing = next(
+            index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---"
+        )
+    except StopIteration as exc:
+        raise ToolError("Catalog frontmatter is unclosed; regenerate the index") from exc
+    return lines[1:closing]
+
+
+def _frontmatter_integer(lines: list[str], key: str) -> int | None:
+    """Read one unique integer frontmatter field without scanning the body."""
+    matches = [line for line in lines if line.startswith(f"{key}:")]
+    if len(matches) > 1:
+        raise ToolError(f"Catalog frontmatter contains duplicate {key}; regenerate the index")
+    if not matches:
+        return None
+    try:
+        return int(matches[0].split(":", 1)[1].strip())
     except (IndexError, ValueError) as exc:
         raise ToolError("Catalog page metadata is invalid; regenerate the index") from exc
+
+
+def _declared_catalog_page_count(prefix: str) -> int:
+    """Read the generated page count without trusting arbitrary body content."""
+    frontmatter = _read_catalog_frontmatter(prefix)
+    if frontmatter is None:
+        return 1
+    page_count = _frontmatter_integer(frontmatter, "x-index-pages")
+    if page_count is None:
+        return 1
     if page_count < 1:
         raise ToolError("Catalog page metadata is invalid; regenerate the index")
     return page_count
@@ -142,13 +169,21 @@ def _read_catalog_page(category_path: Path, page: int) -> str | None:
     """Read one declared catalog page, failing closed on stale pagination."""
     landing_path = category_path / _catalog_page_filename(1)
     try:
-        landing_path.read_text(encoding="utf-8")
+        landing_path.stat()
     except FileNotFoundError:
         return None
     except OSError as exc:
         raise ToolError("Unable to read the catalog landing page") from exc
 
-    page_count = _declared_catalog_page_count(landing_path)
+    if page == 1:
+        try:
+            content = landing_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise ToolError("Unable to read the catalog landing page") from exc
+        _declared_catalog_page_count(content[:4096])
+        return content
+
+    page_count = _declared_catalog_page_count(_read_catalog_prefix(landing_path))
     if page > page_count:
         raise ToolError(f"Catalog page {page} is out of range; available pages: 1-{page_count}")
 
@@ -159,7 +194,7 @@ def _read_catalog_page(category_path: Path, page: int) -> str | None:
         raise ToolError(
             f"Catalog page {page} is missing although the landing page declares {page_count}"
         ) from exc
-    except OSError as exc:
+    except (OSError, UnicodeError) as exc:
         raise ToolError(f"Unable to read catalog page {page}") from exc
 
 

--- a/src/power_framework/mcp/power_server.py
+++ b/src/power_framework/mcp/power_server.py
@@ -104,6 +104,65 @@ _LOOPBACK_HTTP_HOSTS = frozenset({"127.0.0.1", "::1"})
 _MAX_MCP_SEARCH_RESULTS = 20
 
 
+def _catalog_page_filename(page: int) -> str:
+    """Return the stable filename for a one-based catalog page."""
+    return "_index.md" if page == 1 else f"_index-{page}.md"
+
+
+def _validate_catalog_page(page: int) -> int:
+    """Validate the bounded page selector exposed by catalog tools."""
+    if isinstance(page, bool) or not isinstance(page, int) or page < 1:
+        raise ToolError("page must be a positive integer starting at 1")
+    return page
+
+
+def _declared_catalog_page_count(index_path: Path) -> int:
+    """Read the generated page count without trusting arbitrary note content."""
+    try:
+        prefix = index_path.read_text(encoding="utf-8")[:4096]
+    except OSError as exc:
+        raise ToolError("Unable to read the catalog landing page") from exc
+
+    page_line = next(
+        (line for line in prefix.splitlines() if line.startswith("x-index-pages:")),
+        "",
+    )
+    if not page_line:
+        return 1
+    try:
+        page_count = int(page_line.split(":", 1)[1].strip())
+    except (IndexError, ValueError) as exc:
+        raise ToolError("Catalog page metadata is invalid; regenerate the index") from exc
+    if page_count < 1:
+        raise ToolError("Catalog page metadata is invalid; regenerate the index")
+    return page_count
+
+
+def _read_catalog_page(category_path: Path, page: int) -> str | None:
+    """Read one declared catalog page, failing closed on stale pagination."""
+    landing_path = category_path / _catalog_page_filename(1)
+    try:
+        landing_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ToolError("Unable to read the catalog landing page") from exc
+
+    page_count = _declared_catalog_page_count(landing_path)
+    if page > page_count:
+        raise ToolError(f"Catalog page {page} is out of range; available pages: 1-{page_count}")
+
+    page_path = category_path / _catalog_page_filename(page)
+    try:
+        return page_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ToolError(
+            f"Catalog page {page} is missing although the landing page declares {page_count}"
+        ) from exc
+    except OSError as exc:
+        raise ToolError(f"Unable to read catalog page {page}") from exc
+
+
 def _get_vault_path(vault_path: str | None = None) -> Path:
     """Resolve a tool vault path without allowing configured-root substitution."""
     configured_root = os.getenv("POWER_VAULT_DIR") or os.getenv("POWER_VAULT_PATH")
@@ -311,9 +370,10 @@ async def sync_vault(
     },
     meta={"power.risk": {"local_only": True, "egress": "none", "approval": "none"}},
 )
-async def read_sub_index(category: str, vault_path: str | None = None) -> str:
-    """Read the sub-index (_index.md) for a specific P.A.R.A. category. Use this after identifying the relevant category from the main index. Read-only — does not generate files."""
+async def read_sub_index(category: str, vault_path: str | None = None, page: int = 1) -> str:
+    """Read one bounded page of a P.A.R.A. sub-index without generating files."""
     path = _get_vault_path(vault_path)
+    page = _validate_catalog_page(page)
 
     if category not in PARA_FOLDERS:
         raise ToolError(f"Invalid category: {category}. Must be one of: {', '.join(PARA_FOLDERS)}")
@@ -322,9 +382,9 @@ async def read_sub_index(category: str, vault_path: str | None = None) -> str:
     if not category_path.is_dir():
         raise ToolError(f"Category folder not found: {category}")
 
-    sub_index_path = category_path / "_index.md"
-    if sub_index_path.exists():
-        return sub_index_path.read_text(encoding="utf-8")
+    content = _read_catalog_page(category_path, page)
+    if content is not None:
+        return content
 
     return f"No _index.md found for {category}. Use ensure_sub_index to generate it."
 
@@ -338,9 +398,10 @@ async def read_sub_index(category: str, vault_path: str | None = None) -> str:
     },
     meta={"power.risk": {"local_only": True, "egress": "none", "approval": "caller"}},
 )
-async def ensure_sub_index(category: str, vault_path: str | None = None) -> str:
-    """Generate and read a sub-index (_index.md) for a P.A.R.A. category. Use this when _index.md is missing and you need to generate it."""
+async def ensure_sub_index(category: str, vault_path: str | None = None, page: int = 1) -> str:
+    """Generate and read one bounded page of a P.A.R.A. sub-index."""
     path = _get_vault_path(vault_path)
+    page = _validate_catalog_page(page)
 
     if category not in PARA_FOLDERS:
         raise ToolError(f"Invalid category: {category}. Must be one of: {', '.join(PARA_FOLDERS)}")
@@ -357,8 +418,10 @@ async def ensure_sub_index(category: str, vault_path: str | None = None) -> str:
 
     def _gen_and_read() -> str:
         result = run_generate_sub_index(path, category)
-        sub_path = category_path / "_index.md"
-        return f"{result}\n\n{sub_path.read_text(encoding='utf-8')}"
+        content = _read_catalog_page(category_path, page)
+        if content is None:
+            raise ToolError(f"Generated catalog landing page is missing for {category}")
+        return f"{result}\n\n{content}"
 
     return await run_vault_mutation(path, _gen_and_read)
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -140,6 +140,11 @@ async def test_mcp_tools_publish_standard_and_power_risk_annotations() -> None:
         "power.risk": {"local_only": True, "egress": "none", "approval": "caller"}
     }
 
+    for catalog_name in ("read_sub_index", "ensure_sub_index"):
+        catalog_parameters = by_name[catalog_name].parameters
+        assert catalog_parameters["properties"]["page"] == {"default": 1, "type": "integer"}
+        assert "page" not in catalog_parameters["required"]
+
 
 async def test_mcp_wire_discovery_preserves_tool_contract_and_empty_collections() -> None:
     async with Client(power_server.mcp) as client:
@@ -228,6 +233,57 @@ async def test_read_sub_index_existing_category(sample_vault: Path) -> None:
     await ensure_sub_index(category="01_Projects", vault_path=str(sample_vault))
     result = await read_sub_index(category="01_Projects", vault_path=str(sample_vault))
     assert "Test Project" in result
+
+
+async def test_read_sub_index_can_select_declared_page(sample_vault: Path) -> None:
+    category_path = sample_vault / "01_Projects"
+    category_path.joinpath("_index.md").write_text(
+        "---\nx-index-pages: 2\n---\nPage 1 of 2\n", encoding="utf-8"
+    )
+    category_path.joinpath("_index-2.md").write_text(
+        "---\nx-index-page: 2\nx-index-pages: 2\n---\nPage 2 of 2\n",
+        encoding="utf-8",
+    )
+
+    result = await read_sub_index(category="01_Projects", page=2, vault_path=str(sample_vault))
+
+    assert "Page 2 of 2" in result
+
+
+async def test_read_sub_index_rejects_invalid_or_stale_page(sample_vault: Path) -> None:
+    category_path = sample_vault / "01_Projects"
+    category_path.joinpath("_index.md").write_text(
+        "---\nx-index-pages: 2\n---\nPage 1 of 2\n", encoding="utf-8"
+    )
+
+    with pytest.raises(ToolError, match="positive integer"):
+        await read_sub_index(category="01_Projects", page=0, vault_path=str(sample_vault))
+    with pytest.raises(ToolError, match="out of range"):
+        await read_sub_index(category="01_Projects", page=3, vault_path=str(sample_vault))
+    with pytest.raises(ToolError, match="missing"):
+        await read_sub_index(category="01_Projects", page=2, vault_path=str(sample_vault))
+
+
+async def test_ensure_sub_index_can_return_requested_page(
+    sample_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_generate(vault_path: Path, category: str) -> str:
+        category_path = vault_path / category
+        category_path.joinpath("_index.md").write_text(
+            "---\nx-index-pages: 2\n---\nPage 1 of 2\n", encoding="utf-8"
+        )
+        category_path.joinpath("_index-2.md").write_text(
+            "---\nx-index-page: 2\nx-index-pages: 2\n---\nPage 2 of 2\n",
+            encoding="utf-8",
+        )
+        return "Generated test catalog"
+
+    monkeypatch.setattr(power_server, "run_generate_sub_index", fake_generate)
+
+    result = await ensure_sub_index(category="01_Projects", page=2, vault_path=str(sample_vault))
+
+    assert result.startswith("Generated test catalog")
+    assert "Page 2 of 2" in result
 
 
 async def test_read_sub_index_invalid_category(sample_vault: Path) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -264,6 +264,40 @@ async def test_read_sub_index_rejects_invalid_or_stale_page(sample_vault: Path) 
         await read_sub_index(category="01_Projects", page=2, vault_path=str(sample_vault))
 
 
+async def test_read_sub_index_ignores_body_metadata_and_rejects_malformed_frontmatter(
+    sample_vault: Path,
+) -> None:
+    category_path = sample_vault / "01_Projects"
+    landing_path = category_path / "_index.md"
+    landing_path.write_text(
+        "---\ntype: System Guide\n---\nbody x-index-pages: 2\n", encoding="utf-8"
+    )
+    with pytest.raises(ToolError, match="out of range"):
+        await read_sub_index(category="01_Projects", page=2, vault_path=str(sample_vault))
+
+    landing_path.write_text("---\nx-index-pages: 2\nx-index-pages: 2\n---\n", encoding="utf-8")
+    with pytest.raises(ToolError, match="duplicate"):
+        await read_sub_index(category="01_Projects", vault_path=str(sample_vault))
+
+    landing_path.write_text("---\nx-index-pages: 2\n", encoding="utf-8")
+    with pytest.raises(ToolError, match="unclosed"):
+        await read_sub_index(category="01_Projects", vault_path=str(sample_vault))
+
+
+async def test_read_sub_index_wraps_invalid_utf8_in_tool_error(sample_vault: Path) -> None:
+    category_path = sample_vault / "01_Projects"
+    category_path.joinpath("_index.md").write_bytes(b"\xff\xfe")
+    with pytest.raises(ToolError, match="Unable to read"):
+        await read_sub_index(category="01_Projects", vault_path=str(sample_vault))
+
+    category_path.joinpath("_index.md").write_text(
+        "---\nx-index-pages: 2\n---\nPage 1 of 2\n", encoding="utf-8"
+    )
+    category_path.joinpath("_index-2.md").write_bytes(b"\xff\xfe")
+    with pytest.raises(ToolError, match="Unable to read catalog page"):
+        await read_sub_index(category="01_Projects", page=2, vault_path=str(sample_vault))
+
+
 async def test_ensure_sub_index_can_return_requested_page(
     sample_vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- add an optional one-based `page` argument to `read_sub_index` and `ensure_sub_index`
- let agents reach generated `_index-2.md` and later pages without filesystem access
- fail closed on invalid, out-of-range, missing, or malformed pagination state
- preserve the existing string envelope and positional `vault_path` compatibility
- document the bounded navigation contract

Refs #283 (paginated MCP catalog navigation)

## Verification

- `899 passed, 10 skipped`, coverage `81.31%`
- `111 passed, 1 skipped` benchmark suite
- Ruff check and format check: pass
- mypy: pass
- doc-drift: pass
- release contract: pass
- `mkdocs build --strict`: pass (existing unlisted-page warnings only)
- FastMCP schema readback: both tools expose optional integer `page`, default `1`
- signed commit: `8b8e0b105316193cdedfba3ad9580106f39a2671`

This is catalog navigation only. It does not change retrieval ranking, dense/ANN behavior, reranker quality, or evidence claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added page selection for sub-index catalogs.
  * Catalogs now support multiple pages, with clear validation for unavailable or outdated pages.
  * Catalog generation can refresh pages when needed before returning the requested content.

* **Documentation**
  * Updated tool documentation to include the optional page parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->