### PR TITLE
fix(sync): rebuild stale legacy indexes from source

### DIFF
--- a/src/power_framework/core/generation_index.py
+++ b/src/power_framework/core/generation_index.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import sqlite3
 import uuid
@@ -24,6 +25,8 @@ from .vault_storage import (
     vault_cache_dir,
     vault_db_path,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class IndexGenerationError(RuntimeError):
@@ -694,6 +697,12 @@ def _migrate_legacy_database(
         ):
             path.unlink(missing_ok=True)
         if isinstance(exc, IndexGenerationError):
+            if str(exc).startswith("source coverage mismatch:"):
+                logger.warning(
+                    "Legacy search database is stale for the current vault; "
+                    "rebuilding from source files"
+                )
+                return None
             raise
         raise IndexGenerationError(f"legacy generation {generation_id} failed: {exc}") from exc
 
@@ -794,6 +803,8 @@ def sync_vault_atomically(
             provider,
             model,
         )
+        if active_path is None and not os.getenv("POWER_SEARCH_DB"):
+            _archive_legacy_database(root, vault_db_path(root), generation_id)
     except Exception as exc:
         _record_failure(root, generation_id, str(exc))
         for path in (

--- a/tests/test_generation_index.py
+++ b/tests/test_generation_index.py
@@ -441,6 +441,38 @@ def test_legacy_search_database_is_imported_before_removal(
     assert search_vault(vault, "legacy-token", mode="fts")
 
 
+def test_stale_legacy_database_falls_back_to_source_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legacy snapshot missing current notes must not block recovery."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    vault = _vault(tmp_path, "stale-legacy", "legacy-token")
+    legacy_path = vault_db_path(vault)
+    with closing(sqlite3.connect(legacy_path)) as conn:
+        _init_db(conn)
+        _sync_vault_to_db(vault, conn, sync_embeddings=False)
+
+    added = vault / "01_Projects" / "Added.md"
+    added.write_text(
+        "---\n"
+        "type: Project\n"
+        "title: Added\n"
+        "description: added after the legacy snapshot\n"
+        "timestamp: 2026-07-27T00:00:00+00:00\n"
+        "---\n\nadded-token\n",
+        encoding="utf-8",
+    )
+
+    report = sync_vault_atomically(vault, sync_embeddings=False, allow_partial=False)
+
+    assert report.actual_files == 2
+    assert not legacy_path.exists()
+    archive = legacy_path.parent / "legacy" / f"search.db.{report.generation_id}.bak"
+    assert archive.is_file()
+    assert search_vault(vault, "legacy-token", mode="fts")
+    assert search_vault(vault, "added-token", mode="fts")
+
+
 def test_cleanup_failure_after_pointer_commit_keeps_new_generation_active(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Problem
A legacy search database can be valid but stale when notes were added or removed after it was created. `power sync --fts-only --strict` then aborts during legacy migration with a source coverage mismatch, leaving the vault at an incomplete index and preventing recovery.

## Change
- Treat only the explicit legacy source-coverage mismatch as a stale snapshot.
- Rebuild from current source files without publishing the stale database.
- Archive the legacy database only after the replacement generation is published.
- Keep corruption, integrity, dense-loss, and other generation failures fail-closed.
- Add regression coverage for preserving old and new notes and the archive receipt.

## Validation
- `pytest -q`: 922 passed, 10 skipped; coverage 81.59%
- `ruff check src tests scripts`
- `ruff format --check src tests scripts`
- `mypy src/power_framework`
- `python scripts/check_doc_drift.py`
- `python scripts/verify_release_contract.py`
- Real Brain readiness: `power sync --fts-only --strict` -> 714/714 indexed, 0 excluded; `power doctor --json` -> active immutable generation and 714/714 coverage.
