### PR TITLE
fix: narrow A2A claims + 3.6.3 negative tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Validate, index, search, and manage your knowledge base from the command line â€
 [![Docs](https://img.shields.io/badge/docs-mkdocs--material-8A2BE2?logo=materialformkdocs)](https://weby-homelab.github.io/power-framework/)
 [![OKF BundleDex](https://bundledex.net/static-badge.svg)](https://bundledex.net)
 [![MCP Marketplace](https://img.shields.io/badge/MCP%20Marketplace-Indexed-blueviolet)](https://getlulu.dev/mcps)
-[![A2A Protocol](https://img.shields.io/badge/A2A-Agent_Ready-8B5CF6?logo=openai&logoColor=white)](.agents/AGENTS.md)
+[![Discovery](https://img.shields.io/badge/discovery-experimental%2Fcustom--discovery-8B5CF6?logo=openai&logoColor=white)](.agents/AGENTS.md)
 
 ## About P.O.W.E.R. - Hybrid Knowledge Management Framework
 

--- a/README.ua.md
+++ b/README.ua.md
@@ -14,7 +14,7 @@
 [![Docs](https://img.shields.io/badge/docs-mkdocs--material-8A2BE2?logo=materialformkdocs)](https://weby-homelab.github.io/power-framework/)
 [![OKF BundleDex](https://bundledex.net/static-badge.svg)](https://bundledex.net)
 [![MCP Marketplace](https://img.shields.io/badge/MCP%20Marketplace-Indexed-blueviolet)](https://getlulu.dev/mcps)
-[![A2A Protocol](https://img.shields.io/badge/A2A-Agent_Ready-8B5CF6?logo=openai&logoColor=white)](.agents/AGENTS.md)
+[![Discovery](https://img.shields.io/badge/discovery-experimental%2Fcustom--discovery-8B5CF6?logo=openai&logoColor=white)](.agents/AGENTS.md)
 
 ## Про P.O.W.E.R. - Hybrid Knowledge Management Framework
 

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -203,3 +203,58 @@ def test_expired_decision_fails_closed(decision_service: DecisionService) -> Non
             actor="operator",
             authority="apply",
         )
+
+
+def test_decision_pending_before_expiry_and_terminal_not_rewritten(
+    decision_service: DecisionService,
+) -> None:
+    """Pending before boundary stays pending; approved/rejected do not become expired."""
+    future = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
+    pending = decision_service.create_decision(
+        decision_id="dec_future",
+        task_id="task_decision",
+        title="Still open",
+        requested_by="agent-1",
+        expires_at=future,
+    )
+    loaded = decision_service.get_decision(pending.decision_id)
+    assert loaded is not None
+    assert loaded.status == "pending"
+
+    approved = decision_service.create_decision(
+        decision_id="dec_approved_exp",
+        task_id="task_decision",
+        title="Already approved",
+        requested_by="agent-1",
+        expires_at=future,
+    )
+    resolved, _ = decision_service.resolve_decision(
+        approved.decision_id,
+        action="approve",
+        actor="operator",
+        authority="apply",
+    )
+    assert resolved.status == "approved"
+    # Force expires_at into the past on disk; terminal status must not flip to expired.
+    decision_file = decision_service._decision_file(approved.decision_id)
+    decision_file.write_text(
+        resolved.model_copy(
+            update={"expires_at": (datetime.now(UTC) - timedelta(hours=1)).isoformat()}
+        ).model_dump_json(),
+        encoding="utf-8",
+    )
+    still = decision_service.get_decision(approved.decision_id)
+    assert still is not None
+    assert still.status == "approved"
+
+
+def test_decision_rejects_naive_expires_at(decision_service: DecisionService) -> None:
+    """Naive timestamps are rejected or fail closed (tz-aware contract)."""
+    with pytest.raises((ValueError, TypeError)):
+        decision_service.create_decision(
+            decision_id="dec_naive",
+            task_id="task_decision",
+            title="Naive expiry",
+            requested_by="agent-1",
+            expires_at="2026-08-19T12:00:00",
+        )

--- a/tests/test_task_service.py
+++ b/tests/test_task_service.py
@@ -374,21 +374,23 @@ def test_task_values_reject_malformed_refs_and_unknown_state(temp_vault: Path) -
     """Malformed whitelisted refs and unknown transition targets fail closed."""
     service = TaskService(temp_vault)
     service.create_task(task_id="task_refs", title="Refs check")
-    with pytest.raises((ValueError, TypeError)):
+    with pytest.raises((ValueError, TypeError), match=r"list|type|artifact|validation|Input"):
         service.transition_task(
             "task_refs",
             "ready",
             expected_revision=1,
             values={"artifact_refs": "not-a-list"},
         )
-    with pytest.raises((ValueError, TypeError)):
+    with pytest.raises(
+        (ValueError, TypeError), match=r"dict|mapping|type|external|validation|Input"
+    ):
         service.transition_task(
             "task_refs",
             "ready",
             expected_revision=1,
             values={"external_refs": ["not-a-mapping"]},
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Invalid state transition|not-a-real-state|state"):
         service.transition_task("task_refs", "not-a-real-state", expected_revision=1)
 
 

--- a/tests/test_task_service.py
+++ b/tests/test_task_service.py
@@ -249,25 +249,74 @@ def test_event_hash_chaining(temp_vault: Path) -> None:
     assert events[2].prev_event_digest == events[1].payload_digest
 
 
-@pytest.mark.parametrize("tamper", ["payload", "payload_digest", "prev_event_digest"])
+@pytest.mark.parametrize(
+    "tamper",
+    [
+        "payload",
+        "payload_digest",
+        "prev_event_digest",
+        "duplicate_sequence",
+        "skipped_sequence",
+        "wrong_task_id",
+        "truncated_final_line",
+        "unexpected_schema_field",
+    ],
+)
 def test_event_hash_chain_rejects_tampering(temp_vault: Path, tamper: str) -> None:
-    """Payload and link changes fail closed when the journal is read."""
+    """Payload, link, sequence, identity, and schema tampering fail closed on read."""
     service = TaskService(temp_vault)
     service.create_task(task_id="task_tamper", title="Tamper check")
     service.transition_task("task_tamper", "ready")
     event_file = temp_vault / ".power" / "tasks" / "events" / "task_tamper.jsonl"
-    records = [json.loads(line) for line in event_file.read_text(encoding="utf-8").splitlines()]
+    raw = event_file.read_text(encoding="utf-8")
+    records = [json.loads(line) for line in raw.splitlines() if line.strip()]
     if tamper == "payload":
         records[1]["payload"]["to_state"] = "working"
+        event_file.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8"
+        )
+        match = r"hash|digest"
     elif tamper == "payload_digest":
         records[1]["payload_digest"] = "0" * 64
-    else:
+        event_file.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8"
+        )
+        match = r"hash|digest"
+    elif tamper == "prev_event_digest":
         records[1]["prev_event_digest"] = "0" * 64
-    event_file.write_text(
-        "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8"
-    )
+        event_file.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8"
+        )
+        match = r"hash|digest|chain"
+    elif tamper == "duplicate_sequence":
+        records[1]["sequence"] = records[0]["sequence"]
+        event_file.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8"
+        )
+        match = r"sequence|monotonic"
+    elif tamper == "skipped_sequence":
+        records[1]["sequence"] = records[0]["sequence"] + 2
+        event_file.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8"
+        )
+        match = r"sequence|monotonic"
+    elif tamper == "wrong_task_id":
+        records[1]["task_id"] = "other_task"
+        event_file.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8"
+        )
+        match = r"task_id|Task"
+    elif tamper == "truncated_final_line":
+        event_file.write_text(raw.rstrip("\n")[:-8] + "\n", encoding="utf-8")
+        match = r"Malformed|JSON|journal|event"
+    else:  # unexpected_schema_field
+        records[1]["unexpected_field"] = "nope"
+        event_file.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8"
+        )
+        match = r"extra|unexpected|Forbidden|validation|Malformed|journal|event"
 
-    with pytest.raises(ValueError, match=r"hash|digest"):
+    with pytest.raises(ValueError, match=match):
         service.get_events("task_tamper")
 
 
@@ -319,6 +368,28 @@ def test_task_values_are_revalidated_before_persistence(temp_vault: Path) -> Non
         service.transition_task(
             "task_bounds", "ready", expected_revision=1, values={"max_attempts": 11}
         )
+
+
+def test_task_values_reject_malformed_refs_and_unknown_state(temp_vault: Path) -> None:
+    """Malformed whitelisted refs and unknown transition targets fail closed."""
+    service = TaskService(temp_vault)
+    service.create_task(task_id="task_refs", title="Refs check")
+    with pytest.raises((ValueError, TypeError)):
+        service.transition_task(
+            "task_refs",
+            "ready",
+            expected_revision=1,
+            values={"artifact_refs": "not-a-list"},
+        )
+    with pytest.raises((ValueError, TypeError)):
+        service.transition_task(
+            "task_refs",
+            "ready",
+            expected_revision=1,
+            values={"external_refs": ["not-a-mapping"]},
+        )
+    with pytest.raises(ValueError):
+        service.transition_task("task_refs", "not-a-real-state", expected_revision=1)
 
 
 def test_v1_work_packet_migration(temp_vault: Path) -> None:


### PR DESCRIPTION
## Summary
Closes Promt_POWER_3.6.3 residual **F2** (human A2A claims) and **F5** (negative matrix).

### Changes
- README / README.ua: replace `A2A-Agent_Ready` badge with `experimental/custom-discovery`
- Expand `test_event_hash_chain_rejects_tampering` (duplicate/skipped sequence, wrong task_id, truncated line, unexpected schema)
- Add malformed refs / unknown state mutation tests
- Add decision pending-before-expiry, terminal-not-rewritten, naive expires_at tests

### Verify
- `pytest tests/test_task_service.py tests/test_decision_service.py tests/test_application.py --no-cov` → 46 passed locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated English and Ukrainian README badges to highlight the experimental Discovery guide.

* **Tests**
  * Added coverage for decision expiry handling, terminal statuses, and invalid timestamps.
  * Expanded validation tests for tampered event records, malformed references, invalid transitions, and unexpected data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->