### PR TITLE
fix(ci): enforce strict Windows coverage smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           }
           $lintText
           uv run power markdown-check $vault
-          uv run power sync $vault --fts-only
+          uv run power sync $vault --fts-only --strict
           $searchResult = uv run power search $vault "Windows smoke" --mode fts
           $searchText = $searchResult -join [Environment]::NewLine
           if ($LASTEXITCODE -ne 0 -or $searchText -notmatch "First Note") {

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -33,7 +33,7 @@ def test_ci_has_windows_runtime_smoke_for_documented_lifecycle() -> None:
     assert "runs-on: windows-latest" in ci_text
     assert "uv sync --locked" in ci_text
     assert "uv run power index $vault --strict" in ci_text
-    assert "uv run power sync $vault --fts-only" in ci_text
+    assert "uv run power sync $vault --fts-only --strict" in ci_text
     assert 'uv run power search $vault "Windows smoke" --mode fts' in ci_text
 
 


### PR DESCRIPTION
## Problem
The Windows runtime smoke ran `power sync --fts-only` without `--strict`. A partial Windows index could therefore pass the cross-platform smoke even though the documented coverage invariant requires fail-closed behavior.

## Change
- Run the Windows FTS sync with `--strict`.
- Update the CI policy regression so this contract cannot silently regress.

## Validation
- `pytest -q`: 922 passed, 10 skipped; coverage 81.59%
- `pytest tests/test_ci_policy.py -q --no-cov`: 7 passed
- CI workflow YAML parse: OK
- Ruff check/format, mypy, doc-drift, release contract: green
