### PR TITLE
fix(core): dynamic cross-platform opencode binary discovery via Path.home and PATH

### DIFF
--- a/src/power_framework/core/utils.py
+++ b/src/power_framework/core/utils.py
@@ -459,9 +459,11 @@ def run_opencode_cli(prompt: str) -> str:
 
     local_logger = logging.getLogger(__name__)
 
-    # Locate opencode binary
-    binary = "/root/.opencode/bin/opencode"
-    if not os.path.exists(binary):
+    # Locate opencode binary dynamically across systems
+    user_opencode = Path.home() / ".opencode" / "bin" / "opencode"
+    if user_opencode.exists():
+        binary = str(user_opencode)
+    else:
         binary = shutil.which("opencode") or "opencode"
 
     try:


### PR DESCRIPTION
Resolves opencode CLI binary dynamically using user home directory and system PATH instead of hardcoded root paths.