### PR TITLE
feat(mcp): expose read-only server discovery contract

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,14 +1,14 @@
 # P.O.W.E.R. Framework — Agent Instructions
 
 Python 3.11+ toolkit for AI-native Second Brain management. CLI (`power`, 20 top-level
-commands) + MCP server (19 tools).
+commands) + MCP server (20 tools).
 
 ## Project Structure
 
 ```
 src/power_framework/       # Core library
   core/                    #   models, parser, indexer, linter, searcher, embedder
-  mcp/                     #   FastMCP-3.x server (19 async tools)
+  mcp/                     #   FastMCP-3.x server (20 async tools)
 tests/                     # Pytest suite; CI enforces coverage >=70%
 scripts/                   # Dev/CI utilities
 docs/                      # MkDocs-material documentation site
@@ -44,7 +44,7 @@ pre-commit run --all-files # Git hooks (ruff + mypy + pip-audit)
 | `core/linter.py`      | Health checks: links, metadata, orphans, stale/expired |
 | `core/searcher.py`    | FTS5/dense/hybrid/reranked search (`semantic` default) |
 | `core/embeddings.py`  | BGE-M3 ONNX (1024d) + MiniLM fallback                  |
-| `mcp/power_server.py` | FastMCP 3.x, 19 async tools, HTTP transport + /health  |
+| `mcp/power_server.py` | FastMCP 3.x, 20 async tools, HTTP transport + /health  |
 
 ## Workflow
 

--- a/.agents/skills/holistic-analysis/SKILL.md
+++ b/.agents/skills/holistic-analysis/SKILL.md
@@ -42,7 +42,7 @@ Verify against this checklist:
 - Are background threads constrained (`ThreadPoolExecutor` instead of raw threads)?
 - Is the image/codebase clean (no systemd artifacts, no empty directories)?
 - Does the vault pass `power lint` with exit code 0?
-- Are all 19 MCP tools functional via the FastMCP 3.x server?
+- Are all 20 MCP tools functional via the FastMCP 3.x server?
 - Is the `models.lock.json` SHA-pinned for both `canonical_embedding` and `canonical_reranker`?
 - Does the semantic GT (`--gt-mode semantic`) show `ndcg@5(reranked) > ndcg@5(fts)`?
 

--- a/.agents/skills/power/references/runtime-contract.md
+++ b/.agents/skills/power/references/runtime-contract.md
@@ -6,7 +6,7 @@ sync/doctor правила. Авторитетна правда — `power docto
 
 ## Runtime version
 
-`v3.4.0` — runtime contract: **20 CLI commands** + **19 MCP tools** (FastMCP 3.x).
+`v3.4.0` — runtime contract: **20 CLI commands** + **20 MCP tools** (FastMCP 3.x).
 
 ## CLI (20 команд)
 
@@ -31,8 +31,11 @@ sync/doctor правила. Авторитетна правда — `power docto
 19. `power rename <path> --old <old> --new <new>` — перейменування з оновленням зв'язків
 20. `power doctor [<path>] [--json]` — read-only діагностика runtime, ONNX provider, індексу та ledger виключених нотаток
 
-## MCP Tools (19) — FastMCP 3.x
+## MCP Tools (20) — FastMCP 3.x
 
+- Discovery: `get_server_info` — versioned runtime, configured vault, coverage,
+  and embedding configuration; `probe_provider=true` is an explicit no-download
+  provider-binding probe.
 - Індекси й каталог: `generate_index`, `read_sub_index`, `ensure_sub_index`
 - Запис: `ingest_note`, `synthesize_session`
 - Пошук: `search_vault_tool`, `sync_vault`, `suggest_related_tool`
@@ -42,6 +45,12 @@ sync/doctor правила. Авторитетна правда — `power docto
   `apply_memory_change`, `validate_memory_state`, `read_memory_history`
 - Handoff: `handoff_work` — content-free Markdown packet, checkpoints,
   resume/cancel/input-required semantics та idempotency keys
+
+`get_server_info` is the MCP equivalent of the CLI doctor discovery contract.
+Its default call is lightweight and does not load ONNX Runtime, open a model
+session, create cache state, or access the network. A configured or listed
+provider is never treated as an active binding; use `probe_provider=true` when
+an actual no-download session binding receipt is required.
 
 **Канонічний запис замикає пошук.** `ingest_note`, `synthesize_session` та
 `apply_memory_change` в одному transaction workflow оновлюють note, index,
@@ -97,6 +106,9 @@ power sync PATH [--fts-only] [--force] [--strict | --allow-partial] [--accept-de
 - `power doctor [<path>] [--json]` — read-only діагностика. Report має
   `read_only=true` і `network_access=false`, включає повний ledger
   `excluded_notes` та стабільні issue codes для агентів і CI.
+- MCP `get_server_info` — той самий versioned doctor JSON для довгоживучого
+  агента; за замовчуванням discovery не пробує model/provider, а
+  `probe_provider=true` явно запитує no-download binding probe.
 
 ## Models / environment
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ Unlike generic knowledge management tools, P.O.W.E.R. is designed from the groun
 - **Knowledge Graph** — `related` field connects notes across the vault; visualized in sub-indexes for Graph RAG workflows
 - **Freshness Monitoring** — linter detects stale/expired notes based on `expiry` metadata field
 - **Agent Auto-Ingest** — `synthesize_session` MCP tool lets agents autonomously create permanent knowledge artifacts with governance + graph links + full catalog maintenance
-- **MCP-native** — expose 19 tools to MCP-compatible AI clients through FastMCP 3.x
+- **MCP-native** — expose 20 tools to MCP-compatible AI clients through FastMCP 3.x
+- **Truthful agent discovery** — call `get_server_info` first to verify the
+  running package version, vault boundary, coverage, and explicit provider
+  binding state; the default discovery call performs no model load or network access
 - **Windows-safe rename** — `power rename` uses `os.replace()` for the physical
   move, so renaming onto an existing destination works on Windows instead of
   raising `FileExistsError`
@@ -49,7 +52,7 @@ the role-specific guides before touching a vault:
 - **[Windows 11 25H2](docs/windows-11-installation.md)** — complete PowerShell
   installation, Visual C++ prerequisite, exact interpreter paths, and checks
 - **[CLI reference](docs/cli.md)** — all 20 commands, flags, and actual exit behavior
-- **[MCP server](docs/mcp-server.md)** — all 19 governed tools, rate limits,
+- **[MCP server](docs/mcp-server.md)** — all 20 governed tools, rate limits,
   configured-vault boundary, and untrusted retrieval contract
 - **[Migration guide](docs/migration-guide.md)** — 6-phase, manifest/hash-driven
   migration from any Markdown source methodology into a canonical POWER vault
@@ -107,7 +110,7 @@ coverage from checks that must pass on the target Windows host.
 | Feature                          | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **CLI**                          | 20 commands, including `power doctor` for read-only runtime/index diagnosis, `power cache` for namespace hygiene, `power import` for preflighted Markdown migration, `power memory` for explicit proposal/approval, and `power handoff` for durable cross-agent work packets                                                                                                                                                                                                                                                                                                                            |
-| **MCP Server**                   | 19 tools, including governed memory context, proposal, apply, validation, history, `handoff_work`, and search-index synchronization operations                                                                                                                                                                                                                                                                                                                                                    |
+| **MCP Server**                   | 20 tools, including governed memory context, proposal, apply, validation, history, `handoff_work`, and search-index synchronization operations                                                                                                                                                                                                                                                                                                                                                    |
 | **OKF Validation**               | Pydantic v2 schemas enforce strict metadata on every note with governance (`owner`, `status`, `expiry`)                                                                                                                                                                                                                                                                                                                                                                             |
 | **Knowledge Graph (Graph RAG)**  | `related` field in OKF frontmatter supporting `TypedRelation` (path, relation, confidence) with BFS traversal and Mermaid diagram export (`to_mermaid`)                                                                                                                                                                                                                                                                                                                             |
 | **Freshness Monitoring**         | Linter flags stale/expired notes by checking `expiry` dates, ensuring your vault stays current                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -422,7 +425,7 @@ flowchart TD
     end
 
     subgraph AI ["🤖 AI Agent (FastMCP 3.x)"]
-        Tools[["🔌 19 Async MCP Tools (stdio/HTTP)"]]:::agent
+        Tools[["🔌 20 Async MCP Tools (stdio/HTTP)"]]:::agent
         Search[["🔍 Hybrid / Reranked Search"]]:::agent
         ROT{{"🛠️ ROT & Contradiction Audit (Semantic/LLM)"}}:::agent
     end
@@ -491,7 +494,7 @@ flowchart TD
 | `core/constants.py`                       | Centralized exclusion lists and system constants                                                                                                                                                                                   |
 | `core/utils.py`                           | Path traversal protection, atomic writes, backups, rate limiter                                                                                                                                                                    |
 | `core/cli.py`                             | Command-line interface with 20 commands, including read-only doctor diagnostics, preflighted import, transactional memory, and durable handoff workflows                                                                                                                           |
-| `mcp/power_server.py`                     | FastMCP 3.x server with 19 async tools, loopback HTTP transport, and `/health`                                                                                                                                                     |
+| `mcp/power_server.py`                     | FastMCP 3.x server with 20 async tools, loopback HTTP transport, and `/health`                                                                                                                                                     |
 
 All components share `power_framework.core` as the single source of truth.
 

--- a/README.ua.md
+++ b/README.ua.md
@@ -29,7 +29,10 @@ P.O.W.E.R. — це гібридна система, створена для п�
 - **Knowledge Graph** — поле `related` зв'язує нотатки між собою для Graph RAG
 - **Freshness Monitoring** — лінтер виявляє застарілі нотатки за полем `expiry`
 - **Agent Auto-Ingest** — MCP інструмент `synthesize_session` для автономного створення нотаток агентами з governance + graph links + index
-- **MCP-нативний** — 19 інструментів доступні MCP-сумісним AI-клієнтам через FastMCP 3.x
+- **MCP-нативний** — 20 інструментів доступні MCP-сумісним AI-клієнтам через FastMCP 3.x
+- **Правдива discovery для агентів** — спочатку викликайте `get_server_info`,
+  щоб перевірити версію запущеного пакета, vault boundary, coverage і явний
+  стан provider binding; стандартний виклик не завантажує модель і не звертається до мережі
 - **Windows-safe rename** — `power rename` використовує `os.replace()` для
   фізичного переміщення, тому перейменування на існуючу ціль працює у Windows
   замість помилки `FileExistsError`
@@ -46,7 +49,7 @@ P.O.W.E.R. створений для роботи як людьми, так і A
 - **[Windows 11 25H2](docs/windows-11-installation.ua.md)** — повне
   PowerShell-встановлення, Visual C++ prerequisite, точні interpreter paths і checks
 - **[CLI reference](docs/cli.md)** — усі 20 команд, flags і реальна exit behavior
-- **[MCP server](docs/mcp-server.md)** — усі 19 governed tools, rate limits,
+- **[MCP server](docs/mcp-server.md)** — усі 20 governed tools, rate limits,
   configured-vault boundary і untrusted retrieval contract
 - **[Migration guide](docs/migration-guide.ua.md)** — 6-фазна manifest/hash-driven
   міграція з будь-якої Markdown source methodology у canonical POWER vault
@@ -104,7 +107,7 @@ rollback і uninstall.
 | Функція                          | Що робить                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **CLI**                          | 20 команд, включно з `power doctor` для read-only діагностики runtime/index, `power cache` для гігієни namespace, `power import` для preflighted Markdown migration, `power memory` для явного proposal/approval та `power handoff` для durable cross-agent work packets                                                                                                                                                                                                                                                                                           |
-| **MCP Server**                   | 19 інструментів, включно з керованими операціями memory context, proposal, apply, validation, history та `handoff_work`                                                                                                                                                                                                                                                                                                                                                                              |
+| **MCP Server**                   | 20 інструментів, включно з керованими операціями memory context, proposal, apply, validation, history та `handoff_work`                                                                                                                                                                                                                                                                                                                                                                              |
 | **OKF Validation**               | Pydantic v2 схеми забезпечують строгі OKF-метадані на кожній нотатці з governance-полями (`owner`, `status`, `expiry`)                                                                                                                                                                                                                                                                                                                                                               |
 | **Knowledge Graph (Graph RAG)**  | Поле `related` в OKF frontmatter з підтримкою `TypedRelation` (path, relation, confidence), BFS обходом та експортом підграфів у Mermaid-діаграми (`to_mermaid`)                                                                                                                                                                                                                                                                                                                     |
 | **Freshness Monitoring**         | Лінтер виявляє застарілі нотатки за полем `expiry`                                                                                                                                                                                                                                                                                                                                                                                                                                   |
@@ -486,7 +489,7 @@ flowchart TD
 | `core/constants.py`                       | Централізовані списки виключень та системні константи                                                                                                                                                                                                  |
 | `core/utils.py`                           | Захист від path traversal, атомарний запис, бекапи, rate limiter                                                                                                                                                                                       |
 | `core/cli.py`                             | Командний рядок із 20 командами, включно з read-only doctor diagnostics, cache hygiene, preflighted import, transactional memory і durable handoff workflows                                                                                                                               |
-| `mcp/power_server.py`                     | FastMCP 3.x сервер із 19 async tools, loopback HTTP transport та `/health`                                                                                                                                                                             |
+| `mcp/power_server.py`                     | FastMCP 3.x сервер із 20 async tools, loopback HTTP transport та `/health`                                                                                                                                                                             |
 
 Всі компоненти використовують `power_framework.core` як єдине джерело правди.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ src/power_framework/
 └── mcp/
     ├── __init__.py     # Package marker
     ├── __main__.py     # python -m entry point
-    └── power_server.py # FastMCP 3.x server (19 tools + health)
+    └── power_server.py # FastMCP 3.x server (20 tools + health)
 
 tests/
 ├── test_cli.py         # CLI functional tests

--- a/docs/documentation-inventory.ua.md
+++ b/docs/documentation-inventory.ua.md
@@ -20,7 +20,7 @@
 | `docs/migration-guide.md` | Міграція наявної бази | Шість fail-closed фаз |
 | `docs/migration-guide.ua.md` | Українська міграція | Семантично паритетна |
 | `docs/cli.md` | Виконуваний CLI-контракт | 20 команд |
-| `docs/mcp-server.md` | Виконуваний MCP-контракт | 19 інструментів |
+| `docs/mcp-server.md` | Виконуваний MCP-контракт | 20 інструментів |
 | `docs/mcp-client-onboarding.md` | Golden onboarding для чотирьох клієнтів | stdio shape + proposal gate |
 | `docs/mcp-client-onboarding.ua.md` | Український golden onboarding | Семантично паритетний |
 
@@ -39,7 +39,7 @@
 
 ## Усунений дрейф
 
-- Старий MCP-інвентар замінено на фактичні `19` інструментів; CLI
+- Старий MCP-інвентар замінено на фактичні `20` інструментів; CLI
   задокументовано як `20` top-level команд.
   топ-рівневих команд.
 - `reranked` більше не називається стандартним режимом: код використовує `semantic`,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -163,7 +163,7 @@ POWER_VAULT_DIR="$POWER_VAULT" "$POWER_PYTHON" -c \
 ```
 
 Restart long-lived MCP clients after changing their configuration or Python
-environment. See [MCP Server](mcp-server.md) for the 19-tool contract and
+environment. See [MCP Server](mcp-server.md) for the 20-tool contract and
 transport security boundary.
 
 ## 8. Daily operating sequence

--- a/docs/getting-started.ua.md
+++ b/docs/getting-started.ua.md
@@ -164,7 +164,7 @@ POWER_VAULT_DIR="$POWER_VAULT" "$POWER_PYTHON" -c \
 ```
 
 Після зміни конфігурації або Python environment перезапустіть long-lived
-MCP-клієнт. Повний контракт 19 інструментів і transport security boundary
+MCP-клієнт. Повний контракт 20 інструментів і transport security boundary
 описано в [MCP Server](mcp-server.md).
 
 ## 8. Щоденна послідовність

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ reconcile every file by manifest and hash, and make cutover reversible.
 
 - Python 3.11 or newer.
 - 20 top-level CLI commands; see the [CLI reference](cli.md).
-- 19 MCP tools; see the [MCP server reference](mcp-server.md).
+- 20 MCP tools; see the [MCP server reference](mcp-server.md).
 - `semantic` is the default search mode; `reranked` is an explicit opt-in.
 - The generated root index and MCP sub-index operations cover the canonical P.A.R.A.
   directories. Arbitrary source layouts must be mapped during migration.

--- a/docs/mcp-client-onboarding.md
+++ b/docs/mcp-client-onboarding.md
@@ -141,12 +141,17 @@ After changing a client configuration, restart or reload that client. The
 first task is read-only until the explicit proposal step:
 
 1. Open the client's MCP status view (`/mcp` where supported) and confirm that
-   `power` is connected and exposes 19 tools.
+   `power` is connected and exposes 20 tools.
 2. Ask the agent to list tools, resources, resource templates, and prompts.
-   POWER should expose 19 tools and no resources, templates, or prompts.
-3. Ask the agent to call `get_memory_context` for a short query. This must not
+   POWER should expose 20 tools and no resources, templates, or prompts.
+3. Ask the agent to call `get_server_info` with its default arguments. Confirm
+   the reported package version, configured vault path, and explicit
+   `embedding.binding` state before trusting retrieval. Use
+   `probe_provider=true` only when an actual no-download provider binding check
+   is needed.
+4. Ask the agent to call `get_memory_context` for a short query. This must not
    create a file, namespace, index, or history entry.
-4. Ask the agent to call `propose_memory_change` for a new note, but do not
+5. Ask the agent to call `propose_memory_change` for a new note, but do not
    approve it. This creates only a durable content-addressed proposal ledger
    entry; the target note, catalog, and search projection must remain absent.
 

--- a/docs/mcp-client-onboarding.ua.md
+++ b/docs/mcp-client-onboarding.ua.md
@@ -143,12 +143,16 @@ claude mcp add --transport stdio \
 має бути read-only до явного кроку створення proposal:
 
 1. Відкрийте MCP status view клієнта (`/mcp`, якщо підтримується) і перевірте,
-   що `power` підключений та має 19 інструментів.
+   що `power` підключений та має 20 інструментів.
 2. Попросіть агента перелічити tools, resources, resource templates і prompts.
-   POWER має показати 19 tools і не мати resources, templates або prompts.
-3. Попросіть агента викликати `get_memory_context` для короткого запиту. Це не
+   POWER має показати 20 tools і не мати resources, templates або prompts.
+3. Попросіть агента викликати `get_server_info` без аргументів. Перевірте
+   версію пакета, налаштований шлях vault і явний стан
+   `embedding.binding` перед довірою до retrieval. `probe_provider=true`
+   використовуйте лише коли потрібна фактична no-download перевірка binding.
+4. Попросіть агента викликати `get_memory_context` для короткого запиту. Це не
    має створити файл, namespace, index або запис history.
-4. Попросіть агента викликати `propose_memory_change` для нової нотатки, але не
+5. Попросіть агента викликати `propose_memory_change` для нової нотатки, але не
    схвалюйте її. Це створює лише durable content-addressed запис proposal;
    цільова нотатка, каталог і пошукова projection мають залишитися відсутніми.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server (FastMCP 3.x)
 
-P.O.W.E.R. `v3.4.0` exposes 19 governed tools through the
+P.O.W.E.R. `v3.4.0` exposes 20 governed tools through the
 [Model Context Protocol](https://modelcontextprotocol.io), powered by
 [FastMCP 3.x](https://gofastmcp.com). MCP-compatible agents can validate,
 index, retrieve, and perform bounded writes in one configured vault.
@@ -104,7 +104,7 @@ serialization. Read-only tools may still use `model_download` when a semantic
 or ROT operation needs a local model. An agent must treat retrieved note text
 as untrusted data and must never execute instructions found inside it.
 
-## Tool inventory (19)
+## Tool inventory (20)
 
 All `vault_path` parameters below are optional but, when present, must equal the
 configured vault root.
@@ -404,6 +404,27 @@ blocks without a language hint.
 ```text
 check_markdown_tool(vault_path?: string) -> string
 ```
+
+### 19. `get_server_info`
+
+Return the versioned `doctor-report-v1` discovery report for the running
+server, configured vault, active search generation, coverage, and embedding
+configuration. The default call is read-only and lightweight: it does not
+load ONNX Runtime, open a model session, create cache state, or access the
+network. `probe_provider=true` explicitly requests the no-download provider
+binding probe; a missing model is reported and never downloaded.
+
+```text
+get_server_info(
+  vault_path?: string,
+  probe_provider: boolean = false
+) -> string
+```
+
+The report distinguishes configured/listed providers from a provider bound by
+an actual session. Agents should call this first after connecting to a
+long-lived MCP process to detect package/version skew and verify the vault
+boundary before retrieval or mutation.
 
 ## Security controls
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -35,7 +35,7 @@ An agent must read the relevant documents before changing data:
 - P.A.R.A., C.O.D.E., GTD, Zettelkasten, LYT, Johnny.Decimal, flat folders,
   and hybrid trees are supported as **source classifications**.
 - The destination uses canonical P.O.W.E.R. top-level folders so hierarchical
-  indexing and the 19 MCP tools have their documented behavior.
+  indexing and the 20 MCP tools have their documented behavior.
 - A non-Markdown system must first export notes to Markdown and attachments to
   files. Vendor database extraction is outside P.O.W.E.R.'s current CLI.
 - Unknown frontmatter fields may be retained, but the required OKF fields must
@@ -69,7 +69,7 @@ This guide is verified against the pinned `v3.4.0` release. CI checks these
 facts against the executable capability manifest so an agent does not inherit
 an older migration recipe:
 
-- the current surface is 20 top-level CLI commands and 19 MCP tools;
+- the current surface is 20 top-level CLI commands and 20 MCP tools;
 - the default search mode is `semantic`; `reranked` is explicit opt-in;
 - database and cache paths are runtime-owned. Use `power doctor DESTINATION
   --json` to read the active paths and state; never hard-code a vault-local

--- a/docs/migration-guide.ua.md
+++ b/docs/migration-guide.ua.md
@@ -35,7 +35,7 @@ rollback path.
 - P.A.R.A., C.O.D.E., GTD, Zettelkasten, LYT, Johnny.Decimal, flat folders та
   hybrid trees підтримуються як **класифікації джерела**.
 - Destination використовує канонічні top-level folders P.O.W.E.R., щоб
-  hierarchical index і 19 MCP tools мали задокументовану поведінку.
+  hierarchical index і 20 MCP tools мали задокументовану поведінку.
 - Не-Markdown система має спочатку експортувати нотатки у Markdown, а
   attachments — у файли. Vendor database extraction не реалізовано в CLI.
 - Невідомі frontmatter fields можна зберегти, але required OKF fields мають
@@ -69,7 +69,7 @@ rollback path.
 executable capability manifest, щоб агент не успадковував старий migration
 recipe:
 
-- поточна surface — 20 top-level CLI commands і 19 MCP tools;
+- поточна surface — 20 top-level CLI commands і 20 MCP tools;
 - режим пошуку за замовчуванням — `semantic`; `reranked` є explicit opt-in;
 - database і cache paths належать runtime. Для active paths і state використовуйте
   `power doctor DESTINATION --json`; не hard-code-ьте vault-local database

--- a/skills/power/references/runtime-contract.md
+++ b/skills/power/references/runtime-contract.md
@@ -6,7 +6,7 @@ sync/doctor правила. Авторитетна правда — `power docto
 
 ## Runtime version
 
-`v3.4.0` — runtime contract: **20 CLI commands** + **19 MCP tools** (FastMCP 3.x).
+`v3.4.0` — runtime contract: **20 CLI commands** + **20 MCP tools** (FastMCP 3.x).
 
 ## CLI (20 команд)
 
@@ -31,8 +31,11 @@ sync/doctor правила. Авторитетна правда — `power docto
 19. `power rename <path> --old <old> --new <new>` — перейменування з оновленням зв'язків
 20. `power doctor [<path>] [--json]` — read-only діагностика runtime, ONNX provider, індексу та ledger виключених нотаток
 
-## MCP Tools (19) — FastMCP 3.x
+## MCP Tools (20) — FastMCP 3.x
 
+- Discovery: `get_server_info` — versioned runtime, configured vault, coverage,
+  and embedding configuration; `probe_provider=true` is an explicit no-download
+  provider-binding probe.
 - Індекси й каталог: `generate_index`, `read_sub_index`, `ensure_sub_index`
 - Запис: `ingest_note`, `synthesize_session`
 - Пошук: `search_vault_tool`, `sync_vault`, `suggest_related_tool`
@@ -42,6 +45,12 @@ sync/doctor правила. Авторитетна правда — `power docto
   `apply_memory_change`, `validate_memory_state`, `read_memory_history`
 - Handoff: `handoff_work` — content-free Markdown packet, checkpoints,
   resume/cancel/input-required semantics та idempotency keys
+
+`get_server_info` is the MCP equivalent of the CLI doctor discovery contract.
+Its default call is lightweight and does not load ONNX Runtime, open a model
+session, create cache state, or access the network. A configured or listed
+provider is never treated as an active binding; use `probe_provider=true` when
+an actual no-download session binding receipt is required.
 
 **Канонічний запис замикає пошук.** `ingest_note`, `synthesize_session` та
 `apply_memory_change` в одному transaction workflow оновлюють note, index,
@@ -97,6 +106,9 @@ power sync PATH [--fts-only] [--force] [--strict | --allow-partial] [--accept-de
 - `power doctor [<path>] [--json]` — read-only діагностика. Report має
   `read_only=true` і `network_access=false`, включає повний ledger
   `excluded_notes` та стабільні issue codes для агентів і CI.
+- MCP `get_server_info` — той самий versioned doctor JSON для довгоживучого
+  агента; за замовчуванням discovery не пробує model/provider, а
+  `probe_provider=true` явно запитує no-download binding probe.
 
 ## Models / environment
 

--- a/src/power_framework/core/doctor.py
+++ b/src/power_framework/core/doctor.py
@@ -228,6 +228,37 @@ def _probe_embedding_binding() -> tuple[dict[str, Any], list[dict[str, str]]]:
     return embedding, issues
 
 
+def _unprobed_embedding_status() -> tuple[dict[str, Any], list[dict[str, str]]]:
+    """Describe embedding configuration without loading runtimes or models.
+
+    MCP discovery is called by long-lived clients and must be cheap and
+    side-effect free by default.  A configured provider is not an active
+    provider, so this deliberately reports ``not_requested`` rather than
+    implying that the requested backend bound successfully.
+    """
+    from .embeddings import EMBED_PROVIDER, requested_device
+
+    embedding: dict[str, Any] = {
+        "provider": EMBED_PROVIDER,
+        "requested_device": requested_device("POWER_EMBED_DEVICE"),
+        "available_providers": [],
+        "model_cached": None,
+        "binding": "not_requested",
+        "bound_provider": None,
+        "probe_seconds": None,
+        "probe_requested": False,
+    }
+    issues = [
+        _issue(
+            "embedding_binding_not_requested",
+            "warning",
+            "The active embedding provider was not probed by this read-only discovery call.",
+            "Call the MCP discovery tool with probe_provider=true or run power doctor --json.",
+        )
+    ]
+    return embedding, issues
+
+
 def _probe_vault(vault_dir: Path) -> tuple[dict[str, Any], list[dict[str, str]]]:
     """Inspect a vault and its search state without creating cache or index files."""
     root = Path(vault_dir).expanduser().resolve()
@@ -392,8 +423,13 @@ def _probe_vault(vault_dir: Path) -> tuple[dict[str, Any], list[dict[str, str]]]
     return vault, issues
 
 
-def run_doctor(vault_dir: Path | None = None) -> dict[str, Any]:
-    """Build the versioned, read-only doctor report."""
+def run_doctor(vault_dir: Path | None = None, *, probe_embedding: bool = True) -> dict[str, Any]:
+    """Build the versioned, read-only doctor report.
+
+    ``probe_embedding=False`` is the lightweight discovery path used by MCP.
+    It reports configuration and vault state without importing ONNX Runtime,
+    opening a model session, or checking model cache files.
+    """
     try:
         package_version = distribution_version("power-framework")
     except PackageNotFoundError:
@@ -422,7 +458,11 @@ def run_doctor(vault_dir: Path | None = None) -> dict[str, Any]:
         "embed_device": requested_device("POWER_EMBED_DEVICE"),
         "reranker_device": requested_device("POWER_RERANKER_DEVICE"),
     }
-    embedding, embedding_issues = _probe_embedding_binding()
+    if probe_embedding:
+        embedding, embedding_issues = _probe_embedding_binding()
+        embedding["probe_requested"] = True
+    else:
+        embedding, embedding_issues = _unprobed_embedding_status()
     report["embedding"] = embedding
     issues.extend(embedding_issues)
     if vault_dir is not None:

--- a/src/power_framework/mcp/power_server.py
+++ b/src/power_framework/mcp/power_server.py
@@ -4,6 +4,7 @@ P.O.W.E.R. MCP Server (FastMCP 3.x).
 
 Exposes MCP tools for AI agent interaction with the knowledge vault:
 - lint_vault: Health check for metadata, links, and orphans
+- get_server_info: Read-only runtime, provider, vault, and coverage discovery
 - generate_index: Compile hierarchical catalog (index.md + _index.md files)
 - sync_vault: Publish an atomic FTS/dense search-index generation
 - read_sub_index: Read a specific category sub-index on-demand (read-only)
@@ -49,6 +50,7 @@ from power_framework.core import (
     OKFMetadata,
     RateLimiter,
     WritePolicy,
+    __version__,
     advance_work_packet,
     apply_change,
     archive_stale_notes,
@@ -83,6 +85,7 @@ from power_framework.core import (
     check_all as check_markdown,
 )
 from power_framework.core.constants import SKIP_FILES
+from power_framework.core.doctor import report_as_json, run_doctor
 from power_framework.core.domains import DomainConfigError
 from power_framework.core.ignore import should_skip
 from power_framework.core.relations import suggest_related_semantic
@@ -90,7 +93,7 @@ from power_framework.core.synthesize import synthesize_session_ingest
 
 logger = logging.getLogger(__name__)
 
-mcp = FastMCP("power", mask_error_details=True)
+mcp = FastMCP("power", version=__version__, mask_error_details=True)
 mcp.add_middleware(
     ErrorHandlingMiddleware(
         include_traceback=False,
@@ -265,6 +268,32 @@ async def health_check(_request: Request) -> Response:
     except RuntimeError as exc:
         return JSONResponse({"status": "error", "detail": str(exc)}, status_code=503)
     return JSONResponse({"status": "ok"})
+
+
+@mcp.tool(
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    meta={"power.risk": {"local_only": True, "egress": "none", "approval": "none"}},
+)
+async def get_server_info(
+    vault_path: str | None = None,
+    probe_provider: bool = False,
+) -> str:
+    """Return the versioned read-only runtime and vault discovery report.
+
+    The default path does not load ONNX Runtime, open a model session, create
+    cache state, or access the network. Set ``probe_provider=True`` to perform
+    the full no-download binding probe; even then a missing model fails closed
+    instead of downloading it.
+    """
+    path = _get_vault_path(vault_path)
+    return await run_blocking(
+        lambda: report_as_json(run_doctor(path, probe_embedding=probe_provider))
+    )
 
 
 @mcp.tool(

--- a/tests/test_doc_drift.py
+++ b/tests/test_doc_drift.py
@@ -57,7 +57,7 @@ def test_current_docs_match_executable_interfaces_and_safe_onboarding(
 
     assert facts["source"] == "power_framework.core.capabilities"
     assert len(facts["interfaces"]["cli_commands"]) == 20
-    assert len(facts["interfaces"]["mcp_tools"]) == 19
+    assert len(facts["interfaces"]["mcp_tools"]) == 20
     assert gate["check_interfaces"](documents, facts) == []
     assert gate["check_onboarding"](documents, facts) == []
     assert gate["check_links"](documents, facts) == []
@@ -124,7 +124,7 @@ def test_interface_gate_rejects_stale_readme_mcp_count() -> None:
     gate = _load_gate()
     facts = gate["_load_code_facts"]()
     documents = gate["_read_current_documents"]()
-    documents["README"] = documents["README"].replace("19 Async MCP Tools", "18 Async MCP Tools", 1)
+    documents["README"] = documents["README"].replace("20 Async MCP Tools", "19 Async MCP Tools", 1)
 
     errors = gate["check_interfaces"](documents, facts)
 
@@ -136,12 +136,12 @@ def test_interface_gate_rejects_stale_getting_started_count() -> None:
     facts = gate["_load_code_facts"]()
     documents = gate["_read_current_documents"]()
     documents["Getting Started"] = documents["Getting Started"].replace(
-        "19-tool contract", "18-tool contract", 1
+        "20-tool contract", "19-tool contract", 1
     )
 
     errors = gate["check_interfaces"](documents, facts)
 
-    assert any("Getting Started" in error and "19 MCP tools" in error for error in errors)
+    assert any("Getting Started" in error and "20 MCP tools" in error for error in errors)
 
 
 def test_interface_gate_rejects_incomplete_mcp_risk_contract() -> None:
@@ -182,7 +182,7 @@ def test_skill_gate_covers_workspace_references_and_readme_ua(monkeypatch, tmp_p
     assert any("Workspace agent skill" in error and "sync_vault" in error for error in errors)
 
     monkeypatch.setenv("POWER_GLOBAL_SKILL_PATH", str(tmp_path / "no-global-copy"))
-    documents["README.ua"] = documents["README.ua"].replace("19 інструментів", "18 інструментів", 1)
+    documents["README.ua"] = documents["README.ua"].replace("20 інструментів", "19 інструментів", 1)
     errors = gate["check_interfaces"](documents, facts)
 
     assert any("README.ua" in error and "MCP tools" in error for error in errors)
@@ -249,7 +249,7 @@ def test_skill_gate_rejects_stale_reference_facts(tmp_path: Path) -> None:
     runtime = root / "references" / "runtime-contract.md"
     runtime.write_text(
         runtime.read_text(encoding="utf-8")
-        .replace("19 MCP tools", "18 MCP tools", 1)
+        .replace("20 MCP tools", "19 MCP tools", 1)
         .replace("`sync_vault`", "`missing_tool`"),
         encoding="utf-8",
     )
@@ -257,7 +257,7 @@ def test_skill_gate_rejects_stale_reference_facts(tmp_path: Path) -> None:
     errors = gate["_check_skill_copy"]("Stale skill", root / "SKILL.md", facts)
 
     assert any(
-        "Stale skill" in error and "does not declare all 19 MCP tools" in error for error in errors
+        "Stale skill" in error and "does not declare all 20 MCP tools" in error for error in errors
     )
     assert any(
         "Stale skill" in error and "missing executable MCP tool `sync_vault`" in error

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -47,7 +47,7 @@ def test_json_report_is_versioned_and_machine_readable(tmp_path: Path, monkeypat
     assert parsed["issues"][0]["code"] == "search_index_missing"
     assert parsed["capabilities"] == capabilities.manifest()
     assert len(parsed["capabilities"]["interfaces"]["cli_commands"]) == 20
-    assert len(parsed["capabilities"]["interfaces"]["mcp_tools"]) == 19
+    assert len(parsed["capabilities"]["interfaces"]["mcp_tools"]) == 20
     contracts = parsed["capabilities"]["interfaces"]["mcp_tool_contracts"]
     assert [contract["name"] for contract in contracts] == parsed["capabilities"]["interfaces"][
         "mcp_tools"
@@ -71,6 +71,25 @@ def test_json_report_is_versioned_and_machine_readable(tmp_path: Path, monkeypat
     assert archive_contract["annotations"]["destructiveHint"] is True
     assert archive_contract["risk"]["approval"] == "explicit"
     assert parsed["capabilities"]["search"]["default_mode"] == "semantic"
+
+
+def test_lightweight_discovery_skips_embedding_probe_and_cache_state(
+    tmp_path: Path, monkeypatch
+) -> None:
+    cache_home = tmp_path / "cache-home"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(cache_home))
+
+    def fail_if_called() -> tuple[dict[str, object], list[dict[str, str]]]:
+        raise AssertionError("lightweight discovery must not probe the embedding session")
+
+    monkeypatch.setattr(doctor, "_probe_embedding_binding", fail_if_called)
+
+    report = doctor.run_doctor(tmp_path, probe_embedding=False)
+
+    assert report["embedding"]["binding"] == "not_requested"
+    assert report["embedding"]["probe_requested"] is False
+    assert report["issues"][0]["code"] == "embedding_binding_not_requested"
+    assert not cache_home.exists()
 
 
 def test_capability_manifest_is_read_only(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -20,6 +20,7 @@ import pytest
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
 
+from power_framework.core import __version__
 from power_framework.core.capabilities import manifest
 from power_framework.core.parser import validate_metadata
 from power_framework.mcp import power_server
@@ -27,6 +28,7 @@ from power_framework.mcp.power_server import (
     apply_memory_change,
     ensure_sub_index,
     generate_index,
+    get_server_info,
     handoff_work,
     ingest_note,
     lint_vault,
@@ -61,6 +63,8 @@ def _mcp_process_env(vault_path: Path, transport: str, port: int | None = None) 
 
 
 async def _assert_wire_contract(client: Client[object]) -> None:
+    assert client.initialize_result is not None
+    assert client.initialize_result.serverInfo.version == __version__
     tools = await client.list_tools()
     resources = await client.list_resources()
     resource_templates = await client.list_resource_templates()
@@ -112,7 +116,7 @@ async def _wait_for_http_health(process: asyncio.subprocess.Process, url: str) -
 async def test_mcp_tools_publish_standard_and_power_risk_annotations() -> None:
     tools = await power_server.mcp.list_tools()
 
-    assert len(tools) == 19
+    assert len(tools) == 20
     by_name = {tool.name: tool for tool in tools}
     assert set(by_name) == set(manifest()["interfaces"]["mcp_tools"])
 
@@ -145,6 +149,21 @@ async def test_mcp_tools_publish_standard_and_power_risk_annotations() -> None:
         assert catalog_parameters["properties"]["page"] == {"default": 1, "type": "integer"}
         assert "page" not in catalog_parameters["required"]
 
+    discovery = by_name["get_server_info"]
+    assert discovery.annotations is not None
+    assert discovery.annotations.readOnlyHint is True
+    assert discovery.annotations.destructiveHint is False
+    assert discovery.annotations.idempotentHint is True
+    assert discovery.annotations.openWorldHint is False
+    assert discovery.meta == {
+        "power.risk": {"local_only": True, "egress": "none", "approval": "none"}
+    }
+    assert discovery.parameters["properties"]["probe_provider"] == {
+        "default": False,
+        "type": "boolean",
+    }
+    assert "probe_provider" not in discovery.parameters.get("required", [])
+
 
 async def test_mcp_wire_discovery_preserves_tool_contract_and_empty_collections() -> None:
     async with Client(power_server.mcp) as client:
@@ -166,6 +185,63 @@ async def test_mcp_wire_discovery_preserves_tool_contract_and_empty_collections(
     assert all(tool.meta and tool.meta.get("power.risk") for tool in tools)
 
 
+async def test_mcp_server_advertises_truthful_package_version() -> None:
+    from power_framework.core import __version__
+
+    async with Client(power_server.mcp) as client:
+        assert client.initialize_result is not None
+        assert client.initialize_result.serverInfo.version == __version__
+
+
+async def test_get_server_info_is_read_only_and_does_not_probe_by_default(
+    sample_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_home = tmp_path / "empty-cache"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(cache_home))
+
+    result = json.loads(await get_server_info(vault_path=str(sample_vault)))
+
+    assert result["schema_version"] == 1
+    assert result["command"] == "doctor"
+    assert result["runtime"]["power_framework"]
+    assert result["vault"]["path"] == str(sample_vault.resolve())
+    assert result["embedding"]["binding"] == "not_requested"
+    assert result["embedding"]["probe_requested"] is False
+    assert any(issue["code"] == "embedding_binding_not_requested" for issue in result["issues"])
+    assert not cache_home.exists()
+    assert not (sample_vault / ".power").exists()
+
+
+async def test_get_server_info_can_request_the_no_download_provider_probe(
+    sample_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from power_framework.core import doctor
+
+    monkeypatch.setattr(
+        doctor,
+        "_probe_embedding_binding",
+        lambda: (
+            {
+                "provider": "bge-m3",
+                "requested_device": "auto",
+                "available_providers": ["CPUExecutionProvider"],
+                "model_cached": True,
+                "binding": "verified",
+                "bound_provider": "CPUExecutionProvider",
+                "probe_seconds": 0.001,
+                "runtime": {"available": True, "version": "test"},
+            },
+            [],
+        ),
+    )
+
+    result = json.loads(await get_server_info(vault_path=str(sample_vault), probe_provider=True))
+
+    assert result["embedding"]["binding"] == "verified"
+    assert result["embedding"]["probe_requested"] is True
+    assert not any(issue["code"] == "embedding_binding_not_requested" for issue in result["issues"])
+
+
 async def test_mcp_stdio_process_preserves_wire_contract(sample_vault: Path) -> None:
     config = {
         "mcpServers": {
@@ -179,6 +255,13 @@ async def test_mcp_stdio_process_preserves_wire_contract(sample_vault: Path) -> 
 
     async with Client(config) as client:
         await _assert_wire_contract(client)
+        info_result = await client.call_tool("get_server_info")
+        assert info_result.content
+        info = json.loads(info_result.content[0].text)
+        assert info["command"] == "doctor"
+        assert info["runtime"]["power_framework"] == __version__
+        assert info["vault"]["path"] == str(sample_vault.resolve())
+        assert info["embedding"]["binding"] == "not_requested"
 
 
 async def test_mcp_http_process_reports_health_and_preserves_wire_contract(


### PR DESCRIPTION
## Summary

- add the additive, read-only `get_server_info` MCP tool backed by the existing `doctor-report-v1` contract;
- make the FastMCP `serverInfo.version` match the installed `power-framework` package;
- keep default discovery no-download/no-model/no-cache and require explicit `probe_provider=true` for an actual provider-binding probe;
- update the 20-tool documentation, onboarding, bundled agent contract, and drift regressions.

This closes the measured agent workflow gap described in #283: a long-lived MCP process could be on a different package version from the CLI without exposing that fact. It does not close the real-vault dense, ANN, or reranker evidence gates in #240/#283.

## Verification

- `905 passed, 10 skipped`, coverage `81.43%`;
- targeted doctor/MCP acceptance: `77 passed`;
- `ruff check`, `ruff format --check`, `mypy src/power_framework`;
- executable doc-drift gate, `compileall`, `git diff --check`;
- isolated `mkdocs build --strict`;
- `scripts/verify_release_contract.py`;
- fresh stdio MCP process verifies `tools/list`, truthful `serverInfo.version`, and the JSON discovery response.

Refs #283
