### PR TITLE
fix(release): align 3.6.4 release docs/contract with version

### DIFF
--- a/.agents/skills/power/SKILL.md
+++ b/.agents/skills/power/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: power
-version: 3.6.3
-description: P.O.W.E.R. 3.6.3 — Hybrid Knowledge Management Framework (P.A.R.A. + OKF v0.1 + Graph RAG + LLM-Wiki + Execution Rules).
+version: 3.6.4
+description: P.O.W.E.R. 3.6.4 — Hybrid Knowledge Management Framework (P.A.R.A. + OKF v0.1 + Graph RAG + LLM-Wiki + Execution Rules).
 ---
 
 # ⚡ P.O.W.E.R. Knowledge Management Skill

--- a/.agents/skills/power/references/runtime-contract.md
+++ b/.agents/skills/power/references/runtime-contract.md
@@ -6,7 +6,7 @@ sync/doctor правила. Авторитетна правда — `power docto
 
 ## Runtime version
 
-`v3.6.3` — runtime contract: **25 CLI commands** + **20 MCP tools** (FastMCP 3.x).
+`v3.6.4` — runtime contract: **25 CLI commands** + **20 MCP tools** (FastMCP 3.x).
 
 ## CLI (25 команд)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ POWER_CLI="$HOME/.local/share/power-framework/venv/bin/power"
 
 "$POWER_PYTHON" -m pip install --upgrade pip
 "$POWER_PYTHON" -m pip install \
-  https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.3-py3-none-any.whl
+  https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.4-py3-none-any.whl
 ```
 
 The base release wheel is FTS-only: it does not install ONNX Runtime, model
@@ -60,7 +60,7 @@ For local MCP, install the optional remote transport from the same wheel:
 
 ```bash
 "$POWER_PYTHON" -m pip install \
-  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.3-py3-none-any.whl"
+  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.4-py3-none-any.whl"
 ```
 
 ### Alternative: install from the pinned tag

--- a/docs/getting-started.ua.md
+++ b/docs/getting-started.ua.md
@@ -35,7 +35,7 @@ POWER_CLI="$HOME/.local/share/power-framework/venv/bin/power"
 
 "$POWER_PYTHON" -m pip install --upgrade pip
 "$POWER_PYTHON" -m pip install \
-  https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.3-py3-none-any.whl
+  https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.4-py3-none-any.whl
 ```
 
 Базовий release wheel є FTS-only: він не встановлює ONNX Runtime, model
@@ -60,7 +60,7 @@ tokenizers, numerical packages або optional MCP transport. Перед MCP д�
 
 ```bash
 "$POWER_PYTHON" -m pip install \
-  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.3-py3-none-any.whl"
+  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.4-py3-none-any.whl"
 ```
 
 ### Альтернатива: встановлення із закріпленого tag

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ python -m venv .venv
 . .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install \
-  "https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.3-py3-none-any.whl"
+  "https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.4-py3-none-any.whl"
 
 power init ./my-vault
 power index ./my-vault --strict

--- a/docs/mcp-client-onboarding.md
+++ b/docs/mcp-client-onboarding.md
@@ -28,7 +28,7 @@ POWER_VAULT="$HOME/Documents/power-vault"
 
 python3 -m venv "$POWER_VENV"
 "$POWER_PYTHON" -m pip install \
-  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.3-py3-none-any.whl"
+  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.4-py3-none-any.whl"
 # Only for a new or empty vault:
 "$POWER_CLI" init "$POWER_VAULT"
 "$POWER_PYTHON" -c 'import sys; print(sys.executable)'

--- a/docs/mcp-client-onboarding.ua.md
+++ b/docs/mcp-client-onboarding.ua.md
@@ -28,7 +28,7 @@ POWER_VAULT="$HOME/Documents/power-vault"
 
 python3 -m venv "$POWER_VENV"
 "$POWER_PYTHON" -m pip install \
-  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.3-py3-none-any.whl"
+  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.3/power_framework-3.6.4-py3-none-any.whl"
 # Лише для нового або порожнього vault:
 "$POWER_CLI" init "$POWER_VAULT"
 "$POWER_PYTHON" -c 'import sys; print(sys.executable)'

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,12 +1,12 @@
 ---
 type: Resource
-title: "AI Agent Migration Guide: Any Markdown Knowledge Base to P.O.W.E.R. v3.6.3"
+title: "AI Agent Migration Guide: Any Markdown Knowledge Base to P.O.W.E.R. v3.6.4"
 description: "Fail-closed, manifest-driven protocol for migrating an existing Markdown knowledge base to a verified P.O.W.E.R. vault without modifying the source."
 tags: [power, migration, guide, ai-agents, safety, verification]
 timestamp: 2026-08-17T12:00:00+03:00
 ---
 
-# AI Agent Migration Guide: Any Markdown Knowledge Base to P.O.W.E.R. v3.6.3
+# AI Agent Migration Guide: Any Markdown Knowledge Base to P.O.W.E.R. v3.6.4
 
 This guide is written as an execution contract for any AI agent with filesystem
 access. It migrates a Markdown or Obsidian knowledge base into the canonical
@@ -17,7 +17,7 @@ For a new empty vault, stop here and use [Getting Started](getting-started.md).
 For Windows 11 25H2 runtime setup, first use the
 [Windows installation guide](windows-11-installation.md).
 
-This guide targets the `v3.6.3` release. Select the clean-install
+This guide targets the `v3.6.4` release. Select the clean-install
 guide when the destination is empty. Select this guide when any existing note,
 attachment, or configuration must be preserved. Never run `power init` inside
 an existing knowledge base.
@@ -73,7 +73,7 @@ manifest instead of pretending that one command performs a lossless migration.
 
 ## Version-stamped executable facts
 
-This guide is verified against the `v3.6.3` release contract. CI checks these
+This guide is verified against the `v3.6.4` release contract. CI checks these
 facts against the executable capability manifest so an agent does not inherit
 an older migration recipe:
 
@@ -275,7 +275,7 @@ manifest checksum, and zero unaccounted authorized source files.
 
 ### 3.1 Install and preflight P.O.W.E.R.
 
-Use the `v3.6.3` environment from Getting Started and verify:
+Use the `v3.6.4` environment from Getting Started and verify:
 
 ```bash
 POWER_PYTHON=/absolute/path/to/venv/bin/python

--- a/docs/migration-guide.ua.md
+++ b/docs/migration-guide.ua.md
@@ -1,12 +1,12 @@
 ---
 type: Resource
-title: "Міграція для AI-агента: будь-яка Markdown-база знань у P.O.W.E.R. v3.6.3"
+title: "Міграція для AI-агента: будь-яка Markdown-база знань у P.O.W.E.R. v3.6.4"
 description: "Fail-closed manifest-driven протокол міграції наявної Markdown-бази знань у перевірений P.O.W.E.R. vault без зміни джерела."
 tags: [power, migration, guide, ai-agents, safety, verification]
 timestamp: 2026-08-17T12:00:00+03:00
 ---
 
-# Міграція для AI-агента: будь-яка Markdown-база знань у P.O.W.E.R. v3.6.3
+# Міграція для AI-агента: будь-яка Markdown-база знань у P.O.W.E.R. v3.6.4
 
 Цей гід є execution contract для будь-якого AI-агента з доступом до файлової
 системи. Він переносить Markdown або Obsidian knowledge base у канонічну
@@ -17,7 +17,7 @@ rollback path.
 [«Початок роботи»](getting-started.ua.md). Для runtime setup на Windows 11 25H2
 спочатку виконайте [Windows-гід](windows-11-installation.ua.md).
 
-Цей гід стосується релізу `v3.6.3`. Обирайте гід чистої
+Цей гід стосується релізу `v3.6.4`. Обирайте гід чистої
 установки, коли destination порожній. Обирайте цей гід, коли потрібно зберегти
 будь-яку наявну нотатку, attachment або configuration. Ніколи не запускайте
 `power init` усередині наявної бази знань.
@@ -73,7 +73,7 @@ rollback path.
 
 ## Версійовані executable facts
 
-Цей гід перевірено проти contract релізу `v3.6.3`. CI звіряє ці факти з
+Цей гід перевірено проти contract релізу `v3.6.4`. CI звіряє ці факти з
 executable capability manifest, щоб агент не успадковував старий migration
 recipe:
 
@@ -273,7 +273,7 @@ manifest checksum і нуль unaccounted authorized files.
 
 ### 3.1 Встановіть і перевірте P.O.W.E.R.
 
-Використовуйте `v3.6.3` environment із clean-install гіда:
+Використовуйте `v3.6.4` environment із clean-install гіда:
 
 ```bash
 POWER_PYTHON=/absolute/path/to/venv/bin/python

--- a/release/models.lock.json
+++ b/release/models.lock.json
@@ -1,6 +1,6 @@
 {
     "schema_version": 1,
-    "release": "3.6.3",
+    "release": "3.6.4",
     "canonical_embedding": {
         "provider": "bge-m3-onnx",
         "repository": "aapot/bge-m3-onnx",

--- a/skills/power/SKILL.md
+++ b/skills/power/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: power
-version: 3.6.3
-description: P.O.W.E.R. 3.6.3 — Hybrid Knowledge Management Framework (P.A.R.A. + OKF v0.1 + Graph RAG + LLM-Wiki + Execution Rules).
+version: 3.6.4
+description: P.O.W.E.R. 3.6.4 — Hybrid Knowledge Management Framework (P.A.R.A. + OKF v0.1 + Graph RAG + LLM-Wiki + Execution Rules).
 ---
 
 # ⚡ P.O.W.E.R. Knowledge Management Skill

--- a/skills/power/references/runtime-contract.md
+++ b/skills/power/references/runtime-contract.md
@@ -6,7 +6,7 @@ sync/doctor правила. Авторитетна правда — `power docto
 
 ## Runtime version
 
-`v3.6.3` — runtime contract: **25 CLI commands** + **20 MCP tools** (FastMCP 3.x).
+`v3.6.4` — runtime contract: **25 CLI commands** + **20 MCP tools** (FastMCP 3.x).
 
 ## CLI (25 команд)
 


### PR DESCRIPTION
Make the full test suite (incl. semantic/bge-m3) green for 3.6.4.

- Skill SKILL.md + runtime-contract.md version markers -> 3.6.4
- migration-guide(.ua) + getting-started(.ua) + mcp-client-onboarding(.ua) + index: wheel pin + versioned facts -> power_framework-3.6.4-py3-none-any.whl
- release/models.lock.json release field -> 3.6.4

No core-logic change. Verified: 1122 passed, 11 skipped, 0 failed with [semantic,rerank] extras + bge-m3 snapshot.