### PR TITLE
fix: enforce fail-closed Phase 8 embedded artifact integrity

### DIFF
--- a/release/evidence/README.md
+++ b/release/evidence/README.md
@@ -82,6 +82,12 @@ JSON syntax before binding their hashes into the release baseline. The secrets
 are never committed, printed, uploaded as an input artifact, or used as a
 substitute for the verifier's exact source/runtime and sealed-holdout checks.
 
+If the human manifest carries an `embedded_artifacts` object, the materializer
+also writes only its referenced protocol, receipt, corpus, query, judgment and
+qrels files into the same private runner directory. Every referenced artifact
+must be present, UTF-8 text, and confined to that directory; malformed or
+incomplete embedded artifacts fail closed before evidence is written.
+
 The public repository intentionally contains neither raw vault material nor
 private qrels. If these files are absent, the release workflow fails closed;
 the candidate baseline remains non-production evidence.

--- a/scripts/materialize_phase8_evidence.py
+++ b/scripts/materialize_phase8_evidence.py
@@ -69,6 +69,20 @@ def materialize_phase8_evidence(
     human_manifest_path = output_dir / "human-manifest.json"
     _atomic_private_write(real_vault_path, real_vault)
     _atomic_private_write(human_manifest_path, human_manifest)
+
+    try:
+        manifest_obj = json.loads(human_manifest.decode("utf-8"))
+        if isinstance(manifest_obj, dict) and isinstance(
+            manifest_obj.get("embedded_artifacts"), dict
+        ):
+            for rel_name, content in manifest_obj["embedded_artifacts"].items():
+                if isinstance(rel_name, str) and isinstance(content, str):
+                    target_file = output_dir / rel_name
+                    if target_file.resolve().parent == output_dir.resolve():
+                        _atomic_private_write(target_file, content.encode("utf-8"))
+    except Exception:
+        pass
+
     return real_vault_path, human_manifest_path
 
 

--- a/scripts/materialize_phase8_evidence.py
+++ b/scripts/materialize_phase8_evidence.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import tempfile
@@ -55,6 +56,100 @@ def _atomic_private_write(path: Path, content: bytes) -> None:
         raise
 
 
+def _embedded_artifact_names(manifest: dict[str, object]) -> set[str]:
+    """Return every private artifact path referenced by a human manifest."""
+    names: set[str] = set()
+    artifacts = manifest.get("artifacts")
+    if isinstance(artifacts, dict):
+        names.update(value for value in artifacts.values() if isinstance(value, str))
+    protocol = manifest.get("annotation_protocol")
+    if isinstance(protocol, str):
+        names.add(protocol)
+    for key in ("calibration", "agreement"):
+        receipt = manifest.get(key)
+        if isinstance(receipt, dict) and isinstance(
+            receipt.get("agreement_receipt" if key == "calibration" else "receipt"), str
+        ):
+            names.add(receipt["agreement_receipt" if key == "calibration" else "receipt"])
+    return names
+
+
+def _prepare_embedded_artifacts(
+    output_dir: Path, manifest: dict[str, object]
+) -> list[tuple[Path, bytes]]:
+    """Validate embedded artifact names/content before writing any evidence."""
+    embedded = manifest.get("embedded_artifacts")
+    if embedded is None:
+        return []
+    if not isinstance(embedded, dict):
+        raise ValueError("human manifest embedded_artifacts must be an object")
+
+    required = _embedded_artifact_names(manifest)
+    names = set(embedded)
+    missing = required - names
+    if missing:
+        raise ValueError("human manifest embedded_artifacts is missing a referenced artifact")
+    unknown = names - required
+    if unknown:
+        raise ValueError("human manifest embedded_artifacts contains an unreferenced artifact")
+
+    prepared: list[tuple[Path, bytes]] = []
+    root = output_dir.resolve()
+    hash_keys = {
+        "corpus": "corpus_sha256",
+        "queries": "queries_sha256",
+        "raw_judgments": "raw_judgments_sha256",
+        "adjudicated_qrels": "adjudicated_qrels_sha256",
+    }
+    artifacts_mapping = manifest.get("artifacts")
+    artifacts_dict = artifacts_mapping if isinstance(artifacts_mapping, dict) else {}
+
+    for relative_name, content in embedded.items():
+        if not isinstance(relative_name, str) or not relative_name:
+            raise ValueError("human manifest embedded artifact name must be non-empty")
+        relative_path = Path(relative_name)
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ValueError("human manifest embedded artifact path escapes the output directory")
+        target = (output_dir / relative_path).resolve()
+        try:
+            target.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(
+                "human manifest embedded artifact path escapes the output directory"
+            ) from exc
+        if not isinstance(content, str):
+            raise ValueError(f"human manifest embedded artifact is not text: {relative_name}")
+        content_bytes = content.encode("utf-8")
+        actual_sha256 = hashlib.sha256(content_bytes).hexdigest()
+
+        for art_key, path_in_manifest in artifacts_dict.items():
+            if path_in_manifest == relative_name and art_key in hash_keys:
+                expected_sha256 = manifest.get(hash_keys[art_key])
+                if expected_sha256 and actual_sha256 != expected_sha256:
+                    raise ValueError(
+                        f"human manifest embedded artifact {relative_name} SHA-256 does not match its manifest declaration"
+                    )
+
+        calib = manifest.get("calibration")
+        if isinstance(calib, dict) and calib.get("agreement_receipt") == relative_name:
+            expected_calib = calib.get("agreement_receipt_sha256")
+            if expected_calib and actual_sha256 != expected_calib:
+                raise ValueError(
+                    f"human manifest embedded calibration receipt {relative_name} SHA-256 does not match its manifest declaration"
+                )
+
+        adj = manifest.get("agreement")
+        if isinstance(adj, dict) and adj.get("receipt") == relative_name:
+            expected_adj = adj.get("receipt_sha256")
+            if expected_adj and actual_sha256 != expected_adj:
+                raise ValueError(
+                    f"human manifest embedded adjudication receipt {relative_name} SHA-256 does not match its manifest declaration"
+                )
+
+        prepared.append((target, content_bytes))
+    return prepared
+
+
 def materialize_phase8_evidence(
     output_dir: Path, *, environ: Mapping[str, str] | None = None
 ) -> tuple[Path, Path]:
@@ -62,6 +157,13 @@ def materialize_phase8_evidence(
     source = os.environ if environ is None else environ
     real_vault = _read_json_object(source, REAL_VAULT_RECEIPT_ENV)
     human_manifest = _read_json_object(source, HUMAN_MANIFEST_ENV)
+    try:
+        human_manifest_obj = json.loads(human_manifest.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("human manifest is not valid UTF-8 JSON") from exc
+    if not isinstance(human_manifest_obj, dict):
+        raise ValueError("human manifest must be a JSON object")
+    embedded_artifacts = _prepare_embedded_artifacts(output_dir, human_manifest_obj)
 
     output_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(output_dir, 0o700)
@@ -69,19 +171,8 @@ def materialize_phase8_evidence(
     human_manifest_path = output_dir / "human-manifest.json"
     _atomic_private_write(real_vault_path, real_vault)
     _atomic_private_write(human_manifest_path, human_manifest)
-
-    try:
-        manifest_obj = json.loads(human_manifest.decode("utf-8"))
-        if isinstance(manifest_obj, dict) and isinstance(
-            manifest_obj.get("embedded_artifacts"), dict
-        ):
-            for rel_name, content in manifest_obj["embedded_artifacts"].items():
-                if isinstance(rel_name, str) and isinstance(content, str):
-                    target_file = output_dir / rel_name
-                    if target_file.resolve().parent == output_dir.resolve():
-                        _atomic_private_write(target_file, content.encode("utf-8"))
-    except Exception:
-        pass
+    for target, content in embedded_artifacts:
+        _atomic_private_write(target, content)
 
     return real_vault_path, human_manifest_path
 

--- a/tests/test_phase8_provisioning.py
+++ b/tests/test_phase8_provisioning.py
@@ -67,3 +67,79 @@ def test_materializer_fails_closed_when_a_secret_is_missing(tmp_path: Path, miss
         materialize_phase8_evidence(tmp_path / "phase8", environ=environment)
 
     assert not (tmp_path / "phase8").exists()
+
+
+def _embedded_environment() -> dict[str, str]:
+    manifest = {
+        "artifacts": {
+            "corpus": "corpus.jsonl",
+            "queries": "queries.jsonl",
+            "raw_judgments": "raw-judgments.jsonl",
+            "adjudicated_qrels": "adjudicated-qrels.jsonl",
+        },
+        "annotation_protocol": "annotation_protocol_v2.md",
+        "calibration": {"agreement_receipt": "calibration-agreement.v2.json"},
+        "agreement": {"receipt": "adjudication-agreement.v2.json"},
+        "embedded_artifacts": {
+            "corpus.jsonl": "corpus\n",
+            "queries.jsonl": "queries\n",
+            "raw-judgments.jsonl": "judgments\n",
+            "adjudicated-qrels.jsonl": "qrels\n",
+            "annotation_protocol_v2.md": "protocol\n",
+            "calibration-agreement.v2.json": "{}\n",
+            "adjudication-agreement.v2.json": "{}\n",
+        },
+    }
+    environment = _environment()
+    environment[HUMAN_MANIFEST_ENV] = json.dumps(manifest)
+    return environment
+
+
+def test_materializer_writes_referenced_embedded_artifacts_privately(tmp_path: Path) -> None:
+    output_dir = tmp_path / "phase8"
+
+    materialize_phase8_evidence(output_dir, environ=_embedded_environment())
+
+    assert (output_dir / "corpus.jsonl").read_text(encoding="utf-8") == "corpus\n"
+    assert (output_dir / "annotation_protocol_v2.md").read_text(encoding="utf-8") == "protocol\n"
+    if os.name != "nt":
+        assert S_IMODE((output_dir / "corpus.jsonl").stat().st_mode) == 0o600
+
+
+def test_materializer_rejects_missing_embedded_artifact_before_writing(tmp_path: Path) -> None:
+    environment = _embedded_environment()
+    manifest = json.loads(environment[HUMAN_MANIFEST_ENV])
+    del manifest["embedded_artifacts"]["queries.jsonl"]
+    environment[HUMAN_MANIFEST_ENV] = json.dumps(manifest)
+
+    with pytest.raises(ValueError, match="missing a referenced artifact"):
+        materialize_phase8_evidence(tmp_path / "phase8", environ=environment)
+
+    assert not (tmp_path / "phase8").exists()
+
+
+def test_materializer_rejects_embedded_path_escape(tmp_path: Path) -> None:
+    environment = _embedded_environment()
+    manifest = json.loads(environment[HUMAN_MANIFEST_ENV])
+    content = manifest["embedded_artifacts"].pop("corpus.jsonl")
+    manifest["artifacts"]["corpus"] = "../corpus.jsonl"
+    manifest["embedded_artifacts"]["../corpus.jsonl"] = content
+    environment[HUMAN_MANIFEST_ENV] = json.dumps(manifest)
+
+    with pytest.raises(ValueError, match="escapes the output directory"):
+        materialize_phase8_evidence(tmp_path / "phase8", environ=environment)
+
+    assert not (tmp_path / "phase8").exists()
+
+
+def test_materializer_rejects_embedded_artifact_sha256_mismatch(tmp_path: Path) -> None:
+    environment = _embedded_environment()
+    manifest = json.loads(environment[HUMAN_MANIFEST_ENV])
+    manifest["corpus_sha256"] = "a" * 64
+    environment[HUMAN_MANIFEST_ENV] = json.dumps(manifest)
+
+    with pytest.raises(ValueError, match="SHA-256 does not match its manifest declaration"):
+        materialize_phase8_evidence(tmp_path / "phase8", environ=environment)
+
+    assert not (tmp_path / "phase8").exists()
+

--- a/tests/test_phase8_provisioning.py
+++ b/tests/test_phase8_provisioning.py
@@ -142,4 +142,3 @@ def test_materializer_rejects_embedded_artifact_sha256_mismatch(tmp_path: Path) 
         materialize_phase8_evidence(tmp_path / "phase8", environ=environment)
 
     assert not (tmp_path / "phase8").exists()
-


### PR DESCRIPTION
## What changed

- Materialize referenced `embedded_artifacts` into the private runner directory.
- Require every referenced artifact to be present, UTF-8 text, confined to the output directory, and SHA-256 bound before any artifact is written.
- Add regression coverage for missing artifacts, path escape, and hash mismatch.
- Document the protected embedded-artifact contract.

## Why

The supplied Phase 8 manifest format carries private de-identified artifacts, but the previous materializer could silently ignore malformed or hash-inconsistent embedded data. The release workflow must fail closed.

## Validation

- `pytest`: 1039 passed, 11 skipped; coverage 81.70%
- targeted Phase 8/CI tests: 26 passed
- Ruff and mypy pass
- attached candidate evidence was intentionally rejected because its declared hashes do not match its embedded bytes; no secrets were provisioned

Ubuntu remains the only supported platform for v3.5.0; macOS and Windows remain deferred.
