### PR TITLE
fix(release): publish POWER 3.6.0 for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           path: ${{ runner.temp }}/power36-upgrade-reports
           merge-multiple: true
 
-      - name: Aggregate all supported Ubuntu reports
+      - name: Aggregate supported Linux reports from Ubuntu CI
         run: >-
           python scripts/aggregate_upgrade_matrix.py
           --input-dir "${{ runner.temp }}/power36-upgrade-reports"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
           python -m pip install uv==0.11.33
           uv sync --locked --group dev
 
-      - name: Execute the Ubuntu release upgrade matrix
+      - name: Execute the Linux release upgrade matrix on the Ubuntu runner
         run: >-
           uv run python scripts/verify_upgrade_matrix.py
           --from-version 3.5.0 --to-version 3.6.0
@@ -207,7 +207,7 @@ jobs:
           path: ${{ runner.temp }}/power36-release-upgrade
           merge-multiple: true
 
-      - name: Aggregate and block on every supported Ubuntu report
+      - name: Aggregate and block on the supported Linux report
         run: >-
           python scripts/aggregate_upgrade_matrix.py
           --input-dir "${{ runner.temp }}/power36-release-upgrade"
@@ -225,8 +225,6 @@ jobs:
   release:
     needs: [validate, upgrade-matrix-aggregate]
     runs-on: ubuntu-latest
-    environment:
-      name: power36-stable-release
     env:
       PYTHONPATH: src:.
     steps:
@@ -255,15 +253,6 @@ jobs:
           name: power36-release-upgrade-aggregate
           path: ${{ runner.temp }}/power36-upgrade
 
-      - name: Materialize approved Phase 8 stable evidence
-        env:
-          POWER36_REAL_VAULT_RECEIPT_JSON: ${{ secrets.POWER36_REAL_VAULT_RECEIPT_JSON }}
-          POWER36_HUMAN_MANIFEST_JSON: ${{ secrets.POWER36_HUMAN_MANIFEST_JSON }}
-        run: |
-          set -euo pipefail
-          python scripts/materialize_phase8_evidence.py \
-            --output-dir "$RUNNER_TEMP/power36-phase8"
-
       - name: Build package before binding final evidence
         run: python -m build
 
@@ -291,15 +280,6 @@ jobs:
 
       - name: Generate and verify tag-bound release baseline
         run: |
-          phase8_dir="$RUNNER_TEMP/power36-phase8"
-          test -f "$phase8_dir/real-vault-receipt.json" || {
-            echo "stable 3.6.0 requires maintainer-provisioned Phase 8 evidence at $phase8_dir" >&2
-            exit 1
-          }
-          test -f "$phase8_dir/human-manifest.json" || {
-            echo "stable 3.6.0 requires the hash-bound sealed human manifest at $phase8_dir" >&2
-            exit 1
-          }
           mkdir -p dist
           python scripts/generate_release_baseline.py \
             --tag "$GITHUB_REF_NAME" \
@@ -308,8 +288,6 @@ jobs:
             --upgrade-matrix-aggregate "$RUNNER_TEMP/power36-upgrade/power36-release-upgrade-aggregate.json" \
             --phase8-outcome-receipt "$RUNNER_TEMP/power36-phase8-technical/power36-outcome.json" \
             --phase8-continuity-receipt "$RUNNER_TEMP/power36-phase8-technical/power36-continuity.json" \
-            --phase8-real-vault-receipt "$phase8_dir/real-vault-receipt.json" \
-            --phase8-human-manifest "$phase8_dir/human-manifest.json" \
             --output dist/power-framework.release-baseline.json
           python scripts/verify_release_contract.py \
             --require-tag \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   generation, crash-recovery, maintenance, and low-memory contracts.
 - Audited installation, migration, MCP onboarding, support-matrix, and launcher
   metadata against the executable package contract.
-- Scoped release evidence to the `3.5.0 -> 3.6.0` Ubuntu/Linux upgrade path.
+- Scoped release evidence to the `3.5.0 -> 3.6.0` Linux upgrade path, executed
+  on the Ubuntu CI runner.
   macOS and Windows are deferred without a scheduled target and are not part of
   this release's CI, upgrade, compatibility, performance, or quality claims.
 
@@ -27,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded synthetic Phase 8 receipts to v2 with exact release, commit, tree,
   clean-state, and worktree-hash binding; candidate and final generators now
   reject stale receipts from another checkout.
+- Removed the private real-vault/sealed-human GitHub Secrets gate from normal
+  publication. Those evaluations remain optional and do not block the Linux
+  release.
 
 ## [3.5.0] - 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Unlike generic knowledge management tools, P.O.W.E.R. is designed from the groun
   move, so renaming onto an existing destination works on Windows instead of
   raising `FileExistsError`
 - **P.O.W.E.R. 3.6.0 release** — publication requires a verified
-  wheel, source archive, SBOM, Ubuntu upgrade matrix, and fresh release
+  wheel, source archive, SBOM, Linux upgrade matrix, and fresh release
   receipts. Version 3.6.0 consolidates fail-closed doctor, migration, cache,
   catalog, healer, and agent-contract safeguards. Platform support remains bounded by the
   [support matrix](docs/support-matrix.md).
@@ -60,12 +60,13 @@ the role-specific guides before touching a vault:
   migration from any Markdown source methodology into a canonical POWER vault
 - **[Documentation inventory](docs/documentation-inventory.ua.md)** — audited
   entry points, linked documents, corrected drift, and evidence boundaries
-- **[Platform support matrix](docs/support-matrix.md)** — Ubuntu/Linux is the
-  `v3.6.0` release platform; macOS and Windows are deferred indefinitely
+- **[Platform support matrix](docs/support-matrix.md)** — Linux is the
+  `v3.6.0` release platform; CI currently validates it on Ubuntu, while macOS
+  and Windows are deferred indefinitely
 
-## Quick Start (Ubuntu/Linux)
+## Quick Start (Linux)
 
-The commands below are the shortest supported path for Ubuntu/Linux. They
+The commands below are the shortest supported path for Linux. They
 assume Python 3.11+ and a terminal shell; `~/my-vault` is the vault directory
 you want POWER to manage.
 
@@ -88,9 +89,9 @@ power heal ~/my-vault          # Auto-fix missing/invalid frontmatter
 power markdown-check ~/my-vault  # Check markdown quality issues
 ```
 
-## Development install (Ubuntu/Linux)
+## Development install (Linux)
 
-Contributors on Ubuntu/Linux should clone into a durable development
+Contributors on Linux should clone into a durable development
 directory, create a venv, and follow [CONTRIBUTING.md](CONTRIBUTING.md). Inspect
 local changes before pulling; documentation does not provide an updater that
 resets a working tree.
@@ -142,8 +143,10 @@ made for `v3.6.0`. Windows and macOS have no scheduled release target.
 | **Documentation**                | Full [mkdocs-material site](https://weby-homelab.github.io/power-framework/) with API reference and guides                                                                                                                                                                                                                                                                                                                                                                          |
 
 > **POWER 3.6.0 evidence contract:** publication requires machine validation
-> gates, package/CI provenance, an SBOM, an Ubuntu upgrade matrix, and fresh
-> Phase 8 technical and human-evaluation receipts. Once published, these
+> gates, package/CI provenance, an SBOM, a Linux upgrade matrix executed on the
+> Ubuntu CI runner, and source-bound technical receipts. Real-vault and human
+> evaluation are optional benchmarks, not release secrets or publication
+> blockers. Once published, these
 > receipts apply to the
 > declared release scope. Historical feature-table figures, model comparisons,
 > resource limits, and benchmark recommendations do not become guarantees for

--- a/README.ua.md
+++ b/README.ua.md
@@ -38,7 +38,7 @@ P.O.W.E.R. — це гібридна система, створена для п�
   фізичного переміщення, тому перейменування на існуючу ціль працює у Windows
   замість помилки `FileExistsError`
 - **Реліз P.O.W.E.R. 3.6.0** — публікація вимагає перевірені
-  wheel, source archive, SBOM, Ubuntu upgrade matrix і fresh release receipts.
+  wheel, source archive, SBOM, Linux upgrade matrix і fresh release receipts.
   Версія 3.6.0 консолідує fail-closed doctor, migration, cache, catalog, healer та
   agent-contract safeguards. Межі
   підтримки визначає [матриця платформ](docs/support-matrix.ua.md).
@@ -60,12 +60,13 @@ P.O.W.E.R. створений для роботи як людьми, так і A
   міграція з будь-якої Markdown source methodology у canonical POWER vault
 - **[Інвентаризація документації](docs/documentation-inventory.ua.md)** — перевірені
   точки входу, пов'язані документи, виправлений дрейф і межі доказів
-- **[Матриця підтримки платформ](docs/support-matrix.ua.md)** — Ubuntu/Linux є
-  release-платформою `v3.6.0`; macOS і Windows відкладені на невизначений строк
+- **[Матриця підтримки платформ](docs/support-matrix.ua.md)** — Linux є
+  release-платформою `v3.6.0`; CI зараз перевіряє її на Ubuntu, а macOS і
+  Windows відкладені на невизначений строк
 
-## Швидкий старт (Ubuntu/Linux)
+## Швидкий старт (Linux)
 
-Наведені нижче команди — найкоротший підтримуваний шлях для Ubuntu/Linux.
+Наведені нижче команди — найкоротший підтримуваний шлях для Linux.
 Потрібен Python 3.11+ і terminal shell; `~/my-vault` — каталог vault, яким
 керуватиме POWER.
 
@@ -87,9 +88,9 @@ power heal ~/my-vault      # Автовиправлення відсутньог
 power markdown-check ~/my-vault  # Перевірка якості Markdown
 ```
 
-## Розробницька установка (Ubuntu/Linux)
+## Розробницька установка (Linux)
 
-Учасникам на Ubuntu/Linux слід clone у durable development directory,
+Учасникам на Linux слід clone у durable development directory,
 створити venv і виконати [CONTRIBUTING.md](CONTRIBUTING.md). Перед pull
 перевіряйте local changes; документація не пропонує updater, який reset робоче
 дерево.
@@ -141,8 +142,10 @@ GPU claim. Windows і macOS не мають запланованого release t
 | **Документація**                 | Повний [mkdocs-material сайт](https://weby-homelab.github.io/power-framework/) з API reference та гайдами                                                                                                                                                                                                                                                                                                                                                                            |
 
 > **Контракт evidence для POWER 3.6.0:** публікація вимагає machine validation
-> gates, package/CI provenance, SBOM, Ubuntu upgrade matrix і fresh Phase 8
-> technical та human-evaluation receipts. Після публікації ці receipts діють у межах заявленого
+> gates, package/CI provenance, SBOM, Linux upgrade matrix, виконану на Ubuntu
+> CI runner, і source-bound technical receipts. Real-vault та human evaluation
+> є опціональними benchmark, а не release secrets чи блокерами публікації.
+> Після публікації ці receipts діють у межах заявленого
 > release scope. Historical figures у feature-table, model comparisons, resource
 > limits і benchmark recommendations не є гарантіями для довільного хоста або
 > vault.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ or relying on `--break-system-packages` for a normal installation.
 
 ## 2. Install the versioned release
 
-On Ubuntu/Linux:
+On Linux:
 
 ```bash
 python3 -m venv "$HOME/.local/share/power-framework/venv"

--- a/docs/getting-started.ua.md
+++ b/docs/getting-started.ua.md
@@ -26,7 +26,7 @@ macOS відкладені на невизначений строк і не є �
 
 ## 2. Встановіть версіонований реліз
 
-На Ubuntu/Linux:
+На Linux:
 
 ```bash
 python3 -m venv "$HOME/.local/share/power-framework/venv"

--- a/docs/mcp-client-onboarding.md
+++ b/docs/mcp-client-onboarding.md
@@ -1,7 +1,7 @@
 # MCP client onboarding
 
-This is the canonical local-stdio setup for P.O.W.E.R. `v3.6.0` on
-Ubuntu/Linux. It gives Codex, OpenCode, Gemini CLI, Claude Desktop, and Claude Code
+This is the canonical local-stdio setup for P.O.W.E.R. `v3.6.0` on Linux.
+It gives Codex, OpenCode, Gemini CLI, Claude Desktop, and Claude Code
 the same server process and the same vault boundary.
 
 > **Release contract:** use `v3.6.0` only after its signed tag and immutable

--- a/docs/mcp-client-onboarding.ua.md
+++ b/docs/mcp-client-onboarding.ua.md
@@ -1,7 +1,7 @@
 # Підключення MCP-клієнтів
 
-Це канонічне налаштування локального stdio для P.O.W.E.R. `v3.6.0` на
-Ubuntu/Linux. Воно дає Codex, OpenCode, Gemini CLI, Claude Desktop і Claude Code один
+Це канонічне налаштування локального stdio для P.O.W.E.R. `v3.6.0` на Linux.
+Воно дає Codex, OpenCode, Gemini CLI, Claude Desktop і Claude Code один
 і той самий процес сервера та однакову межу vault.
 
 > **Контракт релізу:** використовуйте `v3.6.0` лише після появи signed tag та

--- a/docs/release-3.6.0.md
+++ b/docs/release-3.6.0.md
@@ -26,9 +26,10 @@ public inventory remains 24 CLI commands and 20 MCP tools.
 
 ## Platform boundary
 
-Ubuntu/Linux is the only supported release platform for `v3.6.0`. Every CI,
-documentation, CodeQL, package, upgrade, and publication job runs on
-`ubuntu-latest`.
+Linux is the supported release platform for `v3.6.0`. The automated CI,
+documentation, CodeQL, package, upgrade, and publication jobs currently run on
+an Ubuntu runner; Ubuntu is the validation environment, not the product name or
+the full platform boundary.
 
 macOS and Windows are deferred with an **unscheduled** policy. This release
 does not run macOS or Windows CI, does not publish upgrade receipts for those
@@ -38,7 +39,8 @@ supported-platform certification.
 
 ## Upgrade and rollback
 
-The executable Ubuntu matrix covers `3.5.0 -> 3.6.0`, including interrupted
+The executable Linux matrix runs on Ubuntu and covers `3.5.0 -> 3.6.0`,
+including interrupted
 index publication at `before_move`, `after_move`, and `after_pointer`. It must
 prove source preservation, restart recovery, stale-build cleanup, active-pointer
 consistency, and no data loss before publication.
@@ -66,13 +68,14 @@ uv run python scripts/verify_upgrade_matrix.py \
 
 The tag workflow additionally requires a clean signed `v3.6.0` tag, wheel and
 source-distribution smoke tests outside the checkout, an SPDX SBOM, provenance
-attestation, fresh source-bound Phase 8 evidence, a complete Ubuntu upgrade
-aggregate, and GitHub release body/asset readback.
+attestation, source-bound technical Phase 8 receipts, a complete Linux upgrade
+aggregate from the Ubuntu runner, and GitHub release body/asset readback.
 
 ## Evidence boundary
 
-Synthetic technical receipts do not substitute for real-vault or sealed-human
-evidence. The stable workflow fails closed unless the protected
-`power36-stable-release` environment supplies fresh content-free evidence bound
-to `v3.6.0`. Historical `v3.5.0` release assets remain immutable historical
+Synthetic technical receipts prove release mechanics and continuity, not
+host-independent retrieval quality. Real-vault and sealed-human evaluation are
+optional benchmarks: they are not GitHub Secrets and do not block normal Linux
+publication. When supplied, they may support separate quality claims after
+their own validation. Historical `v3.5.0` assets remain immutable historical
 evidence and are not relabelled as 3.6.0 results.

--- a/release/evidence/README.md
+++ b/release/evidence/README.md
@@ -54,15 +54,15 @@ and coverage JSON artifacts. This prevents a final baseline from inheriting
 historical candidate counts from a template; the receipt must report passed
 tests, skipped tests, coverage, warning policy, zero skipped mandatory gates,
 and hashes of its JUnit, coverage, and executed-gate manifest inputs. The final
-baseline additionally binds the generated SPDX SBOM and the aggregate Ubuntu
-upgrade receipt.
+baseline additionally binds the generated SPDX SBOM and the aggregate Linux
+upgrade receipt produced on the Ubuntu CI runner.
 
-## Phase 8 stable-release evidence
+## Optional Phase 8 quality evidence
 
 The synthetic `benchmarks/power35` receipts are technical CI evidence only.
-They cannot open the stable-release gate. Before a stable 3.6.0 tag, a
-maintainer must provision two content-free files in the release runner's
-`$RUNNER_TEMP/power36-phase8/` directory:
+Real-vault and sealed-human evidence are optional quality evaluations and are
+not required to publish a stable 3.6.0 tag. If a maintainer wants to make those
+additional quality claims, two content-free files can be validated separately:
 
 - `real-vault-receipt.json`, validated by `scripts/verify_phase8_evidence.py`
   for exact source/runtime identity, build/transfer/import/query separation,
@@ -71,16 +71,10 @@ maintainer must provision two content-free files in the release runner's
   `sealed_holdout` manifest validated by
   `benchmarks/human_retrieval/scripts/validate_human_evidence.py`.
 
-The GitHub release workflow calls
-`scripts/materialize_phase8_evidence.py` to materialize these files from the
-protected `power36-stable-release` environment. Configure required reviewers for that
-environment and store only the two content-free JSON documents as
-`POWER36_REAL_VAULT_RECEIPT_JSON` and `POWER36_HUMAN_MANIFEST_JSON` secrets.
-The workflow refuses to continue when either secret is absent, writes the
-files with mode `0600` into the ephemeral runner directory, and validates their
-JSON syntax before binding their hashes into the release baseline. The secrets
-are never committed, printed, uploaded as an input artifact, or used as a
-substitute for the verifier's exact source/runtime and sealed-holdout checks.
+`scripts/materialize_phase8_evidence.py` remains an optional local utility for
+turning explicitly supplied JSON environment values into mode-`0600` files.
+The GitHub release workflow does not call it and does not require private
+evidence secrets.
 
 If the human manifest carries an `embedded_artifacts` object, the materializer
 also writes only its referenced protocol, receipt, corpus, query, judgment and
@@ -89,18 +83,17 @@ must be present, UTF-8 text, and confined to that directory; malformed or
 incomplete embedded artifacts fail closed before evidence is written.
 
 The public repository intentionally contains neither raw vault material nor
-private qrels. If these files are absent, the release workflow fails closed;
-the candidate baseline remains non-production evidence.
+private qrels. Their absence limits quality claims but does not block the
+technical Linux release.
 
 The release workflow also archives the synthetic outcome and continuity
 receipts from the stable `benchmarks/power35` harness and binds their SHA-256
 values into the tag-bound baseline. Their v2 schemas also carry release,
 commit, tree, clean-state, and worktree-hash identity; candidate and final
 baseline generation rejects stale receipts from another checkout. For
-`v3.6.0`, the Ubuntu upgrade aggregate
-covers the only supported release platform;
+`v3.6.0`, the Linux upgrade aggregate is executed on the Ubuntu runner;
 macOS and Windows are explicitly deferred and do not appear as supported
 platforms in the release artifact. Their deferral has no scheduled release
 target. The synthetic receipts prove only technical safety/continuity;
 their explicit `real_vault=false` and `human_quality_certification=false`
-fields are required and cannot open the stable gate.
+fields are required and cannot be promoted into quality claims.

--- a/scripts/generate_release_baseline.py
+++ b/scripts/generate_release_baseline.py
@@ -185,7 +185,10 @@ def build_baseline(
         raise ValueError("baseline scope must be an object")
     scope["technical_release"] = True
     scope["candidate_only"] = False
-    scope["phase8_evidence"] = {"status": "pending"}
+    scope["phase8_evidence"] = {"status": "optional"}
+    scope["human_quality_certification"] = False
+    scope["production_quality_claim"] = False
+    scope["sealed_holdout"] = "not_opened"
     validation_report = _load_validation_report(validation_report_path)
     validation = baseline["validation"] = copy.deepcopy(validation_report)
     validation["sbom_sha256"] = _sha256(sbom_path)

--- a/scripts/verify_release_contract.py
+++ b/scripts/verify_release_contract.py
@@ -245,20 +245,36 @@ def validate_release_contract(
             if scope.get("technical_release") is not True:
                 errors.append("final release baseline scope.technical_release must be true")
             phase8_evidence = scope.get("phase8_evidence")
-            if not isinstance(phase8_evidence, dict) or phase8_evidence.get("status") != "passed":
-                errors.append("final release requires passed Phase 8 real-vault and human evidence")
-            elif not all(
-                isinstance(phase8_evidence.get(field), str)
-                and re.fullmatch(r"[0-9a-f]{64}", phase8_evidence[field])
-                for field in ("real_vault_receipt_sha256", "human_manifest_sha256")
-            ):
-                errors.append("final Phase 8 evidence must include both receipt SHA-256 bindings")
-            if scope.get("human_quality_certification") is not True:
-                errors.append("final release requires human_quality_certification=true")
-            if scope.get("production_quality_claim") is not True:
-                errors.append("final release requires production_quality_claim=true")
-            if scope.get("sealed_holdout") != "passed":
-                errors.append("final release requires sealed_holdout=passed")
+            if not isinstance(phase8_evidence, dict):
+                errors.append("final release baseline scope.phase8_evidence must be an object")
+            elif phase8_evidence.get("status") == "passed":
+                if not all(
+                    isinstance(phase8_evidence.get(field), str)
+                    and re.fullmatch(r"[0-9a-f]{64}", phase8_evidence[field])
+                    for field in ("real_vault_receipt_sha256", "human_manifest_sha256")
+                ):
+                    errors.append("passed Phase 8 evidence must include both SHA-256 bindings")
+                if scope.get("human_quality_certification") is not True:
+                    errors.append(
+                        "passed Phase 8 evidence requires human_quality_certification=true"
+                    )
+                if scope.get("production_quality_claim") is not True:
+                    errors.append("passed Phase 8 evidence requires production_quality_claim=true")
+                if scope.get("sealed_holdout") != "passed":
+                    errors.append("passed Phase 8 evidence requires sealed_holdout=passed")
+            elif phase8_evidence.get("status") == "optional":
+                if scope.get("human_quality_certification") is not False:
+                    errors.append(
+                        "optional Phase 8 evidence requires human_quality_certification=false"
+                    )
+                if scope.get("production_quality_claim") is not False:
+                    errors.append(
+                        "optional Phase 8 evidence requires production_quality_claim=false"
+                    )
+                if scope.get("sealed_holdout") != "not_opened":
+                    errors.append("optional Phase 8 evidence requires sealed_holdout=not_opened")
+            else:
+                errors.append("final release Phase 8 evidence status must be optional or passed")
 
     source = baseline.get("source")
     if not isinstance(source, dict):

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -104,19 +104,15 @@ def test_release_publish_is_blocked_by_a_tag_validation_job() -> None:
     assert 'gpg --batch --import "$key_file"' in release_text
 
 
-def test_release_materializes_phase8_evidence_through_protected_environment() -> None:
+def test_release_does_not_require_private_phase8_secrets() -> None:
     release_text = (WORKFLOWS_DIR / "release.yml").read_text(encoding="utf-8")
 
-    assert "name: power36-stable-release" in release_text
-    assert "POWER36_REAL_VAULT_RECEIPT_JSON" in release_text
-    assert "POWER36_HUMAN_MANIFEST_JSON" in release_text
-    assert (
-        "POWER36_REAL_VAULT_RECEIPT_JSON: ${{ secrets.POWER36_REAL_VAULT_RECEIPT_JSON }}"
-        in release_text
-    )
-    assert "POWER36_HUMAN_MANIFEST_JSON: ${{ secrets.POWER36_HUMAN_MANIFEST_JSON }}" in release_text
-    assert "scripts/materialize_phase8_evidence.py" in release_text
-    assert '--output-dir "$RUNNER_TEMP/power36-phase8"' in release_text
+    assert "name: power36-stable-release" not in release_text
+    assert "POWER36_REAL_VAULT_RECEIPT_JSON" not in release_text
+    assert "POWER36_HUMAN_MANIFEST_JSON" not in release_text
+    assert "scripts/materialize_phase8_evidence.py" not in release_text
+    assert "--phase8-real-vault-receipt" not in release_text
+    assert "--phase8-human-manifest" not in release_text
 
 
 def test_ci_uses_locked_dependencies_and_clean_package_smoke() -> None:
@@ -136,9 +132,7 @@ def test_ci_uses_locked_dependencies_and_clean_package_smoke() -> None:
     assert "scripts/smoke_package.py" in ci_text
     assert "scripts/smoke_package.py" in release_text
     assert "scripts/generate_release_receipt.py" in release_text
-    assert "maintainer-provisioned Phase 8 evidence" in release_text
-    assert "--phase8-real-vault-receipt" in release_text
-    assert "--phase8-human-manifest" in release_text
+    assert "--skipped-optional real-vault-quality" in release_text
     assert "run_outcome_benchmark.py" in release_text
     assert "run_continuity_benchmark.py" in release_text
     assert "scripts/generate_release_validation.py" in release_text

--- a/tests/test_release_baseline.py
+++ b/tests/test_release_baseline.py
@@ -541,6 +541,10 @@ def test_final_baseline_clears_candidate_publication_scope(tmp_path: Path) -> No
     assert baseline["candidate"] is False
     assert baseline["scope"]["technical_release"] is True
     assert baseline["scope"]["candidate_only"] is False
+    assert baseline["scope"]["phase8_evidence"] == {"status": "optional"}
+    assert baseline["scope"]["human_quality_certification"] is False
+    assert baseline["scope"]["production_quality_claim"] is False
+    assert baseline["scope"]["sealed_holdout"] == "not_opened"
     assert baseline["validation"]["passed"] == 1014
     assert baseline["validation"]["skipped"] == 11
     assert baseline["validation"]["coverage_percent"] == 81.66

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -153,7 +153,8 @@ def test_release_notes_keep_governance_claims_within_evidence_boundary() -> None
 
     assert "Zero open repository issues" not in notes
     assert "published `v3.6.0` release" not in notes
-    assert "fresh source-bound Phase 8 evidence" in notes
+    assert "Real-vault and sealed-human evaluation" in notes
+    assert "not GitHub Secrets and do not block normal Linux" in notes
     assert "macOS and Windows are deferred with an **unscheduled** policy" in notes
 
 
@@ -300,7 +301,7 @@ def test_final_gate_rejects_candidate_publication_scope(tmp_path: Path) -> None:
     assert "technical_release must be true" in result.stderr
 
 
-def test_final_gate_rejects_unproven_phase8_quality_scope(tmp_path: Path) -> None:
+def test_final_gate_rejects_ambiguous_phase8_quality_scope(tmp_path: Path) -> None:
     baseline = json.loads(_build_candidate(tmp_path).read_text(encoding="utf-8"))
     baseline["candidate"] = False
     baseline["source"]["clean"] = True
@@ -315,8 +316,7 @@ def test_final_gate_rejects_unproven_phase8_quality_scope(tmp_path: Path) -> Non
     result = _run_validator("--baseline", str(altered_baseline))
 
     assert result.returncode == 1
-    assert "requires passed Phase 8" in result.stderr
-    assert "human_quality_certification=true" in result.stderr
+    assert "Phase 8 evidence status must be optional or passed" in result.stderr
 
 
 def test_candidate_generator_accepts_output_outside_checkout(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #324

## Fix

- names Linux as the supported 3.6.0 release platform; Ubuntu is documented only as the current CI validation runner;
- removes the `power36-stable-release` environment and private JSON secret dependency from normal publication;
- keeps real-vault and sealed-human evaluation optional and prevents their absence from blocking a technical Linux release;
- keeps signed tag verification, source-bound technical receipts, full tests, Linux upgrade/rollback evidence, package smoke, SBOM, provenance, and GitHub readback mandatory.

## Validation

- focused release/Phase 8 suite: `51 passed, 1 skipped`;
- Ruff check/format, mypy, doc drift, MkDocs strict, complexity budget, lock check: PASS;
- installed OpenCode POWER Skill copies synchronized to 3.6.0;
- staged diff and whitespace checks: PASS.