### PR TITLE
docs: add cross-platform support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ the role-specific guides before touching a vault:
   migration from any Markdown source methodology into a canonical POWER vault
 - **[Documentation inventory](docs/documentation-inventory.ua.md)** — audited
   entry points, linked documents, corrected drift, and evidence boundaries
+- **[Platform support matrix](docs/support-matrix.md)** — tested, conditional,
+  and unsupported boundaries for Linux, macOS, hosted Windows, and physical
+  Windows 11 25H2
 
 ## Quick Start (Linux/macOS)
 

--- a/README.ua.md
+++ b/README.ua.md
@@ -55,6 +55,9 @@ P.O.W.E.R. створений для роботи як людьми, так і A
   міграція з будь-якої Markdown source methodology у canonical POWER vault
 - **[Інвентаризація документації](docs/documentation-inventory.ua.md)** — перевірені
   точки входу, пов'язані документи, виправлений дрейф і межі доказів
+- **[Матриця підтримки платформ](docs/support-matrix.ua.md)** — межі tested,
+  conditional та unsupported для Linux, macOS, hosted Windows і фізичного
+  Windows 11 25H2
 
 ## Швидкий старт (Linux/macOS)
 

--- a/docs/documentation-inventory.ua.md
+++ b/docs/documentation-inventory.ua.md
@@ -23,6 +23,8 @@
 | `docs/mcp-server.md` | Виконуваний MCP-контракт | 20 інструментів |
 | `docs/mcp-client-onboarding.md` | Golden onboarding для чотирьох клієнтів | stdio shape + proposal gate |
 | `docs/mcp-client-onboarding.ua.md` | Український golden onboarding | Семантично паритетний |
+| `docs/support-matrix.md` | Англійська матриця підтримки платформ | Tested / conditional / unsupported boundaries |
+| `docs/support-matrix.ua.md` | Українська матриця підтримки платформ | Семантично паритетна |
 
 ## Пов'язані документи
 
@@ -59,7 +61,9 @@
 Markdown-перевірку, FTS sync/search і status. Фізичну перевірку Windows 11 25H2
 виконано для follow-up revision `4e5b2b9`; результати наведено у [звіті
 перевірки](tests/windows-11-25h2-validation.md). `windows-latest` CI smoke
-перевіряє загальний Windows runtime, але не замінює доказ цільового хоста.
+перевіряє загальний Windows runtime із strict FTS coverage, але не замінює доказ
+цільового хоста. Платформні межі та заборонені inference claims зведені у
+[матриці підтримки](support-matrix.ua.md).
 
 Автоматичний gate `scripts/check_doc_drift.py` перевіряє поточні кількості CLI/MCP,
 пошуковий контракт, заборонені застарілі шаблони та всі локальні Markdown-посилання

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,8 @@ and an MCP interface for AI agents.
 - [Міграція з наявної бази знань](migration-guide.ua.md)
 - [MCP client onboarding](mcp-client-onboarding.md)
 - [Підключення MCP-клієнтів](mcp-client-onboarding.ua.md)
+- [Platform support matrix](support-matrix.md)
+- [Матриця підтримки платформ](support-matrix.ua.md)
 - [Інвентаризація документації](documentation-inventory.ua.md)
 
 These guides pin the immutable `v3.4.0` release artifact, use an isolated virtual

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,36 @@
+# P.O.W.E.R. platform support matrix
+
+This matrix is the operational boundary for the current `v3.4.0` contract. It
+separates automated lifecycle coverage from model-backed, physical-host, GPU,
+and retrieval-quality evidence. A green CI job does not certify a different
+host, provider, corpus, or performance envelope.
+
+## Current support boundary
+
+| Platform / environment | Tested now | Conditional | Not certified by this matrix |
+| --- | --- | --- | --- |
+| Linux, Python 3.11–3.14 | Ubuntu CI runs the full test suite, Ruff, MyPy, documentation and release-contract gates; package smoke runs wheel/sdist outside the checkout. | Dense, reranked, and provider-backed workflows require a local model cache and an actually bound provider. | Real-vault dense latency, GPU benefit, ANN recall, and reranker quality. |
+| macOS, Python 3.13 | `macos-latest` smoke covers import, init, ingest, strict index, lint, markdown-check, strict FTS sync, and FTS search with offline model settings. | Model-backed dense search requires a locally available model and a verified runtime provider. | Physical Mac hardware performance, GPU acceleration, dense real-vault evidence, and reranker quality. |
+| Hosted Windows CI, Python 3.13 | `windows-latest` smoke covers import, init, ingest, strict index, lint, markdown-check, strict FTS sync, FTS search, and CPU provider selection. | The Windows 11 guide must be followed for a physical installation; provider choice is accepted only after session readback. | Physical Windows 11 25H2 GPU performance, CUDA DLL availability on a user's machine, dense real-vault evidence, and quality claims. |
+| Physical Windows 11 25H2 | The dedicated [Windows installation guide](windows-11-installation.md) and its validation receipts define the supported installation procedure and host-specific checks. | Exact Python, release artifact, OS build, model cache, ONNX provider, and hardware must be recorded in the receipt. | Hosted CI is not a physical Windows 11 certification; no GPU or latency claim is inferred without a fresh host receipt. |
+
+## Evidence rules for agents
+
+- Treat `tested` as lifecycle coverage only. It proves the named command path on
+  the named runner and Python version.
+- Treat `conditional` as a precondition, not as a successful runtime claim.
+  Check `power doctor --json` and require active provider readback before dense
+  work.
+- Treat `unsupported` or missing evidence as a stop condition. Do not silently
+  fall back from an explicitly requested GPU provider to CPU.
+- For a real vault, require an immutable generation, complete coverage, a
+  content-free retrieval receipt, cold/warm/process/MCP controls, and resource
+  attribution before making latency or ranking claims.
+
+## Source of truth
+
+The executable checks live in [CI](../.github/workflows/ci.yml), the release
+workflow is [release.yml](../.github/workflows/release.yml), and the physical
+Windows procedure is [windows-11-installation.md](windows-11-installation.md).
+The roadmap records evidence boundaries and pending gates in
+[`ROADMAP_POWER.md`](https://github.com/weby-homelab/knowledge-base/blob/main/01_Projects/ROADMAP_POWER.md).

--- a/docs/support-matrix.ua.md
+++ b/docs/support-matrix.ua.md
@@ -1,0 +1,35 @@
+# Матриця підтримки платформ P.O.W.E.R.
+
+Ця матриця визначає операційні межі поточного контракту `v3.4.0`. Вона
+відділяє автоматизоване покриття життєвого циклу від доказів для model-backed
+режимів, фізичних хостів, GPU та якості пошуку. Зелений CI не сертифікує інший
+хост, провайдер, корпус або envelope продуктивності.
+
+## Поточна межа підтримки
+
+| Платформа / середовище | Перевірено зараз | Умовно підтримується | Ця матриця не сертифікує |
+| --- | --- | --- | --- |
+| Linux, Python 3.11–3.14 | Ubuntu CI запускає повний suite, Ruff, MyPy, documentation і release-contract gates; package smoke перевіряє wheel/sdist поза checkout. | Dense, reranked і provider-backed workflows потребують локального model cache та реально прив'язаного provider. | Latency на real vault, GPU benefit, ANN recall і якість reranker. |
+| macOS, Python 3.13 | `macos-latest` smoke перевіряє import, init, ingest, strict index, lint, markdown-check, strict FTS sync і FTS search з offline model settings. | Model-backed dense search потребує локально доступної моделі та verified runtime provider. | Продуктивність фізичного Mac, GPU acceleration, dense real-vault evidence і якість reranker. |
+| Hosted Windows CI, Python 3.13 | `windows-latest` smoke перевіряє import, init, ingest, strict index, lint, markdown-check, strict FTS sync, FTS search і CPU provider selection. | Для фізичної установки потрібен [Windows-гід](windows-11-installation.ua.md); вибір provider приймається лише після session readback. | GPU performance фізичного Windows 11 25H2, CUDA DLL на машині користувача, dense real-vault evidence і quality claims. |
+| Фізичний Windows 11 25H2 | Окремий [гід встановлення Windows](windows-11-installation.ua.md) і його validation receipts визначають процедуру установки та host-specific checks. | У receipt мають бути exact Python, release artifact, OS build, model cache, ONNX provider і hardware. | Hosted CI не є сертифікацією фізичного Windows 11; GPU або latency claim не виводиться без свіжого host receipt. |
+
+## Правила доказів для агентів
+
+- `tested` означає лише lifecycle coverage. Це доказ названого command path на
+  названому runner і версії Python.
+- `conditional` означає precondition, а не успішний runtime claim. Перед dense
+  роботою перевіряйте `power doctor --json` і вимагайте active provider readback.
+- `unsupported` або відсутній evidence — stop condition. Не робіть мовчазний
+  fallback з явно запитаного GPU provider на CPU.
+- Для real vault потрібні immutable generation, повне coverage, content-free
+  retrieval receipt, cold/warm/process/MCP controls і resource attribution,
+  перш ніж робити latency або ranking claims.
+
+## Джерело правди
+
+Виконувані перевірки живуть у [CI](../.github/workflows/ci.yml), release
+workflow — у [release.yml](../.github/workflows/release.yml), а фізична
+процедура Windows — у [windows-11-installation.ua.md](windows-11-installation.ua.md).
+Roadmap фіксує межі доказів і pending gates у
+[`ROADMAP_POWER.md`](https://github.com/weby-homelab/knowledge-base/blob/main/01_Projects/ROADMAP_POWER.md).

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -60,6 +60,8 @@ MIGRATION_UA = REPO_ROOT / "docs" / "migration-guide.ua.md"
 HIERARCHICAL = REPO_ROOT / "docs" / "hierarchical-index-migration.md"
 HIERARCHICAL_UA = REPO_ROOT / "docs" / "hierarchical-index-migration.ua.md"
 INVENTORY_UA = REPO_ROOT / "docs" / "documentation-inventory.ua.md"
+SUPPORT_MATRIX = REPO_ROOT / "docs" / "support-matrix.md"
+SUPPORT_MATRIX_UA = REPO_ROOT / "docs" / "support-matrix.ua.md"
 MCP_CLIENT_ONBOARDING = REPO_ROOT / "docs" / "mcp-client-onboarding.md"
 MCP_CLIENT_ONBOARDING_UA = REPO_ROOT / "docs" / "mcp-client-onboarding.ua.md"
 AGENT_INSTRUCTIONS = REPO_ROOT / ".agents" / "AGENTS.md"
@@ -86,6 +88,8 @@ CURRENT_DOCUMENTS = {
     "Hierarchical report": HIERARCHICAL,
     "Hierarchical report UA": HIERARCHICAL_UA,
     "Documentation inventory UA": INVENTORY_UA,
+    "Support matrix": SUPPORT_MATRIX,
+    "Support matrix UA": SUPPORT_MATRIX_UA,
     "Client onboarding": MCP_CLIENT_ONBOARDING,
     "Client onboarding UA": MCP_CLIENT_ONBOARDING_UA,
     "Agent instructions": AGENT_INSTRUCTIONS,


### PR DESCRIPTION
## Summary

- add English and Ukrainian platform support matrices for the v3.4.0 contract;
- link the matrices from both READMEs, the documentation index, and the audited documentation inventory;
- make the documentation drift gate track both new documents and preserve explicit tested/conditional/unsupported boundaries.

The matrix makes lifecycle CI, model-backed runtime checks, physical-host evidence, and retrieval-quality claims distinct so agents do not infer support from an unrelated green job.

## Validation

- `pytest -q` — 922 passed, 10 skipped; coverage 81.59%
- `pytest --no-cov -q tests/test_doc_drift.py tests/test_ci_policy.py tests/test_release_contract.py tests/test_mcp_client_onboarding.py` — 43 passed
- `ruff check src tests scripts`
- `ruff format --check src tests scripts`
- `mypy src/power_framework`
- `python scripts/check_doc_drift.py`
- `python scripts/verify_release_contract.py`
- separate `power markdown-check` for all six changed Markdown files

Signed commit: `643cf9b`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added English and Ukrainian platform support matrices for the P.O.W.E.R. v3.4.0 contract.
  * Documented tested, conditional, and unsupported environments across Linux, macOS, hosted Windows CI, and physical Windows 11.
  * Clarified hardware, provider, performance, and evidence requirements.
  * Added links to the new documentation from the README files and documentation index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->