### PR TITLE
fix(docs): update relative path to CHANGELOG.md in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ are explicitly preserved as v1.6 historical snapshots.
 - [Windows 11 25H2 validation receipt](tests/windows-11-25h2-v3.3.2-validation-fixed.md)
 - [M2 human-evaluation contract](m2-human-evaluation.md)
 - [Real-vault retrieval receipt](benchmarks/real-vault-retrieval.md)
-- [Changelog](CHANGELOG.md)
+- [Changelog](../CHANGELOG.md)
 - [Contributing](contributing.md)
 
 GPLv3 — Built in Ukraine ⚡


### PR DESCRIPTION
Fixes doc-drift CI gate error where docs/index.md had a broken relative link to CHANGELOG.md.