### PR TITLE
fix(tasks): allow backlog -> working and reversible task state transitions

### DIFF
--- a/src/power_framework/core/task_models.py
+++ b/src/power_framework/core/task_models.py
@@ -34,10 +34,11 @@ TERMINAL_STATES: set[TaskState] = {"completed", "failed", "canceled", "rejected"
 
 # Allowed transitions mapping: from_state -> set of allowed to_states
 VALID_TRANSITIONS: dict[TaskState, set[TaskState]] = {
-    "backlog": {"ready", "submitted", "canceled"},
-    "ready": {"working", "input-required", "auth-required", "blocked", "canceled", "rejected"},
-    "submitted": {"working", "input-required", "auth-required", "blocked", "canceled", "rejected"},
+    "backlog": {"ready", "submitted", "working", "canceled"},
+    "ready": {"backlog", "working", "input-required", "auth-required", "blocked", "canceled", "rejected"},
+    "submitted": {"backlog", "ready", "working", "input-required", "auth-required", "blocked", "canceled", "rejected"},
     "working": {
+        "ready",
         "completed",
         "failed",
         "blocked",

--- a/tests/test_task_service.py
+++ b/tests/test_task_service.py
@@ -132,3 +132,27 @@ def test_v1_work_packet_migration(temp_vault: Path) -> None:
     assert task.state == "working"
     assert task.objective == "Legacy task objective"
     assert task.authority == "propose"
+
+
+def test_direct_backlog_to_working_transition(temp_vault: Path) -> None:
+    """Test direct transition from backlog to working state."""
+    service = TaskService(temp_vault)
+    service.create_task(
+        task_id="task_direct_working",
+        title="Direct Work Task",
+        state="backlog",
+    )
+
+    t_working = service.transition_task("task_direct_working", "working", expected_revision=1)
+    assert t_working.state == "working"
+    assert t_working.revision == 2
+
+    # Verify transition back to ready or backlog
+    t_ready = service.transition_task("task_direct_working", "ready", expected_revision=2)
+    assert t_ready.state == "ready"
+    assert t_ready.revision == 3
+
+    t_backlog = service.transition_task("task_direct_working", "backlog", expected_revision=3)
+    assert t_backlog.state == "backlog"
+    assert t_backlog.revision == 4
+


### PR DESCRIPTION
Updates VALID_TRANSITIONS to allow canonical task workflows (backlog -> working, ready -> backlog, etc.) and adds unit test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks can now move directly from **Backlog** to **Working**.
  * Tasks in **Ready** or **Submitted** can be moved back to **Backlog**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->