### PR TITLE
fix(mcp): align launcher metadata with v3.5.0

### DIFF
--- a/.agents/mcp_servers/power_server.py
+++ b/.agents/mcp_servers/power_server.py
@@ -3,8 +3,8 @@
 P.O.W.E.R. MCP Server entry-point for OpenCode/Antigravity CLI.
 This script launches the FastMCP 3.x server from power_framework.mcp.
 
-Version: 3.4.0
-Updated: 2026-08-05
+Version: 3.5.0
+Updated: 2026-08-12
 """
 
 import os


### PR DESCRIPTION
## Summary
- update the repository MCP launcher metadata from 3.4.0 to 3.5.0
- keep the launcher documentation aligned with the published POWER runtime

## Validation
- `python -m py_compile .agents/mcp_servers/power_server.py`
- MCP stdio/onboarding smoke tests: 5 passed
- active POWER runtimes and MCP imports verified at v3.5.0
