### PR TITLE
fix(ci): cover standard json.dumps hash in Phase 8 manifest verification

### DIFF
--- a/scripts/verify_phase8_evidence.py
+++ b/scripts/verify_phase8_evidence.py
@@ -75,7 +75,8 @@ def _candidate_manifest_hashes(path: Path, manifest_obj: dict[str, Any] | None =
             for sort in (False, True):
                 for trailing in (b"\n", b""):
                     if indent is None:
-                        encoded = (
+                        # Compact encoding with no spaces (separators=(",", ":"))
+                        encoded_compact = (
                             json.dumps(
                                 manifest_obj,
                                 ensure_ascii=False,
@@ -84,6 +85,17 @@ def _candidate_manifest_hashes(path: Path, manifest_obj: dict[str, Any] | None =
                             ).encode("utf-8")
                             + trailing
                         )
+                        hashes.add(hashlib.sha256(encoded_compact).hexdigest())
+                        # Standard Python encoding with spaces (default separators ", " and ": ")
+                        encoded_standard = (
+                            json.dumps(
+                                manifest_obj,
+                                ensure_ascii=False,
+                                sort_keys=sort,
+                            ).encode("utf-8")
+                            + trailing
+                        )
+                        hashes.add(hashlib.sha256(encoded_standard).hexdigest())
                     else:
                         encoded = (
                             json.dumps(
@@ -91,7 +103,7 @@ def _candidate_manifest_hashes(path: Path, manifest_obj: dict[str, Any] | None =
                             ).encode("utf-8")
                             + trailing
                         )
-                    hashes.add(hashlib.sha256(encoded).hexdigest())
+                        hashes.add(hashlib.sha256(encoded).hexdigest())
     return hashes
 
 

--- a/tests/test_phase8_evidence.py
+++ b/tests/test_phase8_evidence.py
@@ -270,3 +270,22 @@ def test_phase8_validation_accepts_formatted_human_manifest_hash(tmp_path: Path)
 
     candidates = phase8._candidate_manifest_hashes(human, manifest_obj)
     assert pretty_hash in candidates
+
+
+def test_phase8_validation_accepts_standard_python_dumps_hash(tmp_path: Path) -> None:
+    """Standard json.dumps (with spaces after : and ,) must also be a candidate hash."""
+    human = tmp_path / "human.json"
+    _write_human_manifest(human, status="adjudicated")
+    manifest_obj = json.loads(human.read_text(encoding="utf-8"))
+    # Standard json.dumps produces {"key": "val"} with spaces — not covered by compact separators
+    for trailing in (b"\n", b""):
+        for sort in (False, True):
+            std_bytes = (
+                json.dumps(manifest_obj, ensure_ascii=False, sort_keys=sort).encode("utf-8")
+                + trailing
+            )
+            std_hash = hashlib.sha256(std_bytes).hexdigest()
+            candidates = phase8._candidate_manifest_hashes(human, manifest_obj)
+            assert std_hash in candidates, (
+                f"Standard json.dumps hash missing (sort={sort}, trailing={bool(trailing)})"
+            )


### PR DESCRIPTION
## Причина

Крок **Generate and verify tag-bound release baseline** у release workflow (run [#31595007172](https://github.com/weby-homelab/power-framework/actions/runs/31595007172)) провалився з:

```
Phase 8 evidence validation failed: real-vault receipt human manifest hash does not match the manifest
```

## Корінна причина

`_candidate_manifest_hashes()` у `scripts/verify_phase8_evidence.py` генерує набір хешів для різних форматів JSON маніфесту. Попередній fix (#314) додав:
- Compact encoding: `separators=(',',':')` — без пробілів
- Indented: `indent=2`, `indent=4`

**Відсутній формат**: стандартний Python `json.dumps(obj)` без explicit `separators` — виробляє `{"key": "val"}` з пробілами після `:` та `,`. Це найпоширеніший спосіб генерації JSON і найймовірніший формат при ручному провізіонуванні секрету `POWER35_REAL_VAULT_RECEIPT_JSON.human_evidence.manifest_sha256`.

## Зміни

- `scripts/verify_phase8_evidence.py`: додано стандартний `json.dumps` (з пробілами) до набору кандидатів — з та без trailing newline, `sort_keys=True/False`
- `tests/test_phase8_evidence.py`: додано регресійний тест `test_phase8_validation_accepts_standard_python_dumps_hash`

## Перевірка

- Targeted release tests: **48 passed**
- Full suite (без clean-worktree test): **716 passed, 9 skipped**
- ruff check + format: ✅
- GPG signed commit: ✅

Fixes #316