### PR TITLE
perf(search): cache verified generation identity safely

### DIFF
--- a/docs/api/searcher.md
+++ b/docs/api/searcher.md
@@ -33,3 +33,12 @@ The executable registry is `SEARCH_MODE_REGISTRY` in `core/searcher.py` and
 the generated reference table is in [Architecture](../architecture.md). The
 deprecated `hybrid_reranked` input alias normalizes to `reranked`; it is not a
 canonical mode. The current default is `semantic`, not `reranked`.
+
+## Active-generation resolution
+
+When a vault has an immutable generation, POWER verifies the active state and
+database identity before serving retrieval. The verified identity may be
+reused by later requests only while the generation-state database (including
+its SQLite WAL/SHM files) and the immutable database fingerprint are unchanged.
+Publication explicitly invalidates this cache, and an identity or integrity
+mismatch fails closed instead of falling back to a stale generation.

--- a/src/power_framework/core/generation_index.py
+++ b/src/power_framework/core/generation_index.py
@@ -11,6 +11,7 @@ from contextlib import closing
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from threading import RLock
 
 from .constants import is_catalog_filename
 from .db import _init_db
@@ -70,6 +71,57 @@ class ActiveGeneration:
     source_snapshot_hash: str
     db_sha256: str
     db_size: int
+
+
+# A generation file is immutable after publication.  Cache only its verified
+# identity, and key the entry by filesystem fingerprints so an external
+# publisher, replacement, or corruption cannot silently reuse stale state.
+_FileFingerprint = tuple[int, int, int, int, int]
+_StateFingerprint = tuple[
+    _FileFingerprint | None,
+    _FileFingerprint | None,
+    _FileFingerprint | None,
+]
+_active_generation_cache: dict[
+    Path, tuple[_StateFingerprint, _FileFingerprint, ActiveGeneration]
+] = {}
+_active_generation_cache_lock = RLock()
+
+
+def _file_fingerprint(path: Path) -> _FileFingerprint | None:
+    """Return a read-only invalidation key for one existing file."""
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns)
+
+
+def _state_fingerprint(path: Path) -> _StateFingerprint | None:
+    """Fingerprint the SQLite state database and its optional WAL/SHM files."""
+    database = _file_fingerprint(path)
+    if database is None:
+        return None
+    return (
+        database,
+        _file_fingerprint(path.with_name(path.name + "-wal")),
+        _file_fingerprint(path.with_name(path.name + "-shm")),
+    )
+
+
+def invalidate_active_generation_cache(vault_dir: Path | None = None) -> None:
+    """Invalidate cached active-generation identities after a publication.
+
+    The filesystem key remains the fail-closed backstop for publishers that
+    are outside this process.  A caller may invalidate one vault or all vaults
+    when it performs an operation whose state update is not visible through a
+    normal filesystem timestamp change.
+    """
+    with _active_generation_cache_lock:
+        if vault_dir is None:
+            _active_generation_cache.clear()
+            return
+        _active_generation_cache.pop(Path(vault_dir).expanduser().resolve(), None)
 
 
 def _excluded_reason_counts(excluded_sources: dict[str, str]) -> dict[str, int]:
@@ -379,8 +431,21 @@ def resolve_active_generation(vault_dir: Path) -> ActiveGeneration | None:
     if not root.is_dir():
         return None
     state_path = _existing_state_db_path(root)
-    if state_path is None or not state_path.exists():
+    state_fingerprint = _state_fingerprint(state_path) if state_path is not None else None
+    if state_path is None or state_fingerprint is None:
+        invalidate_active_generation_cache(root)
         return None
+
+    with _active_generation_cache_lock:
+        cached = _active_generation_cache.get(root)
+        if cached is not None:
+            cached_state, cached_generation, active = cached
+            if cached_state == state_fingerprint:
+                current_generation = _file_fingerprint(active.path)
+                if current_generation == cached_generation:
+                    return active
+            _active_generation_cache.pop(root, None)
+
     try:
         with closing(sqlite3.connect(f"file:{state_path}?mode=ro", uri=True, timeout=30)) as conn:
             row = conn.execute(
@@ -398,13 +463,19 @@ def resolve_active_generation(vault_dir: Path) -> ActiveGeneration | None:
     if state != "ready" or not source_snapshot_hash or not db_sha256 or db_size is None:
         raise ActiveGenerationError(f"active generation is not ready: {generation_id}")
     verified_path = _verified_generation_path(root, generation_id, str(db_sha256), int(db_size))
-    return ActiveGeneration(
+    active = ActiveGeneration(
         path=verified_path,
         generation_id=str(generation_id),
         source_snapshot_hash=str(source_snapshot_hash),
         db_sha256=str(db_sha256),
         db_size=int(db_size),
     )
+    generation_fingerprint = _file_fingerprint(verified_path)
+    if generation_fingerprint is None:  # pragma: no cover - verified path exists above
+        raise ActiveGenerationError(f"active generation file is missing: {generation_id}")
+    with _active_generation_cache_lock:
+        _active_generation_cache[root] = (state_fingerprint, generation_fingerprint, active)
+    return active
 
 
 def resolve_active_generation_path(vault_dir: Path) -> Path | None:
@@ -510,6 +581,7 @@ def _publish(
         except Exception:
             conn.rollback()
             raise
+    invalidate_active_generation_cache(vault_dir)
     resolved = resolve_active_generation_path(vault_dir)
     if resolved != generation_path:
         raise ActiveGenerationError(f"active generation readback failed: {generation_id}")

--- a/tests/test_generation_index.py
+++ b/tests/test_generation_index.py
@@ -15,6 +15,7 @@ from power_framework.core.generation_index import (
     ActiveGenerationError,
     IndexGenerationError,
     _state_db_path,
+    invalidate_active_generation_cache,
     resolve_active_generation,
     resolve_active_generation_path,
     sync_vault_atomically,
@@ -241,6 +242,78 @@ def test_missing_active_generation_file_fails_closed(
 
     with pytest.raises(ActiveGenerationError, match="active generation file is missing"):
         search_vault(vault, "stable-token", mode="fts")
+
+
+def test_cached_generation_rechecks_file_identity_before_reuse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cached identity must not hide an externally corrupted generation."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    vault = _vault(tmp_path, "corrupted-cache", "stable-token")
+    sync_vault_atomically(vault, sync_embeddings=False)
+    active = resolve_active_generation(vault)
+    assert active is not None
+
+    active.path.write_bytes(active.path.read_bytes() + b"corruption")
+
+    with pytest.raises(ActiveGenerationError, match="identity mismatch"):
+        resolve_active_generation(vault)
+
+
+def test_publication_invalidates_generation_identity_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A newly published generation is visible to the next read immediately."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    vault = _vault(tmp_path, "cache-invalidation", "first-token")
+    first = sync_vault_atomically(vault, sync_embeddings=False)
+    assert resolve_active_generation(vault) is not None
+
+    note = vault / "01_Projects" / "Test.md"
+    note.write_text(
+        note.read_text(encoding="utf-8").replace("first-token", "second-token"),
+        encoding="utf-8",
+    )
+    second = sync_vault_atomically(vault, sync_embeddings=False)
+
+    assert second.generation_id != first.generation_id
+    active = resolve_active_generation(vault)
+    assert active is not None
+    assert active.generation_id == second.generation_id
+
+    invalidate_active_generation_cache(vault)
+    rechecked = resolve_active_generation(vault)
+    assert rechecked is not None
+    assert rechecked.generation_id == second.generation_id
+
+
+def test_external_active_pointer_change_invalidates_cached_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The state WAL is part of the cache key for another publisher's update."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    vault = _vault(tmp_path, "external-pointer", "first-token")
+    first = sync_vault_atomically(vault, sync_embeddings=False)
+    note = vault / "01_Projects" / "Test.md"
+    note.write_text(
+        note.read_text(encoding="utf-8").replace("first-token", "second-token"),
+        encoding="utf-8",
+    )
+    second = sync_vault_atomically(vault, sync_embeddings=False)
+    published = resolve_active_generation(vault)
+    assert published is not None
+    assert published.generation_id == second.generation_id
+
+    with closing(sqlite3.connect(_state_db_path(vault), timeout=30)) as conn:
+        conn.execute(
+            "UPDATE active_generation SET generation_id = ? WHERE id = 1",
+            (first.generation_id,),
+        )
+        conn.commit()
+
+    active = resolve_active_generation(vault)
+    assert active is not None
+    assert active.generation_id == first.generation_id
 
 
 def test_invalid_sources_are_explicitly_recorded(


### PR DESCRIPTION
## Summary
- cache verified immutable generation identities across retrieval requests
- key reuse by the state database plus SQLite WAL/SHM and generation file fingerprints
- invalidate explicitly after publication and fail closed on changed or corrupted state
- add regressions for corruption, publication, and external active-pointer changes
- document the read contract

## Validation
- full suite: `915 passed, 10 skipped`
- coverage: `81.63%`
- focused generation/search: `112 passed`
- Ruff, format check, and mypy: passed
- no ANN, reranker quality, GPU, or real-vault dense claim is introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved active-generation detection to safely reuse verified results when underlying files remain unchanged.
  - Automatically refreshes generation information after publication or external pointer changes.
  - Detects corrupted or inconsistent generation data and fails safely.

- **Documentation**
  - Added documentation explaining active-generation verification, cache behavior, invalidation, and failure handling.

- **Tests**
  - Added coverage for cache revalidation, publication updates, external changes, and corrupted generation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->