### PR TITLE
fix(docs): keep searcher table syntax valid

### DIFF
--- a/docs/api/searcher.md
+++ b/docs/api/searcher.md
@@ -23,9 +23,9 @@ Class representing a single search result with relevance details.
 | `match_count` | `int`       | Match count fallback                  |
 | `tags`        | `list[str]` | List of tags associated with the note |
 | `retrieval_contract` | `str` | Applied retrieval contract, including an explicit fallback when enabled |
-| `index_kind` | `str | None` | Verified request index: `immutable_generation` or `legacy_db` |
-| `index_generation_id` | `str | None` | Immutable generation identifier when `index_kind` is `immutable_generation` |
-| `index_source_snapshot_hash` | `str | None` | Content-free source snapshot hash for the verified immutable generation |
+| `index_kind` | `str or None` | Verified request index: `immutable_generation` or `legacy_db` |
+| `index_generation_id` | `str or None` | Immutable generation identifier when `index_kind` is `immutable_generation` |
+| `index_source_snapshot_hash` | `str or None` | Content-free source snapshot hash for the verified immutable generation |
 
 ## Retrieval contract
 


### PR DESCRIPTION
## Summary
- replace unescaped pipe characters in the SearchResult Markdown table with table-safe `str or None` notation
- preserve the documented retrieval provenance fields without changing runtime behavior

Follow-up to #299.

## Verification
- staged diff contains only the three documentation type cells
- signed commit verified locally
- `git diff --check` passed
- local .venv and PATH do not include mkdocs/uv; the repository Docs workflow is the authoritative build gate