### PR TITLE
fix(release): provision signing key in GitHub runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,6 +274,21 @@ jobs:
           format: spdx-json
           output-file: dist/power-framework.spdx.json
 
+      - name: Install the pinned maintainer release signing key
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          key_file="$RUNNER_TEMP/power-release-signing-key.asc"
+          gh api users/weby-homelab/gpg_keys \
+            --jq '.[] | select(.key_id == "2D49E810C7F2527E") | .raw_key' \
+            > "$key_file"
+          test -s "$key_file"
+          gpg --batch --with-colons --show-keys "$key_file" \
+            | awk -F: '$1 == "fpr" {print $10; exit}' \
+            | grep -Fxq '7AF1EDA195FE29FF093FB1CA2D49E810C7F2527E'
+          gpg --batch --import "$key_file"
+
       - name: Generate and verify tag-bound release baseline
         run: |
           phase8_dir="$RUNNER_TEMP/power35-phase8"

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -97,6 +97,11 @@ def test_release_publish_is_blocked_by_a_tag_validation_job() -> None:
     assert "needs: validate" in release_text
     assert "needs: [validate, upgrade-matrix-aggregate]" in release_text
     assert "--require-signed-tag" in release_text
+    assert "Install the pinned maintainer release signing key" in release_text
+    assert "gh api users/weby-homelab/gpg_keys" in release_text
+    assert 'select(.key_id == "2D49E810C7F2527E")' in release_text
+    assert "7AF1EDA195FE29FF093FB1CA2D49E810C7F2527E" in release_text
+    assert 'gpg --batch --import "$key_file"' in release_text
 
 
 def test_release_materializes_phase8_evidence_through_protected_environment() -> None:


### PR DESCRIPTION
## Summary

- provision the pinned maintainer GPG public key in the release runner before final tag verification
- verify the primary fingerprint before importing the key
- add CI policy coverage for the signed-tag key bootstrap

## Root cause

The protected Phase 8 evidence and final release baseline passed, but the
GitHub runner had no public key for signing subkey `DD92FC45BD1D6C30`, so
`git verify-tag --raw` failed with `NO_PUBKEY`. The workflow now retrieves the
public key from GitHub's verified GPG-key endpoint and fail-closes on the
expected primary fingerprint.

## Validation

- `./.venv/bin/pytest tests/test_ci_policy.py tests/test_release_contract.py -q --no-cov --override-ini=addopts=`
- Ruff check and format check
- signed commit verified with GPG key `2D49E810C7F2527E`
