### PR TITLE
fix(security): resolve CodeQL alerts #138 and #139

### DIFF
--- a/docs/api/markdown_checks.md
+++ b/docs/api/markdown_checks.md
@@ -19,7 +19,7 @@ Each check returns a list of issue dicts:
 
 ```python
 {
-    "line": 42,       # 1-indexed line number
+    "line": 42,  # 1-indexed line number
     "type": "trailing-whitespace",  # issue category
     "context": "...",  # truncated context snippet
 }

--- a/src/power_framework/core/application_models.py
+++ b/src/power_framework/core/application_models.py
@@ -26,7 +26,9 @@ class SourceItemDTO(BaseDTO):
     size_bytes: int = Field(default=0, ge=0)
     modified_at: str = Field(default="", description="ISO 8601 UTC timestamp")
     tags: list[str] = Field(default_factory=list)
-    trust_label: str = Field(default="local", description="Trust level: local, federated, untrusted")
+    trust_label: str = Field(
+        default="local", description="Trust level: local, federated, untrusted"
+    )
     sha256: str = Field(default="", description="Content hash digest")
 
 

--- a/src/power_framework/core/mutation.py
+++ b/src/power_framework/core/mutation.py
@@ -84,7 +84,7 @@ def vault_mutation(vault_dir: Path) -> Iterator[Path]:
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     process_lock = _get_vault_lock(root)
     with process_lock:
-        descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o666)
+        descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
         try:
             _lock_descriptor(descriptor)
             yield root

--- a/src/power_framework/core/source_service.py
+++ b/src/power_framework/core/source_service.py
@@ -354,7 +354,11 @@ def get_graph_projection(
             if norm in nodes_map and norm != source_path:
                 return norm
             candidate_md = f"{norm}.md"
-            if not norm.endswith(".md") and candidate_md in nodes_map and candidate_md != source_path:
+            if (
+                not norm.endswith(".md")
+                and candidate_md in nodes_map
+                and candidate_md != source_path
+            ):
                 return candidate_md
         # 4. Match by filename stem (case-insensitive)
         target_stem = Path(target_clean).stem.lower()

--- a/src/power_framework/core/source_service.py
+++ b/src/power_framework/core/source_service.py
@@ -238,10 +238,11 @@ def read_source(vault_dir: Path, request: SourceReadRequest) -> SourceReadRespon
 def get_source_stats(vault_dir: Path) -> SourceStatsResponse:
     """Compute aggregate vault statistics."""
     root = vault_dir.expanduser().resolve()
-    vault_id = "default"
-    with contextlib.suppress(Exception):
+    try:
         ident = ensure_vault_identity(root)
         vault_id = ident.vault_id
+    except Exception:
+        vault_id = "default"
 
     cat_counts: dict[str, int] = {}
     tag_counts: dict[str, int] = {}

--- a/src/power_framework/core/task_models.py
+++ b/src/power_framework/core/task_models.py
@@ -35,8 +35,25 @@ TERMINAL_STATES: set[TaskState] = {"completed", "failed", "canceled", "rejected"
 # Allowed transitions mapping: from_state -> set of allowed to_states
 VALID_TRANSITIONS: dict[TaskState, set[TaskState]] = {
     "backlog": {"ready", "submitted", "working", "canceled"},
-    "ready": {"backlog", "working", "input-required", "auth-required", "blocked", "canceled", "rejected"},
-    "submitted": {"backlog", "ready", "working", "input-required", "auth-required", "blocked", "canceled", "rejected"},
+    "ready": {
+        "backlog",
+        "working",
+        "input-required",
+        "auth-required",
+        "blocked",
+        "canceled",
+        "rejected",
+    },
+    "submitted": {
+        "backlog",
+        "ready",
+        "working",
+        "input-required",
+        "auth-required",
+        "blocked",
+        "canceled",
+        "rejected",
+    },
     "working": {
         "ready",
         "completed",
@@ -151,7 +168,7 @@ class TaskEvent(BaseModel):
         payload: dict[str, Any],
         prev_event_digest: str = "",
     ) -> TaskEvent:
-        event_id = f"evt_{task_id}_{sequence}_{int(datetime.now(UTC).timestamp()*1000)}"
+        event_id = f"evt_{task_id}_{sequence}_{int(datetime.now(UTC).timestamp() * 1000)}"
         payload_bytes = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
         payload_digest = hashlib.sha256(payload_bytes).hexdigest()
         return cls(

--- a/src/power_framework/core/task_service.py
+++ b/src/power_framework/core/task_service.py
@@ -221,7 +221,9 @@ class TaskService:
                     scope=data.get("scope", []),
                     authority=data.get("authority", "read-only"),
                     next_action=data.get("next_action", "inspect"),
-                    receipt_ids=[data.get("last_receipt_id")] if data.get("last_receipt_id") else [],
+                    receipt_ids=[data.get("last_receipt_id")]
+                    if data.get("last_receipt_id")
+                    else [],
                     revision=len(data.get("checkpoints", [])) + 1,
                     created_at=data.get("created_at", datetime.now(UTC).isoformat()),
                     updated_at=data.get("updated_at", datetime.now(UTC).isoformat()),

--- a/tests/test_application_v2.py
+++ b/tests/test_application_v2.py
@@ -11,6 +11,7 @@ from power_framework.core.application_models import (
     SourceListRequest,
 )
 from power_framework.core.source_service import (
+    get_source_stats,
     normalize_rel_path,
     resolve_safe_vault_path,
 )
@@ -135,6 +136,19 @@ def test_source_stats(temp_vault: Path) -> None:
     assert env.data["total_notes"] == 2
     assert env.data["category_counts"]["01_Projects"] == 1
     assert env.data["category_counts"]["03_Resources"] == 1
+
+
+def test_source_stats_fallback_vault_id(monkeypatch: pytest.MonkeyPatch, temp_vault: Path) -> None:
+    """Test that get_source_stats falls back to 'default' if identity resolution fails."""
+    import power_framework.core.source_service as src_mod
+
+    def fail_identity(_root: Path) -> None:
+        raise OSError("Permission denied")
+
+    monkeypatch.setattr(src_mod, "ensure_vault_identity", fail_identity)
+    stats = get_source_stats(temp_vault)
+    assert stats.vault_id == "default"
+    assert stats.total_notes == 2
 
 
 def test_graph_projection(temp_vault: Path) -> None:

--- a/tests/test_application_v2.py
+++ b/tests/test_application_v2.py
@@ -6,14 +6,10 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from power_framework.core import source_service
 from power_framework.core.application import ApplicationService
 from power_framework.core.application_models import (
     SourceListRequest,
-)
-from power_framework.core.source_service import (
-    get_source_stats,
-    normalize_rel_path,
-    resolve_safe_vault_path,
 )
 
 if TYPE_CHECKING:
@@ -68,18 +64,18 @@ Reference content.
 
 def test_path_normalization_and_containment(temp_vault: Path) -> None:
     """Ensure path normalization and traversal prevention work fail-closed."""
-    assert normalize_rel_path("01_Projects/Note.md") == "01_Projects/Note.md"
-    assert normalize_rel_path("/01_Projects/Note.md") == "01_Projects/Note.md"
-    assert normalize_rel_path("01_Projects\\Note.md") == "01_Projects/Note.md"
+    assert source_service.normalize_rel_path("01_Projects/Note.md") == "01_Projects/Note.md"
+    assert source_service.normalize_rel_path("/01_Projects/Note.md") == "01_Projects/Note.md"
+    assert source_service.normalize_rel_path("01_Projects\\Note.md") == "01_Projects/Note.md"
 
     with pytest.raises(PermissionError, match="Path traversal"):
-        normalize_rel_path("../secrets.env")
+        source_service.normalize_rel_path("../secrets.env")
 
     with pytest.raises(PermissionError, match="Path traversal"):
-        normalize_rel_path("01_Projects/../../etc/passwd")
+        source_service.normalize_rel_path("01_Projects/../../etc/passwd")
 
     with pytest.raises(PermissionError, match="Path traversal detected"):
-        resolve_safe_vault_path(temp_vault, "../outside.md")
+        source_service.resolve_safe_vault_path(temp_vault, "../outside.md")
 
 
 def test_source_list_and_pagination(temp_vault: Path) -> None:
@@ -140,13 +136,12 @@ def test_source_stats(temp_vault: Path) -> None:
 
 def test_source_stats_fallback_vault_id(monkeypatch: pytest.MonkeyPatch, temp_vault: Path) -> None:
     """Test that get_source_stats falls back to 'default' if identity resolution fails."""
-    import power_framework.core.source_service as src_mod
 
     def fail_identity(_root: Path) -> None:
         raise OSError("Permission denied")
 
-    monkeypatch.setattr(src_mod, "ensure_vault_identity", fail_identity)
-    stats = get_source_stats(temp_vault)
+    monkeypatch.setattr(source_service, "ensure_vault_identity", fail_identity)
+    stats = source_service.get_source_stats(temp_vault)
     assert stats.vault_id == "default"
     assert stats.total_notes == 2
 

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import stat
 import subprocess
 import sys
 import threading
@@ -87,6 +88,16 @@ def test_lock_is_released_after_failure(tmp_path: Path) -> None:
 
     with vault_mutation(vault):
         assert (vault / ".power" / "mutation.lock").exists()
+
+
+def test_mutation_lock_has_strict_permissions(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    with vault_mutation(vault):
+        lock_file = vault / ".power" / "mutation.lock"
+        assert lock_file.exists()
+        assert stat.S_IMODE(lock_file.stat().st_mode) == 0o600
 
 
 def test_os_lock_serializes_another_process(tmp_path: Path) -> None:

--- a/tests/test_task_service.py
+++ b/tests/test_task_service.py
@@ -155,4 +155,3 @@ def test_direct_backlog_to_working_transition(temp_vault: Path) -> None:
     t_backlog = service.transition_task("task_direct_working", "backlog", expected_revision=3)
     assert t_backlog.state == "backlog"
     assert t_backlog.revision == 4
-


### PR DESCRIPTION
## Summary of Security Fixes

This pull request resolves open GitHub CodeQL security alerts for `power-framework`:

1. **Alert #139 (`py/overly-permissive-file` / CWE-732)**:
   - **Target**: `src/power_framework/core/mutation.py`
   - **Fix**: Restricted lock file creation mask from world-writable `0o666` to owner-only `0o600`.
   - **Regression Test**: Added `test_mutation_lock_has_strict_permissions` in `tests/test_mutation.py`.

2. **Alert #138 (`py/multiple-definition` / CWE-563)**:
   - **Target**: `src/power_framework/core/source_service.py`
   - **Fix**: Replaced redundant initial variable assignment followed by `contextlib.suppress` with idiomatic `try...except Exception` pattern in `get_source_stats`.
   - **Regression Test**: Added `test_source_stats_fallback_vault_id` in `tests/test_application_v2.py`.

## Validation
- Full test suite passed: 1013 passed, 59 skipped, 0 failures.
- Required coverage: 79.71% (exceeds 70% threshold).
- Linting: `ruff check` and `ruff format --check` clean.
- Workspace: `./verify.sh` clean.
- GPG-signed commit: `b0d6431f0c19a6ba311ec48dc2cfc69374036fae`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by ensuring mutation lock files use restricted permissions.
  * Added a reliable fallback vault identifier when identity resolution fails.
  * Preserved source statistics, including note counts, during identity-resolution errors.

* **Tests**
  * Added coverage for lock-file permissions and source-statistics fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->