### PR TITLE
feat(bench): complete real-vault receipt contract

### DIFF
--- a/docs/benchmarks/real-vault-retrieval.md
+++ b/docs/benchmarks/real-vault-retrieval.md
@@ -3,7 +3,7 @@
 `scripts/benchmark_retrieval_latency.py` produces a content-free latency
 receipt. It records query-set hash, verified index identity, execution-shape
 timings, sanitized provider binding, peak RSS, optional NVIDIA device memory,
-and error counts. It never writes query text, note content, snippets, paths, or
+and execution errors. It never writes query text, note content, snippets, paths, or
 the doctor report's vault path to the receipt.
 
 Peak RSS is recorded per execution shape. NVIDIA telemetry is sampled only at

--- a/docs/benchmarks/real-vault-retrieval.md
+++ b/docs/benchmarks/real-vault-retrieval.md
@@ -1,0 +1,41 @@
+# Real-vault retrieval receipt
+
+`scripts/benchmark_retrieval_latency.py` produces a content-free latency
+receipt. It records query-set hash, verified index identity, execution-shape
+timings, sanitized provider binding, peak RSS, optional NVIDIA device memory,
+and error counts. It never writes query text, note content, snippets, paths, or
+the doctor report's vault path to the receipt.
+
+Peak RSS is recorded per execution shape. NVIDIA telemetry is sampled only at
+benchmark run start/end so `nvidia-smi` latency cannot contaminate MCP or query
+timings; it is explicitly device-wide and may include unrelated processes.
+
+The normal benchmark remains diagnostic. For the roadmap's real-vault dense
+evidence gate, require both an immutable generation and an actual provider
+session:
+
+```bash
+python scripts/benchmark_retrieval_latency.py \
+  --vault /path/to/isolated-real-vault \
+  --fixture /path/to/frozen-query-fixture \
+  --modes semantic hybrid reranked \
+  --rounds 5 \
+  --cold-rounds 3 \
+  --query-limit 10 \
+  --probe-provider \
+  --require-provider-binding \
+  --require-immutable-generation \
+  --output /tmp/power-real-vault-retrieval.json
+```
+
+The command exits non-zero if the generation is not verified immutable, the
+provider probe does not create a session with an active provider, or any
+execution shape records an error. `gpu_memory_used_bytes` is an optional
+device-wide `nvidia-smi` reading; `null` means that the host does not expose
+that telemetry and is not silently treated as zero.
+
+This receipt is evidence infrastructure, not acceptance by itself. The
+real-vault gate still requires an exact source snapshot, enough repeated
+samples for p50/p95, cold/warm/process/MCP controls, resource readings, and
+`content_free=true`. Synthetic fixtures and CPU feasibility runs remain
+diagnostic only; they do not justify an ANN or reranker quality claim.

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ are explicitly preserved as v1.6 historical snapshots.
 - [POWER 3.4.0 release notes](release-3.4.0.md)
 - [Windows 11 25H2 validation receipt](tests/windows-11-25h2-v3.3.2-validation-fixed.md)
 - [M2 human-evaluation contract](m2-human-evaluation.md)
+- [Real-vault retrieval receipt](benchmarks/real-vault-retrieval.md)
 - [Changelog](CHANGELOG.md)
 - [Contributing](contributing.md)
 

--- a/scripts/benchmark_retrieval_latency.py
+++ b/scripts/benchmark_retrieval_latency.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from contextlib import closing
 from pathlib import Path
 from typing import Any
 
@@ -229,7 +230,8 @@ def _index_identity(vault: Path) -> dict[str, Any]:
         return {"kind": "legacy_db", "generation_id": None}
 
     try:
-        with sqlite3.connect(f"file:{active.path.as_posix()}?mode=ro", uri=True) as connection:
+        database_uri = f"{active.path.resolve().as_uri()}?mode=ro"
+        with closing(sqlite3.connect(database_uri, uri=True)) as connection:
             note_count = int(connection.execute("SELECT COUNT(*) FROM file_metadata").fetchone()[0])
             chunk_count = int(
                 connection.execute("SELECT COUNT(*) FROM chunk_embeddings").fetchone()[0]
@@ -345,7 +347,7 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
             ]
             mode_result["warm_process"] = _summary(warm)
         except Exception as exc:
-            receipt["errors"].append(f"{mode}/warm_process: {type(exc).__name__}: {exc}")
+            receipt["errors"].append(f"{mode}/warm_process: {type(exc).__name__}")
 
         try:
             cold = [
@@ -355,13 +357,13 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
             ]
             mode_result["cold_process"] = _summary(cold)
         except Exception as exc:
-            receipt["errors"].append(f"{mode}/cold_process: {type(exc).__name__}: {exc}")
+            receipt["errors"].append(f"{mode}/cold_process: {type(exc).__name__}")
 
         try:
             mcp = await _mcp_samples(vault, queries, mode, args.rounds, args.max_results)
             mode_result["long_lived_mcp"] = _summary(mcp)
         except Exception as exc:
-            receipt["errors"].append(f"{mode}/long_lived_mcp: {type(exc).__name__}: {exc}")
+            receipt["errors"].append(f"{mode}/long_lived_mcp: {type(exc).__name__}")
 
         receipt["results"][mode] = mode_result
 

--- a/scripts/benchmark_retrieval_latency.py
+++ b/scripts/benchmark_retrieval_latency.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Produce a content-free retrieval latency attribution receipt.
+"""Produce a content-free retrieval latency and resource receipt.
 
-The benchmark deliberately reports timings and counts only. It never writes
-queries, note paths, snippets, or note content to the receipt.
+The benchmark deliberately reports verified metadata, timings, resource
+summaries, and counts only. It never writes queries, note paths, snippets, or
+note content to the receipt.
 
 Examples:
     python scripts/benchmark_retrieval_latency.py --vault /path/to/vault
@@ -18,6 +19,7 @@ import hashlib
 import json
 import math
 import os
+import sqlite3
 import statistics
 import subprocess
 import sys
@@ -26,6 +28,9 @@ import time
 from pathlib import Path
 from typing import Any
 
+from power_framework.core.benchmark_resources import resource_snapshot
+from power_framework.core.doctor import run_doctor
+from power_framework.core.generation_index import resolve_active_generation
 from power_framework.core.metrics.udcg_real import _load_semantic_gt
 from power_framework.core.searcher import search_vault
 from power_framework.core.timing import collect_timings
@@ -50,6 +55,35 @@ def _summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
         for name, value in sample.get("timings_ms", {}).items():
             components.setdefault(name, []).append(float(value))
 
+    resource_values: dict[str, list[int]] = {
+        "peak_rss_bytes": [],
+        "gpu_memory_used_bytes": [],
+    }
+    resource_scopes: set[str] = set()
+    resource_sources: set[str] = set()
+    for sample in samples:
+        resources = sample.get("resources", {})
+        if not isinstance(resources, dict):
+            continue
+        for name in resource_values:
+            value = resources.get(name)
+            if isinstance(value, int) and value >= 0:
+                resource_values[name].append(value)
+        scope = resources.get("gpu_memory_scope")
+        source = resources.get("gpu_memory_source")
+        if isinstance(scope, str):
+            resource_scopes.add(scope)
+        if isinstance(source, str):
+            resource_sources.add(source)
+
+    def resource_summary(values: list[int]) -> dict[str, int | float | None]:
+        return {
+            "samples": len(values),
+            "p50": _percentile([float(value) for value in values], 0.50),
+            "p95": _percentile([float(value) for value in values], 0.95),
+            "max": max(values) if values else None,
+        }
+
     return {
         "samples": len(samples),
         "wall_ms": {
@@ -65,6 +99,12 @@ def _summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
                 "mean": round(statistics.mean(values), 3),
             }
             for name, values in sorted(components.items())
+        },
+        "resources": {
+            "peak_rss_bytes": resource_summary(resource_values["peak_rss_bytes"]),
+            "gpu_memory_used_bytes": resource_summary(resource_values["gpu_memory_used_bytes"]),
+            "gpu_memory_scope": sorted(resource_scopes) or None,
+            "gpu_memory_source": sorted(resource_sources) or None,
         },
     }
 
@@ -84,6 +124,7 @@ def _local_sample(vault: Path, query: str, mode: str, max_results: int) -> dict[
         "wall_ms": (time.perf_counter() - started) * 1000,
         "timings_ms": receipt.as_dict()["components_ms"],
         "result_count": len(results),
+        "resources": resource_snapshot(include_gpu=False),
     }
 
 
@@ -172,19 +213,106 @@ async def _mcp_samples(
                         {
                             "wall_ms": elapsed,
                             "timings_ms": receipt["components_ms"],
+                            "resources": receipt.get("resources", {}),
                         }
                     )
         return samples
+
+
+def _index_identity(vault: Path) -> dict[str, Any]:
+    """Read verified generation identity and dense manifest without user data."""
+    try:
+        active = resolve_active_generation(vault)
+    except Exception as exc:
+        return {"kind": "unreadable", "error_type": type(exc).__name__}
+    if active is None:
+        return {"kind": "legacy_db", "generation_id": None}
+
+    try:
+        with sqlite3.connect(f"file:{active.path.as_posix()}?mode=ro", uri=True) as connection:
+            note_count = int(connection.execute("SELECT COUNT(*) FROM file_metadata").fetchone()[0])
+            chunk_count = int(
+                connection.execute("SELECT COUNT(*) FROM chunk_embeddings").fetchone()[0]
+            )
+            manifest = dict(
+                connection.execute(
+                    "SELECT manifest_key, manifest_value FROM dense_index_manifest"
+                ).fetchall()
+            )
+    except (OSError, sqlite3.Error, TypeError, ValueError) as exc:
+        return {
+            "kind": "unreadable",
+            "generation_id": active.generation_id,
+            "error_type": type(exc).__name__,
+        }
+
+    return {
+        "kind": "immutable_generation",
+        "generation_id": active.generation_id,
+        "source_snapshot_hash": active.source_snapshot_hash,
+        "database_sha256": active.db_sha256,
+        "database_size_bytes": active.db_size,
+        "indexed_notes": note_count,
+        "indexed_chunks": chunk_count,
+        "dense_manifest": {
+            key: manifest[key]
+            for key in ("embedding_provider", "embedding_model", "chunk_count")
+            if key in manifest
+        },
+    }
+
+
+def _provider_receipt(vault: Path, *, probe: bool) -> dict[str, Any]:
+    """Return sanitized actual-provider state; never include doctor paths."""
+    if not probe:
+        return {"probe_requested": False, "binding": "not_requested"}
+    try:
+        report = run_doctor(vault, probe_embedding=True)
+    except Exception as exc:
+        return {
+            "probe_requested": True,
+            "binding": "failed",
+            "error_type": type(exc).__name__,
+        }
+    embedding = report.get("embedding", {})
+    if not isinstance(embedding, dict):
+        return {
+            "probe_requested": True,
+            "binding": "failed",
+            "error_type": "invalid_report",
+        }
+    issues = report.get("issues", [])
+    issue_codes = [
+        {"code": issue.get("code"), "severity": issue.get("severity")}
+        for issue in issues
+        if isinstance(issue, dict)
+    ]
+    available = embedding.get("available_providers", [])
+    runtime = embedding.get("runtime")
+    return {
+        "probe_requested": True,
+        "binding": embedding.get("binding"),
+        "bound_provider": embedding.get("bound_provider"),
+        "configured_provider": embedding.get("provider"),
+        "requested_device": embedding.get("requested_device"),
+        "available_providers": sorted(str(value) for value in available),
+        "runtime_version": runtime.get("version") if isinstance(runtime, dict) else None,
+        "probe_seconds": embedding.get("probe_seconds"),
+        "issues": issue_codes,
+    }
 
 
 async def _run(args: argparse.Namespace) -> dict[str, Any]:
     vault = args.vault.expanduser().resolve()
     queries = _load_queries(args.fixture, args.query_limit)
     query_set_hash = hashlib.sha256("\0".join(queries).encode("utf-8")).hexdigest()
+    resource_start = resource_snapshot()
     receipt: dict[str, Any] = {
-        "schema_version": "power.retrieval-latency.v1",
+        "schema_version": "power.retrieval-latency.v2",
         "content_free": True,
         "query_set_sha256": query_set_hash,
+        "index": _index_identity(vault),
+        "provider": _provider_receipt(vault, probe=args.probe_provider),
         "controls": {
             "query_count": len(queries),
             "rounds": args.rounds,
@@ -194,6 +322,15 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
         "results": {},
         "errors": [],
     }
+
+    if args.require_immutable_generation and receipt["index"].get("kind") != "immutable_generation":
+        receipt["errors"].append(
+            "index/immutable_generation: verified immutable generation required"
+        )
+    if args.require_provider_binding:
+        provider = receipt["provider"]
+        if provider.get("binding") != "verified" or not provider.get("bound_provider"):
+            receipt["errors"].append("provider/binding: verified active provider required")
 
     for mode in args.modes:
         mode_result: dict[str, Any] = {}
@@ -228,6 +365,11 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
 
         receipt["results"][mode] = mode_result
 
+    receipt["resources"] = {
+        "run_start": resource_start,
+        "run_end": resource_snapshot(),
+        "gpu_memory_note": "device-wide snapshots; may include unrelated processes",
+    }
     if receipt["errors"] and not receipt["results"]:
         raise RuntimeError("all retrieval latency modes failed")
     return receipt
@@ -247,6 +389,7 @@ def _worker(args: argparse.Namespace) -> int:
             "wall_ms": (time.perf_counter() - started) * 1000,
             "timings_ms": receipt.as_dict()["components_ms"],
             "result_count": len(results),
+            "resources": resource_snapshot(include_gpu=False),
         },
         sys.stdout,
         sort_keys=True,
@@ -265,6 +408,21 @@ def main() -> int:
     parser.add_argument("--query-limit", type=int, default=4)
     parser.add_argument("--max-results", type=int, default=20)
     parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--probe-provider",
+        action="store_true",
+        help="Probe the actual embedding session and include sanitized provider state",
+    )
+    parser.add_argument(
+        "--require-provider-binding",
+        action="store_true",
+        help="Fail unless the provider probe creates a session with an active provider",
+    )
+    parser.add_argument(
+        "--require-immutable-generation",
+        action="store_true",
+        help="Fail unless the vault resolves to a verified immutable generation",
+    )
     parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--query", help=argparse.SUPPRESS)
     parser.add_argument("--mode", choices=DEFAULT_MODES, help=argparse.SUPPRESS)
@@ -274,6 +432,8 @@ def main() -> int:
         if not args.query or not args.mode:
             parser.error("--worker requires --query and --mode")
         return _worker(args)
+    if args.require_provider_binding:
+        args.probe_provider = True
     if args.rounds < 1 or args.cold_rounds < 1 or args.query_limit < 1:
         parser.error("rounds and query-limit must be positive")
 

--- a/scripts/benchmark_retrieval_mcp_worker.py
+++ b/scripts/benchmark_retrieval_mcp_worker.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 from time import perf_counter
 
+from power_framework.core.benchmark_resources import resource_snapshot
 from power_framework.core.timing import collect_timings
 from power_framework.mcp import power_server
 
@@ -34,6 +35,7 @@ def _format_with_receipt(*args: object, **kwargs: object) -> str:
     payload = json.loads(serialized)
     timing_payload = _last_receipt.as_dict()
     payload["timings_ms"] = timing_payload["components_ms"]
+    timing_payload["resources"] = resource_snapshot(include_gpu=False)
     Path(os.environ["POWER_BENCHMARK_RECEIPT"]).write_text(
         json.dumps(timing_payload, sort_keys=True), encoding="utf-8"
     )

--- a/src/power_framework/core/benchmark_resources.py
+++ b/src/power_framework/core/benchmark_resources.py
@@ -1,0 +1,100 @@
+"""Content-free process and device resource snapshots for diagnostics."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+def _peak_rss_bytes() -> int | None:
+    """Return the process peak resident set size when the host exposes it."""
+    if os.name == "nt":
+        try:
+            from ctypes import wintypes
+
+            class _ProcessMemoryCounters(ctypes.Structure):
+                _fields_ = [
+                    ("cb", wintypes.DWORD),
+                    ("page_fault_count", wintypes.DWORD),
+                    ("peak_working_set_size", ctypes.c_size_t),
+                    ("working_set_size", ctypes.c_size_t),
+                    ("quota_peak_paged_pool_usage", ctypes.c_size_t),
+                    ("quota_paged_pool_usage", ctypes.c_size_t),
+                    ("quota_peak_non_paged_pool_usage", ctypes.c_size_t),
+                    ("quota_non_paged_pool_usage", ctypes.c_size_t),
+                    ("pagefile_usage", ctypes.c_size_t),
+                    ("peak_pagefile_usage", ctypes.c_size_t),
+                ]
+
+            counters = _ProcessMemoryCounters()
+            counters.cb = ctypes.sizeof(counters)
+            windll = ctypes.windll  # type: ignore[attr-defined]
+            process = windll.kernel32.GetCurrentProcess()
+            get_info = windll.psapi.GetProcessMemoryInfo
+            get_info.argtypes = [
+                wintypes.HANDLE,
+                ctypes.POINTER(_ProcessMemoryCounters),
+                wintypes.DWORD,
+            ]
+            get_info.restype = wintypes.BOOL
+            if get_info(process, ctypes.byref(counters), counters.cb):
+                return int(counters.peak_working_set_size)
+        except (AttributeError, OSError, TypeError, ValueError):
+            return None
+        return None
+
+    try:
+        import resource
+
+        value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    except (ImportError, OSError, ValueError):
+        return None
+    if value <= 0:
+        return None
+    # Linux and the BSDs report KiB; macOS reports bytes.
+    return value if sys.platform == "darwin" else value * 1024
+
+
+def _nvidia_memory_used_bytes() -> int | None:
+    """Return aggregate visible-device memory from optional ``nvidia-smi``."""
+    executable = shutil.which("nvidia-smi")
+    if executable is None:
+        return None
+    try:
+        completed = subprocess.run(  # noqa: S603 - fixed executable and arguments
+            [executable, "--query-gpu=memory.used", "--format=csv,noheader,nounits"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    values: list[int] = []
+    for line in completed.stdout.splitlines():
+        try:
+            value = int(line.strip())
+        except ValueError:
+            continue
+        if value >= 0:
+            values.append(value)
+    return sum(values) * 1024 * 1024 if values else None
+
+
+def resource_snapshot(*, include_gpu: bool = True) -> dict[str, Any]:
+    """Return a path-free resource snapshot suitable for a benchmark receipt."""
+    gpu_memory = _nvidia_memory_used_bytes() if include_gpu else None
+    return {
+        "peak_rss_bytes": _peak_rss_bytes(),
+        "gpu_memory_used_bytes": gpu_memory,
+        "gpu_memory_scope": "all_visible_devices"
+        if include_gpu and gpu_memory is not None
+        else None,
+        "gpu_memory_source": "nvidia-smi" if include_gpu and gpu_memory is not None else None,
+    }

--- a/src/power_framework/core/benchmark_resources.py
+++ b/src/power_framework/core/benchmark_resources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ctypes
+import ctypes.wintypes as wintypes
 import os
 import shutil
 import subprocess
@@ -14,7 +15,6 @@ def _peak_rss_bytes() -> int | None:
     """Return the process peak resident set size when the host exposes it."""
     if os.name == "nt":
         try:
-            from ctypes import wintypes
 
             class _ProcessMemoryCounters(ctypes.Structure):
                 _fields_ = [

--- a/tests/test_retrieval_latency_benchmark.py
+++ b/tests/test_retrieval_latency_benchmark.py
@@ -21,14 +21,65 @@ def test_percentile_is_nearest_rank() -> None:
 def test_summary_contains_only_timings_and_counts() -> None:
     result = benchmark._summary(
         [
-            {"wall_ms": 10.0, "timings_ms": {"sqlite_read": 2.0}},
-            {"wall_ms": 20.0, "timings_ms": {"sqlite_read": 4.0}},
+            {
+                "wall_ms": 10.0,
+                "timings_ms": {"sqlite_read": 2.0},
+                "resources": {"peak_rss_bytes": 100, "gpu_memory_used_bytes": None},
+            },
+            {
+                "wall_ms": 20.0,
+                "timings_ms": {"sqlite_read": 4.0},
+                "resources": {"peak_rss_bytes": 200, "gpu_memory_used_bytes": 300},
+            },
         ]
     )
 
     assert result["samples"] == 2
     assert result["wall_ms"]["p50"] == 10.0
     assert result["components_ms"]["sqlite_read"]["p95"] == 4.0
+    assert result["resources"]["peak_rss_bytes"]["max"] == 200
+    assert result["resources"]["gpu_memory_used_bytes"]["p50"] == 300.0
     assert "query" not in result
     assert "snippet" not in result
     assert "path" not in result
+
+
+def test_provider_receipt_is_sanitized(monkeypatch) -> None:
+    monkeypatch.setattr(
+        benchmark,
+        "run_doctor",
+        lambda vault, probe_embedding: {
+            "embedding": {
+                "binding": "verified",
+                "bound_provider": "CPUExecutionProvider",
+                "provider": "bge-m3",
+                "requested_device": "auto",
+                "available_providers": ["CPUExecutionProvider"],
+                "runtime": {"version": "1.0"},
+                "probe_seconds": 0.25,
+            },
+            "issues": [],
+            "vault": {"path": "/private/path"},
+        },
+    )
+
+    result = benchmark._provider_receipt(Path("/private/path"), probe=True)
+
+    assert result["binding"] == "verified"
+    assert result["bound_provider"] == "CPUExecutionProvider"
+    assert "vault" not in result
+    assert "/private/path" not in str(result)
+
+
+def test_resource_snapshot_can_omit_device_probe() -> None:
+    result = benchmark.resource_snapshot(include_gpu=False)
+
+    assert set(result) == {
+        "peak_rss_bytes",
+        "gpu_memory_used_bytes",
+        "gpu_memory_scope",
+        "gpu_memory_source",
+    }
+    assert result["gpu_memory_used_bytes"] is None
+    assert result["gpu_memory_scope"] is None
+    assert result["gpu_memory_source"] is None

--- a/tests/test_retrieval_latency_benchmark.py
+++ b/tests/test_retrieval_latency_benchmark.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import argparse
+import asyncio
 import importlib.util
+import json
+import sqlite3
+from contextlib import closing
 from pathlib import Path
+from types import SimpleNamespace
 
 SCRIPT = Path(__file__).parents[1] / "scripts" / "benchmark_retrieval_latency.py"
 SPEC = importlib.util.spec_from_file_location("benchmark_retrieval_latency", SCRIPT)
@@ -83,3 +89,83 @@ def test_resource_snapshot_can_omit_device_probe() -> None:
     assert result["gpu_memory_used_bytes"] is None
     assert result["gpu_memory_scope"] is None
     assert result["gpu_memory_source"] is None
+
+
+def test_index_identity_encodes_special_database_path(tmp_path, monkeypatch) -> None:
+    database = tmp_path / "generation#1?verified.sqlite"
+    with closing(sqlite3.connect(database)) as connection:
+        connection.execute("CREATE TABLE file_metadata (rel_path TEXT)")
+        connection.execute("CREATE TABLE chunk_embeddings (chunk_id TEXT)")
+        connection.execute(
+            "CREATE TABLE dense_index_manifest (manifest_key TEXT, manifest_value TEXT)"
+        )
+        connection.execute("INSERT INTO file_metadata VALUES ('03_Resources/note.md')")
+        connection.execute("INSERT INTO chunk_embeddings VALUES ('chunk-1')")
+        connection.execute("INSERT INTO dense_index_manifest VALUES ('chunk_count', '1')")
+        connection.commit()
+
+    monkeypatch.setattr(
+        benchmark,
+        "resolve_active_generation",
+        lambda vault: SimpleNamespace(
+            path=database,
+            generation_id="generation-1",
+            source_snapshot_hash="source-hash",
+            db_sha256="database-sha",
+            db_size=database.stat().st_size,
+        ),
+    )
+
+    result = benchmark._index_identity(tmp_path)
+
+    assert result["kind"] == "immutable_generation"
+    assert result["indexed_notes"] == 1
+    assert result["indexed_chunks"] == 1
+    assert result["dense_manifest"] == {"chunk_count": "1"}
+
+
+def test_receipt_errors_are_content_free(monkeypatch, tmp_path) -> None:
+    marker = "query-marker /private/vault"
+    args = argparse.Namespace(
+        vault=tmp_path,
+        fixture=None,
+        query_limit=1,
+        rounds=1,
+        cold_rounds=1,
+        max_results=1,
+        modes=["fts"],
+        probe_provider=False,
+        require_provider_binding=False,
+        require_immutable_generation=False,
+    )
+    monkeypatch.setattr(benchmark, "_load_queries", lambda fixture, limit: [marker])
+    monkeypatch.setattr(
+        benchmark,
+        "_index_identity",
+        lambda vault: {"kind": "legacy_db", "generation_id": None},
+    )
+    monkeypatch.setattr(
+        benchmark,
+        "_provider_receipt",
+        lambda vault, probe: {"probe_requested": False, "binding": "not_requested"},
+    )
+
+    def fail_local(*args, **kwargs):
+        raise RuntimeError(marker)
+
+    monkeypatch.setattr(benchmark, "_local_sample", fail_local)
+    monkeypatch.setattr(benchmark, "_subprocess_sample", fail_local)
+
+    async def fail_mcp(*args, **kwargs):
+        raise RuntimeError(marker)
+
+    monkeypatch.setattr(benchmark, "_mcp_samples", fail_mcp)
+
+    payload = asyncio.run(benchmark._run(args))
+
+    assert payload["errors"] == [
+        "fts/warm_process: RuntimeError",
+        "fts/cold_process: RuntimeError",
+        "fts/long_lived_mcp: RuntimeError",
+    ]
+    assert marker not in json.dumps(payload)


### PR DESCRIPTION
## Summary
- complete the content-free retrieval receipt with verified immutable-generation identity, sanitized provider binding, and resource metadata
- record peak RSS per warm/cold/MCP shape and optional device-wide NVIDIA start/end telemetry without contaminating latency timings
- add fail-closed `--require-provider-binding` and `--require-immutable-generation` gates plus benchmark documentation and regressions

## Validation
- `pytest -q`: 919 passed, 10 skipped; coverage 81.44%
- focused benchmark/timing tests: 6 passed
- Ruff check/format, mypy, doc-drift, release contract, compileall: green
- isolated receipt smoke: `power.retrieval-latency.v2`, `content_free=true`, immutable generation, actual `CPUExecutionProvider`, `errors=[]`

## Boundary
This prepares the roadmap evidence contract; it does not claim real-vault dense acceptance, ANN benefit, GPU query benefit, or reranker quality. Those remain environment/evidence-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retrieval benchmark receipts now include sanitized provider information, index-generation verification, and resource usage metrics.
  * Resource reporting includes process memory and optional NVIDIA GPU memory data.
  * Added documentation for real-vault retrieval benchmarking, privacy safeguards, validation requirements, and failure conditions.

* **Bug Fixes**
  * Improved handling of unavailable or invalid provider and index metadata without exposing sensitive details.

* **Tests**
  * Expanded coverage for resource reporting, GPU probe opt-out, and privacy-safe benchmark receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->