### PR TITLE
feat: publish POWER suite 3.7 contracts

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,6 +1,6 @@
 # P.O.W.E.R. Framework — Agent Instructions
 
-Python 3.11+ toolkit for AI-native Second Brain management. CLI (`power`, 25 top-level
+Python 3.11+ toolkit for AI-native Second Brain management. CLI (`power`, 26 top-level
 commands) + local MCP server (20 tools).
 
 ## Project Structure
@@ -8,7 +8,7 @@ commands) + local MCP server (20 tools).
 ```
 src/power_framework/       # Core library
   core/                    #   models, parser, indexer, linter, searcher, application service
-  mcp/                     #   FastMCP-3.x server (20 async tools)
+  mcp/                     #   official MCP SDK v2 server (20 async tools)
 tests/                     # Pytest suite; CI enforces coverage >=70%
 scripts/                   # Dev/CI utilities
 docs/                      # MkDocs-material documentation site
@@ -44,7 +44,7 @@ pre-commit run --all-files # Git hooks (ruff + mypy + pip-audit)
 | `core/linter.py`      | Health checks: links, metadata, orphans, stale/expired |
 | `core/searcher.py`    | FTS5/dense/hybrid/reranked search (`auto` default; labelled FTS fallback) |
 | `experimental/embeddings.py` | Optional BGE-M3 ONNX (1024d) + MiniLM fallback       |
-| `mcp/power_server.py` | FastMCP 3.x, 20 async tools, stdio/loopback HTTP + /health  |
+| `mcp/power_server.py` | official MCP SDK v2, 20 async tools, stdio/loopback HTTP + /health |
 
 ## Workflow
 
@@ -60,7 +60,7 @@ pre-commit run --all-files # Git hooks (ruff + mypy + pip-audit)
 - Base: `pydantic>=2.0`, `pyyaml>=6.0`, `pathspec>=0.12`, `defusedxml>=0.7.1` — offline FTS/core path
 - `semantic` extra: `onnxruntime`, `tokenizers`, `huggingface-hub`, and `numpy`
 - `rerank` extra: `fastembed` and its explicit neural runtime dependencies
-- `remote`/development: `fastmcp>=3.2` — local MCP server framework
+- `mcp`/`remote`: `mcp>=2.0,<3.0` — official local MCP server/client SDK
 
 ## Skills (on-demand)
 

--- a/.agents/INSTRUCTIONS.md
+++ b/.agents/INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # P.O.W.E.R. Framework — Agent Instructions
 
-Python 3.11+, hatchling, Pydantic v2, local FTS by default, and optional FastMCP/neural extras.
+Python 3.11+, hatchling, Pydantic v2, local FTS by default, and optional official MCP/neural extras.
 
 ## Commands
 
@@ -35,7 +35,7 @@ mypy src/power_framework/  # type check
 src/power_framework/
 ├── core/          # CLI, models, parser, indexer, linter, searcher, application service
 ├── experimental/  # opt-in dense, graph, reranker, query-expansion and ROT adapters
-├── mcp/           # FastMCP 3.x local server — 20 async tools
+├── mcp/           # official MCP SDK v2 local server — 20 async tools
 tests/             # pytest, asyncio_mode=auto, coverage >= 70%
 scripts/           # utility scripts (excluded from ruff T20/S310)
 ```

--- a/.agents/mcp_servers/power_server.py
+++ b/.agents/mcp_servers/power_server.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
 P.O.W.E.R. MCP Server entry-point for OpenCode/Antigravity CLI.
-This script launches the FastMCP 3.x server from power_framework.mcp.
+This script launches the official MCP SDK v2 server from power_framework.mcp.
 
-Version: 3.6.5
-Updated: 2026-08-17
+Version: 3.6.6
+Updated: 2026-08-21
 """
 
 import os
@@ -21,8 +21,8 @@ if os.path.isfile(_env_path):
                 if _k not in os.environ:
                     os.environ[_k] = _v
 
-# Run the power_framework MCP server
-from power_framework.mcp import run  # type: ignore  # noqa: E402
+# Run the public power-mcp entry point.
+from power_framework.mcp.entrypoint import main  # type: ignore  # noqa: E402
 
 if __name__ == "__main__":
-    run()
+    main()

--- a/.agents/skills/holistic-analysis/SKILL.md
+++ b/.agents/skills/holistic-analysis/SKILL.md
@@ -42,7 +42,7 @@ Verify against this checklist:
 - Are background threads constrained (`ThreadPoolExecutor` instead of raw threads)?
 - Is the image/codebase clean (no systemd artifacts, no empty directories)?
 - Does the vault pass `power lint` with exit code 0?
-- Are all 20 MCP tools functional via the FastMCP 3.x server?
+- Are all 20 MCP tools functional via the official MCP Python SDK v2 server?
 - Is the `models.lock.json` SHA-pinned for both `canonical_embedding` and `canonical_reranker`?
 - Does the semantic GT (`--gt-mode semantic`) show `ndcg@5(reranked) > ndcg@5(fts)`?
 

--- a/.agents/skills/power/references/runtime-contract.md
+++ b/.agents/skills/power/references/runtime-contract.md
@@ -6,9 +6,9 @@ sync/doctor правила. Авторитетна правда — `power docto
 
 ## Runtime version
 
-`v3.6.6` — runtime contract: **25 CLI commands** + **20 MCP tools** (FastMCP 3.x).
+`v3.6.6` — runtime contract: **26 CLI commands** + **20 MCP tools** (official MCP Python SDK v2).
 
-## CLI (25 команд)
+## CLI (26 команд)
 
 1. `power init <path>` — створити структуру vault
 2. `power lint <path>` — перевірка метаданих, посилань, orphan
@@ -35,8 +35,9 @@ sync/doctor правила. Авторитетна правда — `power docto
 23. `power control-plane <path> [--apply]` — preview або materialize visible status view
 24. `power maintenance <path> [--apply]` — hash-bound preview/apply для reversible repairs
 25. `power migrate-state <path>` — content-free read-only state-plane inventory; apply is fail-closed
+26. `power integrations <doctor|mcp-config|skill-check|skill-install|install>` — generic dry-run-first suite integration and managed native install flows
 
-## MCP Tools (20) — FastMCP 3.x
+## MCP Tools (20) — official MCP Python SDK v2
 
 - Discovery: `get_server_info` — versioned runtime, configured vault, coverage,
   and embedding configuration; `probe_provider=true` is an explicit no-download
@@ -152,8 +153,9 @@ power sync PATH [--fts-only] [--force] [--strict | --allow-partial] [--accept-de
 - Reranker: `onnx-community/bge-reranker-v2-m3-ONNX` (SHA-pinned, Apache-2.0);
   `jinaai/jina-reranker-v2-base-multilingual` (CC-BY-NC) — явний opt-in.
 - Search default: `auto`; canonical path is verified dense when ready and labelled FTS otherwise. Explicit `semantic` remains fail-closed.
-- MCP entry-point: `python -m power_framework.mcp`; `POWER_VAULT_DIR` обов'язковий
-  і задає єдиний доступний vault.
+- MCP entry-point: `power-mcp` (with `python -m power_framework.mcp` retained as a
+  compatibility module entrypoint); `POWER_VAULT_DIR` обов'язковий і задає
+  єдиний доступний vault.
 - Device: `POWER_EMBED_DEVICE` / `POWER_RERANKER_DEVICE`
   (`auto`, `cpu`, `cuda`, `rocm`, `directml`).
 - Resource control: `POWER_EMBED_BATCH_SIZE`, `POWER_EMBED_NUM_THREADS`,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install locked development environment
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.2"
           python -m pip install uv==0.11.33
           uv sync --locked --group dev
 
@@ -91,7 +91,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.2"
           python -m pip install uv==0.11.33
           uv sync --locked --group dev --extra semantic --extra rerank
 
@@ -135,7 +135,7 @@ jobs:
 
       - name: Install only the locked base runtime
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.2"
           python -m pip install uv==0.11.33
           base_env="$RUNNER_TEMP/power-base"
           UV_PROJECT_ENVIRONMENT="$base_env" uv sync --locked --no-dev
@@ -168,7 +168,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.2"
           python -m pip install uv==0.11.33
           uv sync --locked --group dev
 
@@ -283,7 +283,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.2"
           python -m pip install uv==0.11.33
           uv sync --locked --group dev
 
@@ -304,7 +304,7 @@ jobs:
 
       - name: Install locked runtime dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.2"
           python -m pip install uv==0.11.33
           uv sync --locked --group dev
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.2"
           python -m pip install uv==0.11.33
           uv sync --locked --group dev
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install the locked release-gate environment
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.2"
           python -m pip install uv==0.11.33
           uv sync --locked --group dev --extra semantic --extra rerank
 
@@ -176,7 +176,7 @@ jobs:
 
       - name: Install the locked upgrade environment
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.2"
           python -m pip install uv==0.11.33
           uv sync --locked --group dev
 
@@ -239,7 +239,7 @@ jobs:
 
       - name: Install build tools and framework dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.2"
           pip install build .
       - name: Download Phase 8 technical receipts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Unlike generic knowledge management tools, P.O.W.E.R. is designed from the groun
 - **Knowledge Graph** — `related` field connects notes across the vault; visualized in sub-indexes for Graph RAG workflows
 - **Freshness Monitoring** — linter detects stale/expired notes based on `expiry` metadata field
 - **Agent Auto-Ingest** — `synthesize_session` MCP tool lets agents autonomously create permanent knowledge artifacts with governance + graph links + full catalog maintenance
-- **MCP-native** — expose 20 tools to MCP-compatible AI clients through FastMCP 3.x
+- **MCP-native** — expose 20 tools to MCP-compatible AI clients through the official MCP Python SDK v2
 - **Truthful agent discovery** — call `get_server_info` first to verify the
   running package version, vault boundary, coverage, and explicit provider
   binding state; the default discovery call performs no model load or network access
@@ -56,7 +56,7 @@ the role-specific guides before touching a vault:
   executable acceptance gate, FTS, and MCP preflight
 - **[Windows 11 25H2](docs/windows-11-installation.md)** — complete PowerShell
   installation, Visual C++ prerequisite, exact interpreter paths, and checks
-- **[CLI reference](docs/cli.md)** — all 25 commands, flags, and actual exit behavior
+- **[CLI reference](docs/cli.md)** — all 26 commands, flags, and actual exit behavior
 - **[MCP server](docs/mcp-server.md)** — all 20 governed tools, rate limits,
   configured-vault boundary, and untrusted retrieval contract
 - **[Migration guide](docs/migration-guide.md)** — 6-phase, manifest/hash-driven
@@ -123,7 +123,7 @@ made for `v3.6.6`. Windows and macOS have no scheduled release target.
 
 | Feature                          | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **CLI**                          | 25 commands, including `power doctor` for read-only runtime/index diagnosis, `power connect` for conflict-safe local MCP setup, `power cache` for namespace hygiene, `power import` for preflighted Markdown migration, `power memory` for explicit proposal/approval, `power handoff` for compatibility workflows, and `power task` for canonical Task v2 lifecycle management                                                                                                                                                                                                                                  |
+| **CLI**                          | 26 commands, including `power doctor` for read-only runtime/index diagnosis, `power connect` for conflict-safe local MCP setup, `power integrations` for generic suite installers and Skill/config plans, `power cache` for namespace hygiene, `power import` for preflighted Markdown migration, `power memory` for explicit proposal/approval, `power handoff` for compatibility workflows, and `power task` for canonical Task v2 lifecycle management                                                                                                                                                                                                                                  |
 | **MCP Server**                   | 20 tools, including governed memory context, proposal, apply, validation, history, `handoff_work`, and search-index synchronization operations                                                                                                                                                                                                                                                                                                                                                    |
 | **OKF Validation**               | Pydantic v2 schemas enforce strict metadata on every note with governance (`owner`, `status`, `expiry`)                                                                                                                                                                                                                                                                                                                                                                             |
 | **Knowledge Graph (Graph RAG)**  | `related` field in OKF frontmatter supporting `TypedRelation` (path, relation, confidence) with BFS traversal and Mermaid diagram export (`to_mermaid`)                                                                                                                                                                                                                                                                                                                             |
@@ -292,8 +292,8 @@ pip install https://github.com/weby-homelab/power-framework/releases/download/v3
 {
     "mcpServers": {
         "power": {
-            "command": "python3",
-            "args": ["-m", "power_framework.mcp"],
+            "command": "power-mcp",
+            "args": [],
             "env": {
                 "POWER_VAULT_DIR": "/path/to/your/my-vault"
             }
@@ -308,7 +308,7 @@ pip install https://github.com/weby-homelab/power-framework/releases/download/v3
 "mcp": {
   "power": {
     "type": "local",
-    "command": ["python3", "-m", "power_framework.mcp"],
+    "command": ["power-mcp"],
     "environment": {
       "POWER_VAULT_DIR": "/path/to/your/my-vault"
     },
@@ -456,7 +456,7 @@ flowchart TD
         LogMD[("📜 log.md (Change Log)")]:::wiki
     end
 
-    subgraph AI ["🤖 AI Agent (FastMCP 3.x)"]
+    subgraph AI ["🤖 AI Agent (official MCP SDK v2)"]
         Tools[["🔌 20 Async MCP Tools (stdio/HTTP)"]]:::agent
         Search[["🔍 Hybrid / Reranked Search"]]:::agent
         ROT{{"🛠️ ROT & Contradiction Audit (Semantic/LLM)"}}:::agent
@@ -525,8 +525,8 @@ flowchart TD
 | `core/markdown_checks.py`                 | Markdown quality checks: trailing whitespace, list markers, header jumps                                                                                                                                                           |
 | `core/constants.py`                       | Centralized exclusion lists and system constants                                                                                                                                                                                   |
 | `core/utils.py`                           | Path traversal protection, atomic writes, backups, rate limiter                                                                                                                                                                    |
-| `core/cli.py`                             | Command-line interface with 25 commands, including read-only doctor diagnostics, conflict-safe MCP connection plans, preflighted import, transactional memory, compatibility handoff workflows, and canonical Task v2 lifecycle management                                                                              |
-| `mcp/power_server.py`                     | FastMCP 3.x server with 20 async tools, loopback HTTP transport, and `/health`                                                                                                                                                     |
+| `core/cli.py`                             | Command-line interface with 26 commands, including read-only doctor diagnostics, generic suite integration plans, conflict-safe MCP connection plans, preflighted import, transactional memory, compatibility handoff workflows, and canonical Task v2 lifecycle management                                                                              |
+| `mcp/power_server.py`                     | Official MCP SDK v2 server with 20 async tools, stdio/loopback HTTP transport, and `/health`                                                                                                                                                     |
 
 All components share `power_framework.core` as the single source of truth.
 

--- a/README.ua.md
+++ b/README.ua.md
@@ -31,7 +31,7 @@ P.O.W.E.R. — це гібридна система, створена для п�
 - **Knowledge Graph** — поле `related` зв'язує нотатки між собою для Graph RAG
 - **Freshness Monitoring** — лінтер виявляє застарілі нотатки за полем `expiry`
 - **Agent Auto-Ingest** — MCP інструмент `synthesize_session` для автономного створення нотаток агентами з governance + graph links + index
-- **MCP-нативний** — 20 інструментів доступні MCP-сумісним AI-клієнтам через FastMCP 3.x
+- **MCP-нативний** — 20 інструментів доступні MCP-сумісним AI-клієнтам через офіційний MCP Python SDK v2
 - **Правдива discovery для агентів** — спочатку викликайте `get_server_info`,
   щоб перевірити версію запущеного пакета, vault boundary, coverage і явний
   стан provider binding; стандартний виклик не завантажує модель і не звертається до мережі
@@ -56,7 +56,7 @@ P.O.W.E.R. створений для роботи як людьми, так і A
   vault, executable acceptance gate, FTS і MCP preflight
 - **[Windows 11 25H2](docs/windows-11-installation.ua.md)** — повне
   PowerShell-встановлення, Visual C++ prerequisite, точні interpreter paths і checks
-- **[CLI reference](docs/cli.md)** — усі 25 команд, flags і реальна exit behavior
+- **[CLI reference](docs/cli.md)** — усі 26 команд, flags і реальна exit behavior
 - **[MCP server](docs/mcp-server.md)** — усі 20 governed tools, rate limits,
   configured-vault boundary і untrusted retrieval contract
 - **[Migration guide](docs/migration-guide.ua.md)** — 6-фазна manifest/hash-driven
@@ -122,7 +122,7 @@ GPU claim. Windows і macOS не мають запланованого release t
 
 | Функція                          | Що робить                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **CLI**                          | 25 команд, включно з `power doctor` для read-only діагностики runtime/index, `power connect` для conflict-safe local MCP setup, `power cache` для гігієни namespace, `power import` для preflighted Markdown migration, `power memory` для явного proposal/approval, `power handoff` для compatibility workflows та `power task` для canonical Task v2 lifecycle management                                                                                                                                                                                            |
+| **CLI**                          | 26 команд, включно з `power doctor` для read-only діагностики runtime/index, `power integrations` для generic suite/Skill/launcher plans, `power connect` для conflict-safe local MCP setup, `power cache` для гігієни namespace, `power import` для preflighted Markdown migration, `power memory` для явного proposal/approval, `power handoff` для compatibility workflows та `power task` для canonical Task v2 lifecycle management                                                                                                                                                                                            |
 | **MCP Server**                   | 20 інструментів, включно з керованими операціями memory context, proposal, apply, validation, history та `handoff_work`                                                                                                                                                                                                                                                                                                                                                                              |
 | **OKF Validation**               | Pydantic v2 схеми забезпечують строгі OKF-метадані на кожній нотатці з governance-полями (`owner`, `status`, `expiry`)                                                                                                                                                                                                                                                                                                                                                               |
 | **Knowledge Graph (Graph RAG)**  | Поле `related` в OKF frontmatter з підтримкою `TypedRelation` (path, relation, confidence), BFS обходом та експортом підграфів у Mermaid-діаграми (`to_mermaid`)                                                                                                                                                                                                                                                                                                                     |
@@ -287,8 +287,8 @@ pip install https://github.com/weby-homelab/power-framework/releases/download/v3
 {
     "mcpServers": {
         "power": {
-            "command": "python3",
-            "args": ["-m", "power_framework.mcp"],
+            "command": "power-mcp",
+            "args": [],
             "env": {
                 "POWER_VAULT_DIR": "/path/to/your/my-vault"
             }
@@ -303,7 +303,7 @@ pip install https://github.com/weby-homelab/power-framework/releases/download/v3
 "mcp": {
   "power": {
     "type": "local",
-    "command": ["python3", "-m", "power_framework.mcp"],
+    "command": ["power-mcp"],
     "environment": {
       "POWER_VAULT_DIR": "/path/to/your/my-vault"
     },
@@ -451,7 +451,7 @@ flowchart TD
         LogMD[("📜 log.md (Лог змін)")]:::wiki
     end
 
-    subgraph AI ["🤖 AI-Агент (FastMCP 3.x)"]
+    subgraph AI ["🤖 AI-Агент (official MCP SDK v2)"]
         Tools[["🔌 19 асинхронних інструментів MCP"]]:::agent
         Search[["🔍 Гібридний / Reranked пошук"]]:::agent
         ROT{{"🛠️ Аудит ROT та суперечностей (Semantic/LLM)"}}:::agent
@@ -520,8 +520,8 @@ flowchart TD
 | `core/markdown_checks.py`                 | Перевірки якості Markdown: trailing whitespace, списки, заголовки                                                                                                                                                                                      |
 | `core/constants.py`                       | Централізовані списки виключень та системні константи                                                                                                                                                                                                  |
 | `core/utils.py`                           | Захист від path traversal, атомарний запис, бекапи, rate limiter                                                                                                                                                                                       |
-| `core/cli.py`                             | Командний рядок із 25 командами, включно з read-only doctor diagnostics, conflict-safe MCP connection plans, cache hygiene, preflighted import, transactional memory, compatibility handoff workflows і canonical Task v2 lifecycle management                                                                            |
-| `mcp/power_server.py`                     | FastMCP 3.x сервер із 20 async tools, loopback HTTP transport та `/health`                                                                                                                                                                             |
+| `core/cli.py`                             | Командний рядок із 26 командами, включно з read-only doctor diagnostics, generic suite integration plans, conflict-safe MCP connection plans, cache hygiene, preflighted import, transactional memory, compatibility handoff workflows і canonical Task v2 lifecycle management                                                                            |
+| `mcp/power_server.py`                     | Сервер official MCP SDK v2 із 20 async tools, stdio/loopback HTTP transport та `/health`                                                                                                                                                                             |
 
 Всі компоненти використовують `power_framework.core` як єдине джерело правди.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ src/power_framework/
 ├── py.typed            # PEP 561 marker
 ├── core/
 │   ├── __init__.py     # Stable core exports; optional exports are lazy
-│   ├── cli.py          # CLI entry point (argparse) — 25 commands
+│   ├── cli.py          # CLI entry point (argparse) — 26 commands
 │   ├── constants.py    # Centralized constants (exclusion lists, skip files, system dirs)
 │   ├── healer.py       # Frontmatter Healer
 │   ├── markdown_checks.py  # Markdown quality checks
@@ -35,7 +35,9 @@ src/power_framework/
 └── mcp/
     ├── __init__.py     # Package marker
     ├── __main__.py     # python -m entry point
-    └── power_server.py # FastMCP 3.x server (20 tools + health)
+    ├── entrypoint.py   # public power-mcp launcher and preflight
+    ├── preflight.py    # dependency-light vault boundary check
+    └── power_server.py # official MCP SDK v2 server (20 tools + health)
 
 tests/
 ├── test_cli.py         # CLI functional tests
@@ -57,7 +59,9 @@ tests/
 ## Design decisions
 
 - **`src/` layout** — Standard Python packaging, prevents import confusion
-- **FastMCP 3.x (Prefect)** — Modern MCP framework with structured `ToolError`, `ErrorHandlingMiddleware`, `mask_error_details`, async tools, HTTP transport
+- **Official MCP Python SDK v2** — Modern MCP server/client primitives with
+  legacy and 2026-07-28 protocol-era interoperability, structured `ToolError`,
+  async tools, stdio, and loopback HTTP transport
 - **Pydantic v2** — `model_dump()`, strict validation, `field_validator`, UTC-aware timestamps
 - **Atomic file writes** — `os.replace()` for crash-safe config persistence
 - **Path traversal protection** — `Path.relative_to()` boundary checking (not string-prefix)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@ This reference is aligned with the executable P.O.W.E.R. `v3.6.6` parser.
 
 ```text
 power [-h] [-v] [--verbose]
-      {init,lint,index,ingest,import,search,cache,doctor,connect,memory,handoff,task,sync,rot,archive,status,control-plane,maintenance,migrate-state,cron,heal,markdown-check,suggest-related,synthesize,rename} ...
+      {init,lint,index,ingest,import,search,cache,doctor,integrations,connect,memory,handoff,task,sync,rot,archive,status,control-plane,maintenance,migrate-state,cron,heal,markdown-check,suggest-related,synthesize,rename} ...
 ```
 
 ## Global options
@@ -483,3 +483,25 @@ The transaction refuses symlinked, malformed, commented JSONC, or foreign
 pre-image hash, writes atomically, and creates a `.power-backups` copy before
 changing an existing config. A stale plan must be regenerated; the command
 never starts a client or contacts a network service.
+
+### `integrations`
+
+Build generic, dry-run-first integration plans for the official MCP launcher,
+the packaged POWER Skill, and the managed native Linux installation profile.
+Every write requires `--apply --approved`; Skill installation is atomic and
+never overwrites a non-matching target. Native installation accepts exact wheel
+paths, verifies their SHA-256 digests, uses only the managed
+`~/.local/share/power/venv`, and writes launchers under `~/.local/bin`.
+
+```text
+power integrations doctor
+power integrations mcp-config PATH [--client ...] [--config ...]
+power integrations skill-check [--target PATH]
+power integrations skill-install [--target PATH] [--apply --approved]
+power integrations install --power-wheel POWER.whl [--gui-wheel GUI.whl]
+                            [--home PATH] [--no-deps] [--apply --approved]
+```
+
+`mcp-config` defaults to the public `power-mcp` launcher. `doctor`, all plan
+commands, and omitted `--apply` paths are read-only; no remote service or
+client configuration is contacted during planning.

--- a/docs/documentation-inventory.ua.md
+++ b/docs/documentation-inventory.ua.md
@@ -19,7 +19,7 @@
 | `docs/windows-11-installation.ua.md` | Українська Windows-процедура | Семантично паритетна |
 | `docs/migration-guide.md` | Міграція наявної бази | Шість fail-closed фаз |
 | `docs/migration-guide.ua.md` | Українська міграція | Семантично паритетна |
-| `docs/cli.md` | Виконуваний CLI-контракт | 25 команд |
+| `docs/cli.md` | Виконуваний CLI-контракт | 26 команд |
 | `docs/mcp-server.md` | Виконуваний MCP-контракт | 20 інструментів |
 | `docs/mcp-client-onboarding.md` | Golden onboarding для чотирьох клієнтів | stdio shape + proposal gate |
 | `docs/mcp-client-onboarding.ua.md` | Український golden onboarding | Семантично паритетний |
@@ -47,7 +47,8 @@
 ## Усунений дрейф
 
 - Старий MCP-інвентар замінено на фактичні `20` інструментів; CLI
-  задокументовано як `25` top-level команд.
+  задокументовано як `26` top-level команд.
+- До surface додано generic `power integrations` для suite, Skill і launcher plans.
 - `reranked` більше не називається стандартним режимом: код використовує `semantic`,
   а reranking вмикається явно.
 - Видалено небезпечне оновлення через destructive reset, непереносний `/tmp`,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,8 +40,8 @@ POWER_CLI="$HOME/.local/share/power-framework/venv/bin/power"
 
 The base release wheel is FTS-only: it does not install ONNX Runtime, model
 tokenizers, numerical packages, or the optional MCP transport. Add the explicit
-`remote` extra before configuring MCP, and add `semantic` only for local dense
-experiments.
+`mcp` (or compatibility alias `remote`) extra before configuring MCP, and add
+`semantic` only for local dense experiments.
 
 Verify the executable, package metadata, and lean import:
 
@@ -56,11 +56,11 @@ Verify the executable, package metadata, and lean import:
 Both version commands must report `3.6.6`; the final command must print
 `lean FTS import: OK`.
 
-For local MCP, install the optional remote transport from the same wheel:
+For local MCP, install the official SDK extra from the same wheel:
 
 ```bash
 "$POWER_PYTHON" -m pip install \
-  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.6/power_framework-3.6.6-py3-none-any.whl"
+  "power-framework[mcp] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.6/power_framework-3.6.6-py3-none-any.whl"
 ```
 
 ### Alternative: install from the pinned tag
@@ -161,8 +161,8 @@ the same virtual-environment interpreter used above:
 {
   "mcpServers": {
     "power": {
-      "command": "/home/YOU/.local/share/power-framework/venv/bin/python",
-      "args": ["-m", "power_framework.mcp"],
+      "command": "/home/YOU/.local/share/power-framework/venv/bin/power-mcp",
+      "args": [],
       "env": {
         "POWER_VAULT_DIR": "/home/YOU/Documents/power-vault"
       }
@@ -174,8 +174,7 @@ the same virtual-environment interpreter used above:
 Preflight the exact interpreter and vault before restarting the client:
 
 ```bash
-POWER_VAULT_DIR="$POWER_VAULT" "$POWER_PYTHON" -c \
-  'import os; from pathlib import Path; import power_framework.mcp; p=Path(os.environ["POWER_VAULT_DIR"]); assert p.is_dir(); print("MCP preflight: OK")'
+POWER_VAULT_DIR="$POWER_VAULT" "$POWER_VENV/bin/power-mcp" preflight
 ```
 
 Restart long-lived MCP clients after changing their configuration or Python
@@ -214,7 +213,7 @@ it up before removing either location.
 - CLI and distribution metadata both report `3.6.6`.
 - `power_framework` imports successfully without neural or MCP extras.
 - If MCP is configured, the explicit `remote` extra is installed and MCP
-  preflight imports `power_framework.mcp` successfully.
+  preflight validates the configured vault through the public `power-mcp` launcher.
 - `init`, `ingest`, `index --strict`, `lint`, and `markdown-check` exit `0`.
 - FTS sync exits `0` and FTS search returns the first note.
 - MCP preflight uses the same interpreter and prints `MCP preflight: OK`.

--- a/docs/getting-started.ua.md
+++ b/docs/getting-started.ua.md
@@ -40,8 +40,8 @@ POWER_CLI="$HOME/.local/share/power-framework/venv/bin/power"
 
 Базовий release wheel є FTS-only: він не встановлює ONNX Runtime, model
 tokenizers, numerical packages або optional MCP transport. Перед MCP додайте
-явний extra `remote`, а `semantic` використовуйте лише для локальних dense
-експериментів.
+явний extra `mcp` (або compatibility alias `remote`), а `semantic`
+використовуйте лише для локальних dense експериментів.
 
 Перевірте executable, package metadata та lean import:
 
@@ -56,11 +56,11 @@ tokenizers, numerical packages або optional MCP transport. Перед MCP д�
 Обидві команди версії мають показати `3.6.6`, а остання команда —
 `lean FTS import: OK`.
 
-Для локального MCP встановіть optional transport з того самого wheel:
+Для локального MCP встановіть official SDK extra з того самого wheel:
 
 ```bash
 "$POWER_PYTHON" -m pip install \
-  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.6/power_framework-3.6.6-py3-none-any.whl"
+  "power-framework[mcp] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.6/power_framework-3.6.6-py3-none-any.whl"
 ```
 
 ### Альтернатива: встановлення із закріпленого tag
@@ -162,8 +162,8 @@ interpreter virtual environment:
 {
   "mcpServers": {
     "power": {
-      "command": "/home/YOU/.local/share/power-framework/venv/bin/python",
-      "args": ["-m", "power_framework.mcp"],
+      "command": "/home/YOU/.local/share/power-framework/venv/bin/power-mcp",
+      "args": [],
       "env": {
         "POWER_VAULT_DIR": "/home/YOU/Documents/power-vault"
       }
@@ -175,8 +175,7 @@ interpreter virtual environment:
 Перевірте точний interpreter і vault перед перезапуском клієнта:
 
 ```bash
-POWER_VAULT_DIR="$POWER_VAULT" "$POWER_PYTHON" -c \
-  'import os; from pathlib import Path; import power_framework.mcp; p=Path(os.environ["POWER_VAULT_DIR"]); assert p.is_dir(); print("MCP preflight: OK")'
+POWER_VAULT_DIR="$POWER_VAULT" "$POWER_VENV/bin/power-mcp" preflight
 ```
 
 Після зміни конфігурації або Python environment перезапустіть long-lived

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ and hash, and make cutover reversible.
 ## Executable contract
 
 - Python 3.11 or newer.
-- 25 top-level CLI commands; see the [CLI reference](cli.md).
+- 26 top-level CLI commands; see the [CLI reference](cli.md).
 - 20 MCP tools; see the [MCP server reference](mcp-server.md).
 - `auto` is the default search profile: verified dense when ready, otherwise
   labelled FTS; `semantic` and `reranked` are explicit opt-ins.

--- a/docs/mcp-client-onboarding.md
+++ b/docs/mcp-client-onboarding.md
@@ -28,7 +28,7 @@ POWER_VAULT="$HOME/Documents/power-vault"
 
 python3 -m venv "$POWER_VENV"
 "$POWER_PYTHON" -m pip install \
-  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.6/power_framework-3.6.6-py3-none-any.whl"
+  "power-framework[mcp] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.6/power_framework-3.6.6-py3-none-any.whl"
 # Only for a new or empty vault:
 "$POWER_CLI" init "$POWER_VAULT"
 "$POWER_PYTHON" -c 'import sys; print(sys.executable)'
@@ -39,13 +39,17 @@ configuration below. The MCP process must receive `POWER_VAULT_DIR`; it is the
 configured vault boundary. The server is local stdio, so its stdout is
 reserved for MCP protocol traffic.
 
+The installed public launcher is `power-mcp`. The source-checkout compatibility
+entry point `python -m power_framework.mcp` remains available for tests and
+legacy wrappers, but it is not the canonical client configuration.
+
 Do not point a client at a repository wrapper, a shell script that loads
 secrets, or a different Python installation. Do not add a second vault path to
 the client configuration.
 
 ## Client configurations
 
-Replace `/absolute/path/to/python` and `/absolute/path/to/vault` in exactly one
+Replace `/absolute/path/to/power-mcp` and `/absolute/path/to/vault` in exactly one
 of the following client configurations.
 
 <!-- power-client-config:claude-desktop -->
@@ -59,8 +63,8 @@ macOS, or `~/.config/Claude/claude_desktop_config.json` on Linux:
 {
   "mcpServers": {
     "power": {
-      "command": "/absolute/path/to/python",
-      "args": ["-m", "power_framework.mcp"],
+      "command": "/absolute/path/to/power-mcp",
+      "args": [],
       "env": {
         "POWER_VAULT_DIR": "/absolute/path/to/vault"
       }
@@ -79,8 +83,8 @@ Add the `power` entry to `~/.gemini/settings.json`:
 {
   "mcpServers": {
     "power": {
-      "command": "/absolute/path/to/python",
-      "args": ["-m", "power_framework.mcp"],
+      "command": "/absolute/path/to/power-mcp",
+      "args": [],
       "env": {
         "POWER_VAULT_DIR": "/absolute/path/to/vault"
       }
@@ -101,8 +105,8 @@ Add this table to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.power]
-command = "/absolute/path/to/python"
-args = ["-m", "power_framework.mcp"]
+command = "/absolute/path/to/power-mcp"
+args = []
 env = { "POWER_VAULT_DIR" = "/absolute/path/to/vault" }
 ```
 
@@ -122,7 +126,7 @@ Add the `power` entry directly under `mcp` in `~/.config/opencode/opencode.jsonc
   "mcp": {
     "power": {
       "type": "local",
-      "command": ["/absolute/path/to/python", "-m", "power_framework.mcp"],
+      "command": ["/absolute/path/to/power-mcp"],
       "environment": {
         "POWER_VAULT_DIR": "/absolute/path/to/vault"
       },
@@ -144,7 +148,7 @@ the server name, and `--` separates Claude options from the launch command:
 ```bash
 claude mcp add --transport stdio \
   --env POWER_VAULT_DIR=/absolute/path/to/vault \
-  power -- /absolute/path/to/python -m power_framework.mcp
+  power -- /absolute/path/to/power-mcp
 ```
 
 Run `claude mcp list` and then `/mcp` inside a session to verify the server.

--- a/docs/mcp-client-onboarding.ua.md
+++ b/docs/mcp-client-onboarding.ua.md
@@ -28,7 +28,7 @@ POWER_VAULT="$HOME/Documents/power-vault"
 
 python3 -m venv "$POWER_VENV"
 "$POWER_PYTHON" -m pip install \
-  "power-framework[remote] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.6/power_framework-3.6.6-py3-none-any.whl"
+  "power-framework[mcp] @ https://github.com/weby-homelab/power-framework/releases/download/v3.6.6/power_framework-3.6.6-py3-none-any.whl"
 # Лише для нового або порожнього vault:
 "$POWER_CLI" init "$POWER_VAULT"
 "$POWER_PYTHON" -c 'import sys; print(sys.executable)'
@@ -39,13 +39,17 @@ python3 -m venv "$POWER_VENV"
 vault. Сервер працює через локальний stdio, тому його stdout зарезервований для
 MCP-протоколу.
 
+Встановлений public launcher — `power-mcp`. Compatibility entry point
+`python -m power_framework.mcp` залишається для тестів і legacy wrappers, але не
+є канонічною конфігурацією клієнта.
+
 Не підключайте клієнт до repository wrapper, shell-скрипту, який завантажує
 секрети, або іншої установки Python. Не додавайте до клієнтської конфігурації
 другий шлях до vault.
 
 ## Конфігурації клієнтів
 
-Замініть `/absolute/path/to/python` і `/absolute/path/to/vault` рівно в одній із
+Замініть `/absolute/path/to/power-mcp` і `/absolute/path/to/vault` рівно в одній із
 наведених конфігурацій.
 
 <!-- power-client-config:claude-desktop -->
@@ -59,8 +63,8 @@ MCP-протоколу.
 {
   "mcpServers": {
     "power": {
-      "command": "/absolute/path/to/python",
-      "args": ["-m", "power_framework.mcp"],
+      "command": "/absolute/path/to/power-mcp",
+      "args": [],
       "env": {
         "POWER_VAULT_DIR": "/absolute/path/to/vault"
       }
@@ -79,8 +83,8 @@ MCP-протоколу.
 {
   "mcpServers": {
     "power": {
-      "command": "/absolute/path/to/python",
-      "args": ["-m", "power_framework.mcp"],
+      "command": "/absolute/path/to/power-mcp",
+      "args": [],
       "env": {
         "POWER_VAULT_DIR": "/absolute/path/to/vault"
       }
@@ -101,8 +105,8 @@ MCP-протоколу.
 
 ```toml
 [mcp_servers.power]
-command = "/absolute/path/to/python"
-args = ["-m", "power_framework.mcp"]
+command = "/absolute/path/to/power-mcp"
+args = []
 env = { "POWER_VAULT_DIR" = "/absolute/path/to/vault" }
 ```
 
@@ -123,7 +127,7 @@ project scope не потрібен навмисно.
   "mcp": {
     "power": {
       "type": "local",
-      "command": ["/absolute/path/to/python", "-m", "power_framework.mcp"],
+      "command": ["/absolute/path/to/power-mcp"],
       "environment": {
         "POWER_VAULT_DIR": "/absolute/path/to/vault"
       },
@@ -145,7 +149,7 @@ OpenCode використовує масив для `command` і `environment` �
 ```bash
 claude mcp add --transport stdio \
   --env POWER_VAULT_DIR=/absolute/path/to/vault \
-  power -- /absolute/path/to/python -m power_framework.mcp
+  power -- /absolute/path/to/power-mcp
 ```
 
 Виконайте `claude mcp list`, а потім `/mcp` усередині сесії, щоб перевірити

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,9 +1,10 @@
-# MCP Server (FastMCP 3.x)
+# MCP Server (official Python SDK v2)
 
 P.O.W.E.R. `v3.6.6` exposes 20 governed tools through the
 [Model Context Protocol](https://modelcontextprotocol.io), powered by
-[FastMCP 3.x](https://gofastmcp.com). MCP-compatible agents can validate,
-index, retrieve, and perform bounded writes in one configured vault.
+the official [MCP Python SDK v2](https://github.com/modelcontextprotocol/python-sdk).
+MCP-compatible agents can validate, index, retrieve, and perform bounded writes
+in one configured vault.
 
 ## Required vault boundary
 
@@ -21,7 +22,7 @@ configurations must use `POWER_VAULT_DIR`.
 
 ```bash
 POWER_VAULT_DIR=/absolute/path/to/vault \
-  /absolute/path/to/venv/bin/python -m power_framework.mcp
+  /absolute/path/to/venv/bin/power-mcp
 ```
 
 ### Local loopback HTTP
@@ -29,7 +30,7 @@ POWER_VAULT_DIR=/absolute/path/to/vault \
 ```bash
 POWER_VAULT_DIR=/absolute/path/to/vault \
 POWER_MCP_TRANSPORT=http \
-  /absolute/path/to/venv/bin/python -m power_framework.mcp
+  /absolute/path/to/venv/bin/power-mcp
 ```
 
 - host defaults to `127.0.0.1` and may be only `127.0.0.1` or `::1`;
@@ -56,7 +57,7 @@ Point the client to the exact interpreter where `power-framework` is installed:
   "mcpServers": {
     "power": {
       "command": "/home/YOU/.local/share/power-framework/venv/bin/python",
-      "args": ["-m", "power_framework.mcp"],
+      "args": [],
       "env": {
         "POWER_VAULT_DIR": "/home/YOU/Documents/power-vault"
       }
@@ -72,8 +73,8 @@ Windows paths and preflight commands.
 
 ## Error and retrieved-content boundaries
 
-Tools raise structured `ToolError` messages. FastMCP error masking and
-`ErrorHandlingMiddleware` hide internal tracebacks from clients.
+Tools raise structured SDK `ToolError` messages. POWER converts failures to
+bounded client-safe results and keeps tracebacks in the server log only.
 
 `search_vault_tool` returns a `power.retrieval-envelope.v1` object. The envelope
 and results are marked `trust: "untrusted"` and `data_only: true`; note text is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 
 [project.scripts]
 power = "power_framework.core.cli:main"
+power-mcp = "power_framework.mcp.entrypoint:main"
 
 [dependency-groups]
 dev = [
@@ -41,13 +42,14 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
+    "httpx>=0.27.0",
     "jsonschema>=4.23.0",
     "ruff>=0.8.0",
     "mypy>=1.13.0",
     "types-PyYAML>=6.0.0",
     "pre-commit>=4.0.0",
     "pip-audit>=2.7.0",
-    "fastmcp>=3.2,<4.0",
+    "mcp>=2.0,<3.0",
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.7.0",
 ]
@@ -58,13 +60,14 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
+    "httpx>=0.27.0",
     "jsonschema>=4.23.0",
     "ruff>=0.8.0",
     "mypy>=1.13.0",
     "types-PyYAML>=6.0.0",
     "pre-commit>=4.0.0",
     "pip-audit>=2.7.0",
-    "fastmcp>=3.2,<4.0",
+    "mcp>=2.0,<3.0",
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.7.0",
 ]
@@ -93,8 +96,11 @@ gpu = [
 ]
 fleet = []
 bench = []
+mcp = [
+    "mcp>=2.0,<3.0",
+]
 remote = [
-    "fastmcp>=3.2,<4.0",
+    "mcp>=2.0,<3.0",
 ]
 experimental = [
     "qwen3-embed>=1.12.0",
@@ -114,6 +120,7 @@ packages = ["src/power_framework"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/power_framework/data/semantic_gt.json" = "power_framework/data/semantic_gt.json"
+"skills/power" = "power_framework/data/skills/power"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/release/power-suite-architecture-v1.md
+++ b/release/power-suite-architecture-v1.md
@@ -1,0 +1,145 @@
+# POWER Suite Architecture v1
+
+Status: architecture freeze for the 3.6.7 RC and 3.7.0 release work
+Date: 2026-08-21
+
+## Authority and boundaries
+
+The suite has one canonical state model:
+
+```text
+Markdown/Git = authoritative knowledge source
+ApplicationService = business boundary
+TaskService = task truth
+DecisionService = decision truth
+Proposal/apply = canonical mutation path
+Receipts = core evidence
+GUI/MCP/CLI/Skills = adapters and consumers
+```
+
+Adapters may validate input, enforce their transport contract, and format a
+bounded response. They must not persist a second canonical state, call a
+lower-level canonical mutator directly, or treat retrieved note text as an
+executable instruction.
+
+## Canonical Linux workstation profile
+
+The managed native profile is one exact virtual environment with these stable
+launchers:
+
+```text
+~/.local/share/power/venv
+~/.local/bin/power
+~/.local/bin/power-mcp
+~/.local/bin/power-gui
+```
+
+The install and update harnesses operate only on the managed suite directory.
+They never mutate system Python, an arbitrary project virtualenv, or a hidden
+checkout. Every launcher resolves into the same managed environment and the
+same exact core/GUI candidate pair.
+
+The GUI launcher is available for the native workstation profile. A CLI/MCP
+only profile may omit it without changing the core or Skill contract.
+
+## Canonical local transport
+
+`power-mcp` is the public local entry point and defaults to MCP stdio. It
+requires one explicit, existing `POWER_VAULT_DIR` root and fails closed when
+the root is absent, invalid, or outside the configured boundary. Protocol
+frames are written to stdout; logs and diagnostics are written to stderr.
+
+The adapter owns no business state. MCP tool mutations route through
+`ApplicationService` and return the same content-free receipts and revisions
+as CLI and GUI calls. A client configuration contains an absolute launcher and
+the vault environment only; no vendor-specific business logic is required.
+
+## Portable Skill profile
+
+`skills/power/` is the single source tree and is shipped as release package
+data. It contains `SKILL.md`, `references/`, and bounded `scripts/`. The
+installed Skill is immutable with respect to the release candidate: its tree
+hash and compatible core version are recorded in the suite manifest. Generic
+installation is explicit, dry-run first, path-confined, atomic, idempotent,
+and does not overwrite unrelated agent files.
+
+## GUI profiles
+
+The native `systemd --user` unit is the canonical workstation service. It is
+opt-in, binds to loopback by default, uses a user-owned managed environment,
+reads mode-600 configuration when configuration is required, and has a bounded
+restart policy. Installation never enables it silently.
+
+The container GUI is a supported homelab/server profile, not the product
+foundation. It uses the exact GUI/core pair named by the suite manifest, runs
+non-root with a constrained capability set, keeps rebuildable cache state
+separate from native processes, and may share the canonical vault only through
+the documented mount. Host-native CLI/MCP and the container GUI must be able
+to operate on one disposable vault without turning cache or GUI state into
+authority.
+
+## Explicitly non-canonical
+
+The following are not release requirements and must not become hidden
+dependencies:
+
+```text
+Docker-only all-in-one
+mandatory POWER daemon
+remote unauthenticated MCP
+public MCP, Federation, A2A, or distributed multi-writer state
+```
+
+The existing maintainer fleet updater is operational infrastructure and stays
+separate from the product updater. The product updater consumes a complete,
+hash-bound suite manifest and uses stage/verify/activate/readback/rollback
+semantics. If that updater is not proven safe, automatic updates remain
+disabled and the documented exact-version manual path is used.
+
+## Evidence policy
+
+The release gates must use exact source and artifact identities. A passing
+unit test is not evidence for a clean install, a real subprocess protocol
+client, a container image, or a published artifact unless that gate actually
+runs the corresponding surface.
+
+`M2_HUMAN` remains `EXCLUDED_BY_POLICY`; sealed human evaluation remains
+`DO_NOT_OPEN`; no human retrieval-quality claim is emitted. Retrieval is not
+retuned as part of suite unification unless a direct code/config change
+invalidates the existing machine-only evidence.
+
+## Freeze inputs
+
+The clean worktrees for this implementation are based on the fetched public
+heads:
+
+| Component | Version/tag | Source SHA |
+| --- | --- | --- |
+| POWER core | 3.6.6 / `v3.6.6` | candidate base `origin/main` `527cc8a77187e9fa6d724b604d1a6634545da575`; tag commit `6c6b6ae52f4b29382f0d2ec82fbb4e75ba1f471a` |
+| POWER-GUI | 0.7.4 / `v0.7.4` | candidate base `origin/main` `068b4d32d5d55170de52c81a897526e3d640078a`; tag commit `f1c918c7a8c6de011ff0553f08d00675ad296f59` |
+
+The pre-existing dirty worktrees under `projects/P.O.W.E.R` and
+`projects/ai-second-brain-gui` are intentionally excluded from this freeze;
+they remain untouched and are not silently folded into the candidate.
+
+## Blocker ledger at freeze
+
+The following gates are open and must be closed or explicitly reported as
+NO-GO before a stable release claim:
+
+| ID | Area | Required evidence |
+| --- | --- | --- |
+| B0 | exact version pair | source/tag/version readback and compatibility manifest |
+| B1 | public MCP entry | `power-mcp` console script and clean stdio smoke |
+| B2 | MCP SDK | supported adapter inventory and dual-era subprocess gate |
+| B3 | business boundary | automated transport-boundary test with zero bypasses |
+| B4 | Skill packaging | wheel extraction, tree hash, generic install/check |
+| B5 | native suite | disposable HOME installer and content-free receipt |
+| B6 | manifest | candidate and final suite manifests with exact hashes |
+| B7 | native GUI | opt-in `systemd --user` lifecycle and native E2E |
+| B8 | container profile | pinned pair, non-root/health/cache evidence |
+| B9 | cross-runtime safety | host CLI/MCP plus container GUI concurrency/recovery |
+
+No feature ring is added to close these blockers. A blocker that cannot be
+fixed within the existing architecture produces a documented NO-GO rather than
+an unbounded redesign.

--- a/release/power-suite-candidate.json
+++ b/release/power-suite-candidate.json
@@ -1,0 +1,141 @@
+{
+  "schema": "power.suite.candidate.v1",
+  "status": "candidate-validation",
+  "generated_at": "2026-08-21T22:20:10+03:00",
+  "source": {
+    "power": {
+      "repository": "https://github.com/weby-homelab/power-framework",
+      "tag": "v3.6.6",
+      "version": "3.6.6",
+      "ref": "origin/main-candidate-base",
+      "sha": "527cc8a77187e9fa6d724b604d1a6634545da575",
+      "tag_commit": "6c6b6ae52f4b29382f0d2ec82fbb4e75ba1f471a",
+      "implementation_ref": "feature/power-suite-3.7",
+      "implementation_commit": "08ca9326dc849921db0c61a852ecb83cd6dd96b0"
+    },
+    "gui": {
+      "repository": "https://github.com/weby-homelab/ai-second-brain-gui",
+      "tag": "v0.7.4",
+      "version": "0.7.4",
+      "ref": "origin/main-candidate-base",
+      "sha": "068b4d32d5d55170de52c81a897526e3d640078a",
+      "tag_commit": "f1c918c7a8c6de011ff0553f08d00675ad296f59",
+      "implementation_ref": "feature/power-gui-suite-3.7",
+      "implementation_commit": "27ed678593647f000cc77462611df1fba43808d9"
+    }
+  },
+  "application": {
+    "schema": "power.application.v2",
+    "authority": "ApplicationService",
+    "receipts": "power.receipt.v1"
+  },
+  "native": {
+    "venv": "~/.local/share/power/venv",
+    "launchers": [
+      "~/.local/bin/power",
+      "~/.local/bin/power-mcp",
+      "~/.local/bin/power-gui"
+    ],
+    "transport": "mcp-stdio",
+    "system_python_mutation": false,
+    "daemon_required": false,
+    "fresh_home_install": "verified"
+  },
+  "mcp": {
+    "entry_point": "power-mcp",
+    "transport": "stdio",
+    "vault_root": "POWER_VAULT_DIR",
+    "adapter_target": "official-mcp-python-sdk-v2",
+    "current_adapter": "official-mcp-python-sdk-v2",
+    "tool_contract_hash": "bb4a0790eeb7c47138917508d8556a1f45c8a311995f552388499183b195755c",
+    "protocols_tested": ["legacy", "2026-07-28"],
+    "stdout": "wire-clean-subprocess-verified"
+  },
+  "skill": {
+    "source": "skills/power",
+    "format": "agentskills",
+    "version": "3.6.6",
+    "tree_sha256": "c30126eafca2e3890a0441f9e6803cde88750c16ada975df6fde5a66e81df3d1",
+    "packaged": true,
+    "compatible_core": "3.6.6",
+    "global_targets": [
+      "/root/.agents/skills/power",
+      "/root/.opencode/skills/power",
+      "/root/.config/opencode/skills/power"
+    ]
+  },
+  "gui": {
+    "native": {
+      "profile": "systemd-user",
+      "bind": "127.0.0.1",
+      "opt_in": true,
+      "restart_policy": "bounded",
+      "unit_syntax": "verified",
+      "lifecycle": "not-run-in-live-home"
+    },
+    "container": {
+      "profile": "supported-server",
+      "required_for_mcp": false,
+      "cache_sharing": "separate-rebuildable-cache",
+      "image_digest": null,
+      "local_image_id": "sha256:fabdfba555aa77b30cc1330295a75224426926110500e471cb93fdfd8aacc5f2",
+      "base_image_digest": "sha256:8fb099199b9f2d70342674bd9dbccd3ed03a258f26bbd1d556822c6dfc60c317",
+      "security": "non-root-10001-cap-drop-all-no-new-privileges",
+      "health": "local-candidate-verified"
+    }
+  },
+  "product_updater": {
+    "automatic": false,
+    "mode": "manual-hash-bound",
+    "policy": "release/power-suite-updater-policy.md",
+    "reason": "suite-aware stage/verify/activate/readback/rollback is not proven for this candidate"
+  },
+  "artifacts": {
+    "power_wheel_sha256": "cf853aa73aca5847c43e8097be335c49196a17149eb88a931a000765f85fb512",
+    "gui_wheel_sha256": "dd98f67dfa9a824aa09803d9c78a0eb304c228d187c4012a3bdca84dd3a6f39e",
+    "sbom_sha256": null,
+    "local_sbom_sha256": {
+      "power_lock_cyclonedx1_5": "233f99862dc68189deba59a5206cb95d0e0bfde67772048f23f47ca6966ad7a0",
+      "gui_lock_cyclonedx1_5": "48a7357395e014442d4ec1913e73e6fa66676fa22cad3d89df5938ca944a20b2"
+    },
+    "attestation": "not-published-at-candidate-validation"
+  },
+  "validation": {
+    "core_full_cpu_pytest": "1150 passed, 11 skipped, 2 warnings",
+    "gui_full_pytest": "53 passed, 3 skipped, 1 warning",
+    "mcp_integration_pytest_no_cov": "69 passed",
+    "core_mypy": "pass",
+    "core_ruff": "pass",
+    "gui_ruff": "pass",
+    "documentation_drift": "pass",
+    "native_fresh_home": "power/power-mcp/power-gui launchers, versions, preflight and receipt verified",
+    "container_local": "healthz/login/non-root/cap-drop/no-new-privileges verified",
+    "vault_doctor": "read-only environment warning: five pre-existing invalid-metadata notes and index coverage mismatch; no vault mutation",
+    "m2_human": "EXCLUDED_BY_POLICY"
+  },
+  "release_decision": {
+    "3.6.7": "NO-GO: local implementation gates pass; publication, attestation and lifecycle gates remain open",
+    "3.6.8": "SKIP: blocker-only scope has no additional code blocker after 3.6.7 validation",
+    "3.7.0": "NO-GO: public artifact/digest/SBOM/attestation and native lifecycle evidence are not published or read back"
+  },
+  "evidence_policy": {
+    "m2_human": "EXCLUDED_BY_POLICY",
+    "sealed": "DO_NOT_OPEN",
+    "human_retrieval_quality_claim": "NONE"
+  },
+  "closed_gates": [
+    "B0 exact-version-pair",
+    "B1 power-mcp-entry-point",
+    "B2 official-mcp-sdk-v2-compatibility",
+    "B3 application-service-boundary",
+    "B4 skill-packaging",
+    "B5 native-installer"
+  ],
+  "open_blockers": [
+    "B6 final public suite manifest, artifact publication and readback",
+    "B7 real opt-in systemd-user lifecycle and native GUI E2E",
+    "B8 published container digest plus release SBOM/attestation",
+    "B9 host CLI/MCP plus container GUI concurrent mutation and recovery"
+  ],
+  "validation_report": "release/power-suite-validation-report.md"
+}

--- a/release/power-suite-candidate.json
+++ b/release/power-suite-candidate.json
@@ -21,7 +21,7 @@
       "sha": "068b4d32d5d55170de52c81a897526e3d640078a",
       "tag_commit": "f1c918c7a8c6de011ff0553f08d00675ad296f59",
       "implementation_ref": "feature/power-gui-suite-3.7",
-      "implementation_commit": "27ed678593647f000cc77462611df1fba43808d9"
+      "implementation_commit": "b8001e1e5d3f57ed679b6941c6d0a12a752c931e"
     }
   },
   "application": {
@@ -78,7 +78,7 @@
       "required_for_mcp": false,
       "cache_sharing": "separate-rebuildable-cache",
       "image_digest": null,
-      "local_image_id": "sha256:fabdfba555aa77b30cc1330295a75224426926110500e471cb93fdfd8aacc5f2",
+      "local_image_id": "sha256:017970ee75b40c1ea16f39c8ecaaf5e33c4da7dbebfc8a5d182f09ebdc0d2b26",
       "base_image_digest": "sha256:8fb099199b9f2d70342674bd9dbccd3ed03a258f26bbd1d556822c6dfc60c317",
       "security": "non-root-10001-cap-drop-all-no-new-privileges",
       "health": "local-candidate-verified"
@@ -92,7 +92,7 @@
   },
   "artifacts": {
     "power_wheel_sha256": "cf853aa73aca5847c43e8097be335c49196a17149eb88a931a000765f85fb512",
-    "gui_wheel_sha256": "dd98f67dfa9a824aa09803d9c78a0eb304c228d187c4012a3bdca84dd3a6f39e",
+    "gui_wheel_sha256": "aef46cdde6baa3c88f407e8966ffe66acb16fdaf19198d0cf65edeb2b329bffc",
     "sbom_sha256": null,
     "local_sbom_sha256": {
       "power_lock_cyclonedx1_5": "233f99862dc68189deba59a5206cb95d0e0bfde67772048f23f47ca6966ad7a0",
@@ -102,11 +102,12 @@
   },
   "validation": {
     "core_full_cpu_pytest": "1150 passed, 11 skipped, 2 warnings",
-    "gui_full_pytest": "53 passed, 3 skipped, 1 warning",
+    "gui_full_pytest": "54 passed, 3 skipped, 1 warning",
     "mcp_integration_pytest_no_cov": "69 passed",
     "core_mypy": "pass",
     "core_ruff": "pass",
     "gui_ruff": "pass",
+    "gui_accessibility_review": "pass: labels, focus-visible guard, reduced-motion fallback and explicit transitions",
     "documentation_drift": "pass",
     "native_fresh_home": "power/power-mcp/power-gui launchers, versions, preflight and receipt verified",
     "container_local": "healthz/login/non-root/cap-drop/no-new-privileges verified",

--- a/release/power-suite-updater-policy.md
+++ b/release/power-suite-updater-policy.md
@@ -1,0 +1,19 @@
+# POWER Suite updater policy
+
+The 3.6.7/3.7.0 suite candidate does not enable an automatic product updater.
+The existing fleet updater remains maintainer infrastructure and is not a
+product dependency.
+
+Until a suite-aware updater proves stage, verify, activate, readback, rollback,
+and downgrade behavior for the exact core/GUI/Skill/container pair, updates
+are manual and hash-bound:
+
+1. Build or obtain the exact POWER and POWER-GUI wheels.
+2. Run `power integrations install` without `--apply` and inspect the artifact
+   digests, target managed venv, and launcher set.
+3. Apply only with `--apply --approved` after reviewing the plan.
+4. Verify the launcher versions, `power-mcp preflight`, GUI health, and the
+   `suite-install.json` receipt before enabling `systemd --user`.
+
+Automatic activation remains disabled when any artifact, container digest,
+rollback proof, or publication readback is missing.

--- a/release/power-suite-validation-report.md
+++ b/release/power-suite-validation-report.md
@@ -19,6 +19,16 @@ sealed human-evaluation material was not opened.
 Both implementation commits are signed with GPG key `2D49E810C7F2527E` and
 the required `weby-homelab <rekvizitor.ua@gmail.com>` identity.
 
+The feature branches are clean and PR-ready:
+
+- POWER: `feature/power-suite-3.7`, local HEAD `2971550c6e915f82b59e6707641ab6db496e8571`;
+- POWER-GUI: `feature/power-gui-suite-3.7`, local HEAD `b8001e1e5d3f57ed679b6941c6d0a12a752c931e`.
+
+No remote feature branch or PR was created because the configured GitHub
+credentials are invalid (`gh auth status` reports invalid `GITHUB_TOKEN` and
+account token). No token was read from or written to a file, and no push, merge,
+tag, or publication was attempted.
+
 ## 3.6.7 implementation gates
 
 The following local gates passed:

--- a/release/power-suite-validation-report.md
+++ b/release/power-suite-validation-report.md
@@ -21,7 +21,7 @@ the required `weby-homelab <rekvizitor.ua@gmail.com>` identity.
 
 The feature branches are clean and PR-ready:
 
-- POWER: `feature/power-suite-3.7`, local HEAD `815256aa8d9bbdd48a1f276729830c3999b914cb`;
+- POWER: `feature/power-suite-3.7`, signed handoff evidence commit `815256aa8d9bbdd48a1f276729830c3999b914cb`;
 - POWER-GUI: `feature/power-gui-suite-3.7`, local HEAD `b8001e1e5d3f57ed679b6941c6d0a12a752c931e`.
 
 No remote feature branch or PR was created because the configured GitHub

--- a/release/power-suite-validation-report.md
+++ b/release/power-suite-validation-report.md
@@ -21,7 +21,7 @@ the required `weby-homelab <rekvizitor.ua@gmail.com>` identity.
 
 The feature branches are clean and PR-ready:
 
-- POWER: `feature/power-suite-3.7`, local HEAD `2971550c6e915f82b59e6707641ab6db496e8571`;
+- POWER: `feature/power-suite-3.7`, local HEAD `815256aa8d9bbdd48a1f276729830c3999b914cb`;
 - POWER-GUI: `feature/power-gui-suite-3.7`, local HEAD `b8001e1e5d3f57ed679b6941c6d0a12a752c931e`.
 
 No remote feature branch or PR was created because the configured GitHub

--- a/release/power-suite-validation-report.md
+++ b/release/power-suite-validation-report.md
@@ -14,7 +14,7 @@ sealed human-evaluation material was not opened.
 | Component | Candidate base | Tag readback | Implementation commit |
 | --- | --- | --- | --- |
 | POWER | `origin/main` `527cc8a77187e9fa6d724b604d1a6634545da575` | `v3.6.6` → `6c6b6ae52f4b29382f0d2ec82fbb4e75ba1f471a` | `08ca9326dc849921db0c61a852ecb83cd6dd96b0` |
-| POWER-GUI | `origin/main` `068b4d32d5d55170de52c81a897526e3d640078a` | `v0.7.4` → `f1c918c7a8c6de011ff0553f08d00675ad296f59` | `27ed678593647f000cc77462611df1fba43808d9` |
+| POWER-GUI | `origin/main` `068b4d32d5d55170de52c81a897526e3d640078a` | `v0.7.4` → `f1c918c7a8c6de011ff0553f08d00675ad296f59` | `b8001e1e5d3f57ed679b6941c6d0a12a752c931e` |
 
 Both implementation commits are signed with GPG key `2D49E810C7F2527E` and
 the required `weby-homelab <rekvizitor.ua@gmail.com>` identity.
@@ -50,7 +50,7 @@ The following local gates passed:
 - The GUI container candidate was built from the pinned Python base image
   `sha256:8fb099199b9f2d70342674bd9dbccd3ed03a258f26bbd1d556822c6dfc60c317`.
   Local image ID is
-  `sha256:fabdfba555aa77b30cc1330295a75224426926110500e471cb93fdfd8aacc5f2`.
+  `sha256:017970ee75b40c1ea16f39c8ecaaf5e33c4da7dbebfc8a5d182f09ebdc0d2b26`.
   A disposable run returned `/healthz` version `3.6.6`, returned HTTP 200 for
   `/login`, ran as UID/GID `10001`, used `cap_drop=ALL`,
   `no-new-privileges:true`, and kept `/data` as rebuildable cache state.
@@ -60,7 +60,7 @@ The following local gates passed:
 | Surface | Command/result |
 | --- | --- |
 | POWER full suite | `POWER_EMBED_DEVICE=cpu POWER_RERANKER_DEVICE=cpu uv run --extra dev --extra rerank python -m pytest --no-cov -q` → **1150 passed, 11 skipped, 2 warnings** |
-| GUI full suite | `uv run --extra dev python -m pytest -q` → **53 passed, 3 skipped, 1 warning** |
+| GUI full suite | `uv run --extra dev python -m pytest -q` → **54 passed, 3 skipped, 1 warning** |
 | MCP/integration focus | `uv run --extra dev --extra mcp python -m pytest --no-cov -q` over entrypoint, packaging, onboarding, boundary, server, integrations and cross-process tests → **69 passed** |
 | POWER formatting/lint | Ruff format check and Ruff check → **pass** |
 | GUI formatting/lint | Ruff format check and Ruff check → **pass** |
@@ -71,6 +71,14 @@ The following local gates passed:
 The first inherited automatic/CUDA test invocation was not used as a release
 gate because this host has no CUDA execution provider. The explicit CPU gate
 above is the canonical reproducible result and passed in full.
+
+The Web Interface Guidelines review also passed as a static product gate after
+the GUI accessibility hardening commit: form controls have associated labels,
+the skip link and focus-visible ring remain present, `transition: all` and
+focus-outline suppression were removed from the owned stylesheet, and a
+`prefers-reduced-motion` fallback is present. The graph keeps its accessible
+table fallback. This is static evidence; it does not replace the still-open
+live native GUI lifecycle gate.
 
 The required read-only startup health check
 `uv run power doctor /root/geminicli/brain --json` returned an environment
@@ -85,7 +93,7 @@ the verified installer was run only in disposable HOME roots.
 | Artifact | SHA-256 or status |
 | --- | --- |
 | `power_framework-3.6.6-py3-none-any.whl` | `cf853aa73aca5847c43e8097be335c49196a17149eb88a931a000765f85fb512` |
-| `power_gui-0.7.4-py3-none-any.whl` | `dd98f67dfa9a824aa09803d9c78a0eb304c228d187c4012a3bdca84dd3a6f39e` |
+| `power_gui-0.7.4-py3-none-any.whl` | `aef46cdde6baa3c88f407e8966ffe66acb16fdaf19198d0cf65edeb2b329bffc` |
 | Local POWER CycloneDX 1.5 export | `233f99862dc68189deba59a5206cb95d0e0bfde67772048f23f47ca6966ad7a0` |
 | Local GUI CycloneDX 1.5 export | `48a7357395e014442d4ec1913e73e6fa66676fa22cad3d89df5938ca944a20b2` |
 | Published suite SBOM/digest | **not available** |

--- a/release/power-suite-validation-report.md
+++ b/release/power-suite-validation-report.md
@@ -1,0 +1,125 @@
+# POWER Suite validation report
+
+Date: 2026-08-21
+
+Status: candidate validation complete; stable publication is **NO-GO** until the
+open release gates below are closed with external readback evidence.
+
+## Scope and source identity
+
+This report covers the requested 3.6.7 hardening, the blocker-only 3.6.8
+review, and the 3.7.0 stable-suite gates. `M2_HUMAN` remains excluded and the
+sealed human-evaluation material was not opened.
+
+| Component | Candidate base | Tag readback | Implementation commit |
+| --- | --- | --- | --- |
+| POWER | `origin/main` `527cc8a77187e9fa6d724b604d1a6634545da575` | `v3.6.6` → `6c6b6ae52f4b29382f0d2ec82fbb4e75ba1f471a` | `08ca9326dc849921db0c61a852ecb83cd6dd96b0` |
+| POWER-GUI | `origin/main` `068b4d32d5d55170de52c81a897526e3d640078a` | `v0.7.4` → `f1c918c7a8c6de011ff0553f08d00675ad296f59` | `27ed678593647f000cc77462611df1fba43808d9` |
+
+Both implementation commits are signed with GPG key `2D49E810C7F2527E` and
+the required `weby-homelab <rekvizitor.ua@gmail.com>` identity.
+
+## 3.6.7 implementation gates
+
+The following local gates passed:
+
+- Official MCP Python SDK v2 is the runtime adapter. `power-mcp` is the public
+  console entry point; `python -m power_framework.mcp` remains compatibility
+  only. Real subprocess tests cover both legacy initialization and protocol
+  version `2026-07-28`; stdout remains wire-clean.
+- All 20 MCP tools expose output schemas, annotations, bounded risk metadata,
+  and the deterministic tool-contract hash
+  `bb4a0790eeb7c47138917508d8556a1f45c8a311995f552388499183b195755c`.
+- Mutating MCP paths delegate through `ApplicationService`; the AST boundary
+  test reports no low-level mutator bypass. Two independent source CLI
+  processes also completed a same-vault mutation test with the lock and
+  resulting notes intact.
+- The packaged Skill tree contains five files and has SHA-256
+  `c30126eafca2e3890a0441f9e6803cde88750c16ada975df6fde5a66e81df3d1`. The
+  generic installer was planned and atomically applied to the three managed
+  targets under `/root/.agents`, `/root/.opencode`, and
+  `/root/.config/opencode`; all target trees match the source hash.
+- The managed native installer was run in a disposable HOME with the exact
+  wheel pair. It created only the managed venv and launchers, produced a
+  `power.native-install.v1` receipt, reported POWER `3.6.6` and GUI `0.7.4`,
+  passed `power-mcp preflight`, and did not mutate system Python.
+- The canonical user unit is loopback-only, opt-in, uses a bounded restart
+  policy, and has no system-level `User=`/`Group=` mutation. Its syntax passes
+  `systemd-analyze verify`; live enable/start was intentionally not performed
+  in the real HOME, so lifecycle evidence remains open.
+- The GUI container candidate was built from the pinned Python base image
+  `sha256:8fb099199b9f2d70342674bd9dbccd3ed03a258f26bbd1d556822c6dfc60c317`.
+  Local image ID is
+  `sha256:fabdfba555aa77b30cc1330295a75224426926110500e471cb93fdfd8aacc5f2`.
+  A disposable run returned `/healthz` version `3.6.6`, returned HTTP 200 for
+  `/login`, ran as UID/GID `10001`, used `cap_drop=ALL`,
+  `no-new-privileges:true`, and kept `/data` as rebuildable cache state.
+
+## Verification commands and results
+
+| Surface | Command/result |
+| --- | --- |
+| POWER full suite | `POWER_EMBED_DEVICE=cpu POWER_RERANKER_DEVICE=cpu uv run --extra dev --extra rerank python -m pytest --no-cov -q` → **1150 passed, 11 skipped, 2 warnings** |
+| GUI full suite | `uv run --extra dev python -m pytest -q` → **53 passed, 3 skipped, 1 warning** |
+| MCP/integration focus | `uv run --extra dev --extra mcp python -m pytest --no-cov -q` over entrypoint, packaging, onboarding, boundary, server, integrations and cross-process tests → **69 passed** |
+| POWER formatting/lint | Ruff format check and Ruff check → **pass** |
+| GUI formatting/lint | Ruff format check and Ruff check → **pass** |
+| POWER static types | `uv run mypy src/power_framework` → **Success: no issues found in 77 source files** |
+| Public documentation drift | `uv run python scripts/check_doc_drift.py --check interfaces,onboarding,clients` → **pass** |
+| Wheel packaging | POWER and GUI wheels built successfully; POWER wheel contains all five Skill files |
+
+The first inherited automatic/CUDA test invocation was not used as a release
+gate because this host has no CUDA execution provider. The explicit CPU gate
+above is the canonical reproducible result and passed in full.
+
+The required read-only startup health check
+`uv run power doctor /root/geminicli/brain --json` returned an environment
+error, not a candidate-code failure: five existing prompt/strategy notes are
+excluded for invalid metadata and the current index has a coverage mismatch.
+Those user-owned vault notes were not modified. The native integration doctor
+also correctly reports the live `/root/.local` profile as incomplete because
+the verified installer was run only in disposable HOME roots.
+
+## Artifact and supply-chain evidence
+
+| Artifact | SHA-256 or status |
+| --- | --- |
+| `power_framework-3.6.6-py3-none-any.whl` | `cf853aa73aca5847c43e8097be335c49196a17149eb88a931a000765f85fb512` |
+| `power_gui-0.7.4-py3-none-any.whl` | `dd98f67dfa9a824aa09803d9c78a0eb304c228d187c4012a3bdca84dd3a6f39e` |
+| Local POWER CycloneDX 1.5 export | `233f99862dc68189deba59a5206cb95d0e0bfde67772048f23f47ca6966ad7a0` |
+| Local GUI CycloneDX 1.5 export | `48a7357395e014442d4ec1913e73e6fa66676fa22cad3d89df5938ca944a20b2` |
+| Published suite SBOM/digest | **not available** |
+| Signed release attestation | **not available** |
+
+The local CycloneDX hashes were calculated from `uv export` output and are
+evidence of the checked lockfiles, not a substitute for a published SBOM or
+attestation bound to a registry artifact. Automatic product updates remain
+disabled under `release/power-suite-updater-policy.md`.
+
+## 3.6.8 and 3.7.0 decisions
+
+3.6.8 is **SKIP**: its blocker-only scope produced no additional code blocker
+after the 3.6.7 gates passed.
+
+3.7.0 is **NO-GO** for publication, even though the local implementation gates
+are green. The remaining required evidence is:
+
+- B6: final suite manifest publication and external artifact/readback identity;
+- B7: an actual opt-in `systemd --user` install, start, restart, stop, and
+  readback test in a disposable user profile;
+- B8: published container digest plus release SBOM and signed attestation;
+- B9: host CLI/MCP and container GUI concurrent mutation/recovery against one
+  disposable vault, including a verified failure/recovery path.
+
+The local host cross-process test, native installer, and container health/security
+smoke do not claim those missing external gates. No product feature ring was
+added to hide the blockers.
+
+## Subagent advisory record
+
+Antigravity-cli was invoked with Gemini 3.7 Flash high effort and OpenCode was
+used for independent read-only audits. Their output was treated as advisory:
+the useful OpenCode findings identified stale FastMCP/packaging/doc contracts,
+which were corrected and then covered by the gates above. No subagent was
+allowed to publish artifacts, open sealed M2 material, or override the
+ApplicationService/source-of-truth boundary.

--- a/scripts/benchmark_mcp_latency.py
+++ b/scripts/benchmark_mcp_latency.py
@@ -4,7 +4,7 @@
 Requires a running MCP server:
     POWER_VAULT_DIR=/root/gemma/brain POWER_MCP_TRANSPORT=http \\
     POWER_MCP_HOST=127.0.0.1 POWER_MCP_PORT=8765 \\
-    python -m power_framework.mcp
+    power-mcp
 
 Usage:
     python scripts/benchmark_mcp_latency.py
@@ -34,9 +34,12 @@ async def main(fixture: Path | None = None) -> int:
         return 1
 
     try:
-        from fastmcp import Client
+        from mcp import Client
     except ImportError:
-        print("ERROR: fastmcp not installed (pip install fastmcp)", file=sys.stderr)
+        print(
+            "ERROR: official MCP SDK v2 is not installed (pip install 'power-framework[mcp]')",
+            file=sys.stderr,
+        )
         return 1
 
     client = Client(SERVER_URL)
@@ -48,7 +51,7 @@ async def main(fixture: Path | None = None) -> int:
                 await client.call_tool(
                     "search_vault_tool",
                     {"query": queries[0], "max_results": 20, "search_mode": mode},
-                    timeout=120,
+                    read_timeout_seconds=120,
                 )
             except Exception as e:
                 print(f"  {mode}: warmup failed ({e}) — skipping mode")
@@ -62,7 +65,7 @@ async def main(fixture: Path | None = None) -> int:
                         await client.call_tool(
                             "search_vault_tool",
                             {"query": query, "max_results": 20, "search_mode": mode},
-                            timeout=120,
+                            read_timeout_seconds=120,
                         )
                     except Exception as e:
                         print(f"  {mode}: query '{query}' failed: {e}", file=sys.stderr)

--- a/scripts/benchmark_retrieval_latency.py
+++ b/scripts/benchmark_retrieval_latency.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from contextlib import closing
+from contextlib import asynccontextmanager, closing
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +38,30 @@ from power_framework.core.timing import collect_timings
 
 DEFAULT_MODES = ("fts", "semantic", "hybrid", "reranked")
 MCP_WORKER = Path(__file__).with_name("benchmark_retrieval_mcp_worker.py")
+
+
+@asynccontextmanager
+async def _stdio_session(environment: dict[str, str]):
+    """Open the benchmark worker through the official SDK v2 stdio client."""
+    try:
+        from mcp import ClientSession, StdioServerParameters, stdio_client
+    except ImportError as exc:  # pragma: no cover - exercised by the packaging gate
+        raise RuntimeError(
+            "official MCP SDK v2 is required for the MCP latency shape "
+            "(pip install 'power-framework[mcp]')"
+        ) from exc
+
+    parameters = StdioServerParameters(
+        command=sys.executable,
+        args=[str(MCP_WORKER.resolve())],
+        env=environment,
+    )
+    async with (
+        stdio_client(parameters) as (read_stream, write_stream),
+        ClientSession(read_stream, write_stream) as session,
+    ):
+        await session.initialize()
+        yield session
 
 
 def _percentile(values: list[float], quantile: float) -> float | None:
@@ -170,11 +194,6 @@ async def _mcp_samples(
     rounds: int,
     max_results: int,
 ) -> list[dict[str, Any]]:
-    try:
-        from fastmcp import Client
-    except ImportError as exc:  # pragma: no cover - packaging gate covers this
-        raise RuntimeError("fastmcp is required for the MCP latency shape") from exc
-
     with tempfile.TemporaryDirectory(prefix="power-timing-") as receipt_dir:
         receipt_path = Path(receipt_dir) / "receipt.json"
         environment = os.environ.copy()
@@ -185,21 +204,13 @@ async def _mcp_samples(
                 "POWER_BENCHMARK_RECEIPT": str(receipt_path),
             }
         )
-        config = {
-            "mcpServers": {
-                "power": {
-                    "command": sys.executable,
-                    "args": [str(MCP_WORKER.resolve())],
-                    "env": environment,
-                }
-            }
-        }
         samples: list[dict[str, Any]] = []
-        async with Client(config) as client:
+        async with _stdio_session(dict(environment)) as client:
             warmup_query = queries[0]
             await client.call_tool(
                 "search_vault_tool",
                 {"query": warmup_query, "max_results": max_results, "search_mode": mode},
+                read_timeout_seconds=300,
             )
             for _ in range(rounds):
                 for query in queries:
@@ -207,6 +218,7 @@ async def _mcp_samples(
                     await client.call_tool(
                         "search_vault_tool",
                         {"query": query, "max_results": max_results, "search_mode": mode},
+                        read_timeout_seconds=300,
                     )
                     elapsed = (time.perf_counter() - started) * 1000
                     receipt = json.loads(receipt_path.read_text(encoding="utf-8"))

--- a/scripts/benchmark_retrieval_mcp_worker.py
+++ b/scripts/benchmark_retrieval_mcp_worker.py
@@ -48,7 +48,7 @@ application.format_untrusted_search_envelope = _format_with_receipt
 
 
 if __name__ == "__main__":
-    # FastMCP's startup banner is useful interactively but would pollute the
-    # benchmark operator's stdout/stderr receipt stream.
+    # Keep the official SDK v2 stdio channel free of benchmark chatter; the
+    # content-free receipt is written to the explicit side-channel path.
     sys.stderr = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115
     power_server.run()

--- a/skills/power/references/runtime-contract.md
+++ b/skills/power/references/runtime-contract.md
@@ -6,9 +6,9 @@ sync/doctor правила. Авторитетна правда — `power docto
 
 ## Runtime version
 
-`v3.6.6` — runtime contract: **25 CLI commands** + **20 MCP tools** (FastMCP 3.x).
+`v3.6.6` — runtime contract: **26 CLI commands** + **20 MCP tools** (official MCP Python SDK v2).
 
-## CLI (25 команд)
+## CLI (26 команд)
 
 1. `power init <path>` — створити структуру vault
 2. `power lint <path>` — перевірка метаданих, посилань, orphan
@@ -35,8 +35,9 @@ sync/doctor правила. Авторитетна правда — `power docto
 23. `power control-plane <path> [--apply]` — preview або materialize visible status view
 24. `power maintenance <path> [--apply]` — hash-bound preview/apply для reversible repairs
 25. `power migrate-state <path>` — content-free read-only state-plane inventory; apply is fail-closed
+26. `power integrations <doctor|mcp-config|skill-check|skill-install|install>` — generic dry-run-first suite integration and managed native install flows
 
-## MCP Tools (20) — FastMCP 3.x
+## MCP Tools (20) — official MCP Python SDK v2
 
 - Discovery: `get_server_info` — versioned runtime, configured vault, coverage,
   and embedding configuration; `probe_provider=true` is an explicit no-download
@@ -152,8 +153,9 @@ power sync PATH [--fts-only] [--force] [--strict | --allow-partial] [--accept-de
 - Reranker: `onnx-community/bge-reranker-v2-m3-ONNX` (SHA-pinned, Apache-2.0);
   `jinaai/jina-reranker-v2-base-multilingual` (CC-BY-NC) — явний opt-in.
 - Search default: `auto`; canonical path is verified dense when ready and labelled FTS otherwise. Explicit `semantic` remains fail-closed.
-- MCP entry-point: `python -m power_framework.mcp`; `POWER_VAULT_DIR` обов'язковий
-  і задає єдиний доступний vault.
+- MCP entry-point: `power-mcp` (with `python -m power_framework.mcp` retained as a
+  compatibility module entrypoint); `POWER_VAULT_DIR` обов'язковий і задає
+  єдиний доступний vault.
 - Device: `POWER_EMBED_DEVICE` / `POWER_RERANKER_DEVICE`
   (`auto`, `cpu`, `cuda`, `rocm`, `directml`).
 - Resource control: `POWER_EMBED_BATCH_SIZE`, `POWER_EMBED_NUM_THREADS`,

--- a/src/power_framework/core/application.py
+++ b/src/power_framework/core/application.py
@@ -14,6 +14,7 @@ import re
 import time
 import uuid
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -23,7 +24,19 @@ from .application_models import (
 )
 from .capabilities import manifest
 from .decision_service import DecisionService
-from .memory_api import apply_change, apply_change_by_id, propose_change, read_history
+from .healer import heal_vault
+from .indexer import run_generate_hierarchical_index, run_generate_sub_index, scan_folder_notes
+from .linter import archive_stale_notes, run_lint_report
+from .memory_api import (
+    apply_change,
+    apply_change_by_id,
+    commit_note_change,
+    propose_change,
+    read_history,
+)
+from .models import PARA_FOLDERS, MemoryKind, MemoryMetadata, NoteType, OKFMetadata, WritePolicy
+from .mutation import execute_vault_mutation
+from .parser import build_frontmatter
 from .searcher import (
     DEFAULT_SEARCH_MODE,
     format_untrusted_search_envelope,
@@ -35,7 +48,9 @@ from .source_service import (
     list_sources,
     read_source,
 )
+from .synthesize import synthesize_session_ingest
 from .task_service import TaskService
+from .utils import resolve_path_in_vault
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -119,6 +134,56 @@ class ApplicationEnvelope:
 
 
 _TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+def _catalog_page_filename(page: int) -> str:
+    """Return the stable generated catalog filename for a one-based page."""
+    return "_index.md" if page == 1 else f"_index-{page}.md"
+
+
+def _read_generated_catalog_page(vault_dir: Path, category: str, page: int) -> str:
+    """Read one generated catalog page after the application mutation."""
+    category_dir = vault_dir / category
+    landing = category_dir / _catalog_page_filename(1)
+    if page == 1:
+        try:
+            return landing.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"Generated catalog landing page is missing for {category}"
+            ) from exc
+        except (OSError, UnicodeError) as exc:
+            raise RuntimeError("Unable to read the generated catalog landing page") from exc
+
+    try:
+        prefix = landing.read_text(encoding="utf-8")[:4096]
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Generated catalog landing page is missing for {category}"
+        ) from exc
+    except (OSError, UnicodeError) as exc:
+        raise RuntimeError("Unable to read the generated catalog landing page") from exc
+
+    page_count = 1
+    for line in prefix.splitlines():
+        if line.startswith("x-index-pages:"):
+            try:
+                page_count = int(line.split(":", 1)[1].strip())
+            except (IndexError, ValueError) as exc:
+                raise ValueError("Generated catalog page metadata is invalid") from exc
+            break
+    if page > page_count:
+        raise ValueError(f"Catalog page {page} is out of range; available pages: 1-{page_count}")
+
+    target = category_dir / _catalog_page_filename(page)
+    try:
+        return target.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Catalog page {page} is missing although the landing page declares {page_count}"
+        ) from exc
+    except (OSError, UnicodeError) as exc:
+        raise RuntimeError(f"Unable to read catalog page {page}") from exc
 
 
 class ApplicationService:
@@ -253,6 +318,296 @@ class ApplicationService:
                 approved=True,
                 idempotency_key=request.idempotency_key,
             ),
+        )
+
+    @staticmethod
+    def _mutation_context(context: RequestContext | None) -> RequestContext:
+        """Require an explicit application authority for a write use case."""
+        request = context or RequestContext(authority="apply")
+        if request.authority not in {"propose", "apply"}:
+            raise PermissionError("mutation requires propose or apply authority")
+        return request
+
+    def generate_index(self, *, context: RequestContext | None = None) -> ApplicationEnvelope:
+        """Regenerate the hierarchical index under the canonical vault lock."""
+        request = self._mutation_context(context)
+        return self._run(
+            "index.generate",
+            request,
+            lambda: {
+                "result": execute_vault_mutation(
+                    self.vault_dir, lambda: run_generate_hierarchical_index(self.vault_dir)
+                )
+            },
+        )
+
+    def ensure_sub_index(
+        self,
+        category: str,
+        *,
+        page: int = 1,
+        context: RequestContext | None = None,
+    ) -> ApplicationEnvelope:
+        """Generate and return one bounded P.A.R.A. catalog page."""
+        request = self._mutation_context(context)
+        if category not in PARA_FOLDERS:
+            raise ValueError(
+                f"Invalid category: {category}. Must be one of: {', '.join(PARA_FOLDERS)}"
+            )
+        if not (self.vault_dir / category).is_dir():
+            raise ValueError(f"Category folder not found: {category}")
+        if isinstance(page, bool) or not isinstance(page, int) or page < 1:
+            raise ValueError("page must be a positive integer starting at 1")
+
+        def execute() -> dict[str, object]:
+            notes = scan_folder_notes(self.vault_dir).get(category, [])
+            if not notes:
+                return {"result": f"No notes found in {category}.", "content": ""}
+
+            def mutate() -> dict[str, object]:
+                result = run_generate_sub_index(self.vault_dir, category)
+                content = _read_generated_catalog_page(self.vault_dir, category, page)
+                return {"result": result, "content": content}
+
+            return execute_vault_mutation(self.vault_dir, mutate)
+
+        return self._run("index.ensure-sub-index", request, execute)
+
+    def sync_vault(
+        self,
+        *,
+        fts_only: bool = True,
+        accept_dense_loss: bool = False,
+        force_rebuild: bool = False,
+        allow_partial: bool = False,
+        context: RequestContext | None = None,
+    ) -> ApplicationEnvelope:
+        """Publish an atomic search generation through the application boundary."""
+        request = self._mutation_context(context)
+
+        def build() -> dict[str, object]:
+            from .generation_index import (
+                IndexGenerationError,
+                list_invalid_sources,
+                sync_vault_atomically,
+            )
+
+            invalid_sources = list_invalid_sources(self.vault_dir)
+            if invalid_sources and not allow_partial:
+                details = "; ".join(
+                    f"{rel_path} ({reason})" for rel_path, reason in sorted(invalid_sources.items())
+                )
+                raise ValueError(
+                    "Vault sync failed closed: "
+                    f"{len(invalid_sources)} note(s) are excluded and remain unsearchable. "
+                    f"Excluded: {details}. Pass allow_partial=True only to publish the valid subset."
+                )
+
+            try:
+                report = sync_vault_atomically(
+                    self.vault_dir,
+                    sync_embeddings=not fts_only,
+                    force_rebuild=force_rebuild,
+                    allow_partial=allow_partial,
+                    accept_dense_loss=accept_dense_loss,
+                )
+            except IndexGenerationError as exc:
+                raise RuntimeError(
+                    f"Vault sync failed; previous index remains active: {exc}"
+                ) from exc
+
+            lines = [
+                "=== Vault Sync ===",
+                f"Generation: {report.generation_id}",
+                f"Mode: {'FTS only' if fts_only else 'FTS + embeddings'}",
+                f"Notes scanned: {report.total_scanned}",
+                f"Notes indexed: {report.actual_files}",
+                f"Notes excluded (invalid metadata): {report.invalid_sources}",
+                f"Chunks: {report.actual_chunks}",
+            ]
+            if report.invalid_sources:
+                lines.append("")
+                lines.append("Exclusion reasons:")
+                lines.extend(
+                    f"- {rel_path}: {reason}"
+                    for rel_path, reason in sorted(report.excluded_sources.items())
+                )
+                lines.append(
+                    "Excluded notes are not searchable. Run 'power index <vault> --strict' "
+                    "to list them, or heal_frontmatter_tool to repair them."
+                )
+            return {
+                "result": "\n".join(lines),
+                "generation_id": report.generation_id,
+                "actual_files": report.actual_files,
+                "actual_chunks": report.actual_chunks,
+                "excluded_sources": report.excluded_sources,
+            }
+
+        return self._run(
+            "index.sync",
+            request,
+            lambda: execute_vault_mutation(self.vault_dir, build),
+        )
+
+    def ingest_note(
+        self,
+        *,
+        name: str,
+        note_type: str,
+        title: str,
+        description: str,
+        content: str,
+        resource: str | None = None,
+        tags: list[str] | None = None,
+        context: RequestContext | None = None,
+    ) -> ApplicationEnvelope:
+        """Create one validated note and publish all required projections."""
+        request = self._mutation_context(context)
+        note_name = name if name.endswith(".md") else f"{name}.md"
+        try:
+            target_file = resolve_path_in_vault(
+                self.vault_dir, note_name, allowed_directories=PARA_FOLDERS
+            )
+        except ValueError as exc:
+            raise ValueError(
+                "Invalid note path; use an existing PARA directory and a Markdown filename."
+            ) from exc
+        if target_file.exists():
+            raise FileExistsError(f"Note already exists at {note_name}")
+
+        metadata = OKFMetadata(
+            type=NoteType(note_type),
+            title=title,
+            description=description,
+            resource=resource,
+            tags=tags or [],
+            okf_version="0.2",
+            memory=MemoryMetadata(
+                kind=MemoryKind.SEMANTIC,
+                sources=["power://mcp/ingest_note"],
+                evidence=[f"sha256:{hashlib.sha256(content.encode('utf-8')).hexdigest()}"],
+                write_policy=WritePolicy.AGENT_PROPOSED,
+            ),
+            timestamp=datetime.now(UTC),
+        )
+        full_content = f"{build_frontmatter(metadata)}\n\n{content}\n"
+
+        def execute() -> dict[str, object]:
+            date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+            log_entry = (
+                f"\n## [{date_str}] ingest | Created {title}\n"
+                f"- **Action:** Created note '{note_name}' of type {note_type} via MCP tool ingest_note.\n"
+                f"- **Result:** Saved note to {note_name} and compiled hierarchical index.\n"
+            )
+            receipt = commit_note_change(
+                self.vault_dir,
+                note_name,
+                full_content,
+                require_absent=True,
+                allowed_directories=PARA_FOLDERS,
+                operation="mcp.ingest_note",
+                log_entry=log_entry,
+            )
+            lint_result = run_lint_report(self.vault_dir)
+            return {
+                "result": (
+                    f"Note '{note_name}' has been successfully ingested!\n"
+                    f"{receipt['index_summary']}\n"
+                    f"Search projection: {receipt['search_mode']} ({receipt['search_generation']})\n"
+                    "Action appended to log.md when the log exists.\n\n"
+                    f"Linting Check:\n{lint_result}"
+                ),
+                "note": note_name,
+                "receipt": receipt,
+            }
+
+        return self._run("memory.ingest-note", request, execute)
+
+    def synthesize_session(
+        self,
+        *,
+        name: str,
+        title: str,
+        description: str,
+        content: str,
+        note_type: str = "Daily Log",
+        tags: list[str] | None = None,
+        related: list[str] | None = None,
+        owner: str | None = None,
+        context: RequestContext | None = None,
+    ) -> ApplicationEnvelope:
+        """Create a governed session artifact through the core ingest workflow."""
+        request = self._mutation_context(context)
+        note_name = name if name.endswith(".md") else f"{name}.md"
+        try:
+            resolve_path_in_vault(self.vault_dir, note_name, allowed_directories=PARA_FOLDERS)
+        except ValueError as exc:
+            raise ValueError(
+                "Invalid note path; use an existing PARA directory and a Markdown filename."
+            ) from exc
+        return self._run(
+            "synthesize.session",
+            request,
+            lambda: {
+                "result": synthesize_session_ingest(
+                    name=name,
+                    title=title,
+                    description=description,
+                    content=content,
+                    note_type=note_type,
+                    tags=tags,
+                    related=related,
+                    owner=owner,
+                    vault_path=self.vault_dir,
+                )
+            },
+        )
+
+    def archive_notes(
+        self,
+        *,
+        dry_run: bool = True,
+        context: RequestContext | None = None,
+    ) -> ApplicationEnvelope:
+        """Preview or apply stale-note archival through the core boundary."""
+        request = context if dry_run else self._mutation_context(context)
+        return self._run(
+            "maintenance.archive-notes",
+            request,
+            lambda: {
+                "result": (
+                    archive_stale_notes(self.vault_dir, dry_run=True)
+                    if dry_run
+                    else execute_vault_mutation(
+                        self.vault_dir,
+                        lambda: archive_stale_notes(self.vault_dir, dry_run=False),
+                    )
+                )
+            },
+        )
+
+    def heal_frontmatter(
+        self,
+        *,
+        dry_run: bool = True,
+        context: RequestContext | None = None,
+    ) -> ApplicationEnvelope:
+        """Preview or apply frontmatter healing through the core boundary."""
+        request = context if dry_run else self._mutation_context(context)
+        return self._run(
+            "maintenance.heal-frontmatter",
+            request,
+            lambda: {
+                "result": (
+                    heal_vault(self.vault_dir, dry_run=True)
+                    if dry_run
+                    else execute_vault_mutation(
+                        self.vault_dir,
+                        lambda: heal_vault(self.vault_dir, dry_run=False),
+                    )
+                )
+            },
         )
 
     def task(

--- a/src/power_framework/core/application_models.py
+++ b/src/power_framework/core/application_models.py
@@ -1,7 +1,7 @@
 """Versioned DTO models for POWER Application API v2.
 
 These models define standard, serialization-safe, and bounded data transfer
-objects used across all transport adapters (CLI, FastMCP, POWER-GUI, Federation, A2A).
+objects used across all transport adapters (CLI, official MCP SDK, POWER-GUI, Federation, A2A).
 """
 
 from __future__ import annotations

--- a/src/power_framework/core/capabilities.py
+++ b/src/power_framework/core/capabilities.py
@@ -57,7 +57,7 @@ def _literal_dict(node: ast.AST) -> dict[str, Any]:
 
 @lru_cache(maxsize=1)
 def _mcp_tool_contracts() -> list[dict[str, Any]]:
-    """Read FastMCP tool contracts without importing FastMCP or the server."""
+    """Read SDK-independent tool contracts without importing the MCP server."""
     source = ast.parse(_read_source(_package_root() / "mcp" / "power_server.py"))
     contracts: list[dict[str, Any]] = []
     for node in ast.walk(source):

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -57,6 +57,15 @@ from .importer import (
     format_import_report,
 )
 from .indexer import generate_log_initial, run_generate_hierarchical_index
+from .integrations import (
+    apply_mcp_config_integration_plan,
+    apply_native_install_plan,
+    apply_skill_install_plan,
+    build_integrations_doctor,
+    build_mcp_config_integration_plan,
+    build_native_install_plan,
+    build_skill_check_plan,
+)
 from .linter import (
     archive_stale_notes,
     run_lint_report,
@@ -898,6 +907,78 @@ def _cmd_connect(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_integrations(args: argparse.Namespace) -> int:
+    """Plan or apply generic, path-safe suite integration operations."""
+    try:
+        if args.integration_command == "doctor":
+            print(json.dumps(build_integrations_doctor(), ensure_ascii=False, sort_keys=True))
+        elif args.integration_command == "mcp-config":
+            plan = build_mcp_config_integration_plan(
+                args.path,
+                client=args.client,
+                config_path=args.config,
+                executable=args.executable,
+                remove=args.remove,
+            )
+            if args.plan_output:
+                atomic_write(
+                    Path(args.plan_output).expanduser(),
+                    json.dumps(plan, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+                )
+            if args.apply:
+                print(
+                    json.dumps(
+                        apply_mcp_config_integration_plan(plan, approved=args.approved),
+                        ensure_ascii=False,
+                        sort_keys=True,
+                    )
+                )
+            else:
+                print(json.dumps(plan, ensure_ascii=False, sort_keys=True))
+        elif args.integration_command == "skill-check":
+            print(
+                json.dumps(build_skill_check_plan(args.target), ensure_ascii=False, sort_keys=True)
+            )
+        elif args.integration_command == "skill-install":
+            plan = build_skill_check_plan(args.target)
+            if args.apply:
+                print(
+                    json.dumps(
+                        apply_skill_install_plan(plan, approved=args.approved),
+                        ensure_ascii=False,
+                        sort_keys=True,
+                    )
+                )
+            else:
+                print(json.dumps(plan, ensure_ascii=False, sort_keys=True))
+        elif args.integration_command == "install":
+            plan = build_native_install_plan(
+                home=args.home,
+                power_wheel=args.power_wheel,
+                gui_wheel=args.gui_wheel,
+            )
+            if args.apply:
+                print(
+                    json.dumps(
+                        apply_native_install_plan(
+                            plan,
+                            approved=args.approved,
+                            no_deps=args.no_deps,
+                        ),
+                        ensure_ascii=False,
+                        sort_keys=True,
+                    )
+                )
+            else:
+                print(json.dumps(plan, ensure_ascii=False, sort_keys=True))
+        else:  # pragma: no cover - argparse enforces the choices
+            raise ValueError(f"unsupported integration command: {args.integration_command}")
+    except (KeyError, PermissionError, RuntimeError, ValueError, OSError) as exc:
+        logger.error("Integration transaction failed: %s", exc)
+        return 1
+    return 0
+
+
 def _cmd_memory(args: argparse.Namespace) -> int:
     vault_dir = _resolve_path(args.path)
     try:
@@ -1312,6 +1393,78 @@ def main() -> None:
         help="Explicitly probe the configured provider without downloading a model",
     )
     p_doctor.set_defaults(func=_cmd_doctor)
+
+    p_integrations = subparsers.add_parser(
+        "integrations",
+        help="Plan or apply generic POWER suite integrations (dry-run by default)",
+    )
+    integration_sub = p_integrations.add_subparsers(dest="integration_command", required=True)
+    integration_sub.add_parser(
+        "doctor", help="Read-only integration, launcher, SDK, and Skill diagnostics"
+    ).set_defaults(func=_cmd_integrations)
+
+    p_mcp_config = integration_sub.add_parser(
+        "mcp-config", help="Plan or apply a hash-bound local MCP client configuration"
+    )
+    p_mcp_config.add_argument("path", help="Path to the POWER vault")
+    p_mcp_config.add_argument(
+        "--client",
+        choices=["auto", "codex", "opencode", "gemini", "claude"],
+        default="auto",
+        help="Client to configure",
+    )
+    p_mcp_config.add_argument("--config", default=None, help="Explicit client config path")
+    p_mcp_config.add_argument(
+        "--executable",
+        default="power-mcp",
+        help="Public MCP launcher (default: power-mcp)",
+    )
+    p_mcp_config.add_argument("--remove", action="store_true", help="Plan removal")
+    p_mcp_config.add_argument("--apply", action="store_true", help="Apply the plan")
+    p_mcp_config.add_argument(
+        "--approved", action="store_true", help="Explicitly approve the config write"
+    )
+    p_mcp_config.add_argument("--plan-output", default=None, help="Write the plan to JSON")
+    p_mcp_config.set_defaults(func=_cmd_integrations)
+
+    p_skill_check = integration_sub.add_parser(
+        "skill-check", help="Read-only check of a packaged POWER Skill installation"
+    )
+    p_skill_check.add_argument(
+        "--target",
+        default=str(Path.home() / ".agents" / "skills" / "power"),
+        help="Skill target directory",
+    )
+    p_skill_check.set_defaults(func=_cmd_integrations)
+
+    p_skill_install = integration_sub.add_parser(
+        "skill-install", help="Plan or atomically install the packaged POWER Skill"
+    )
+    p_skill_install.add_argument(
+        "--target",
+        default=str(Path.home() / ".agents" / "skills" / "power"),
+        help="Skill target directory",
+    )
+    p_skill_install.add_argument("--apply", action="store_true", help="Apply the plan")
+    p_skill_install.add_argument(
+        "--approved", action="store_true", help="Explicitly approve the Skill write"
+    )
+    p_skill_install.set_defaults(func=_cmd_integrations)
+
+    p_install = integration_sub.add_parser(
+        "install", help="Plan or install an exact wheel pair into the managed native venv"
+    )
+    p_install.add_argument(
+        "--home", default=None, help="Disposable HOME root for the managed profile"
+    )
+    p_install.add_argument("--power-wheel", required=True, help="Exact POWER framework wheel")
+    p_install.add_argument("--gui-wheel", default=None, help="Optional exact POWER-GUI wheel")
+    p_install.add_argument("--no-deps", action="store_true", help="Skip dependency resolution")
+    p_install.add_argument("--apply", action="store_true", help="Apply the plan")
+    p_install.add_argument(
+        "--approved", action="store_true", help="Explicitly approve the native install"
+    )
+    p_install.set_defaults(func=_cmd_integrations)
 
     p_connect = subparsers.add_parser(
         "connect", help="Plan or apply a conflict-safe local MCP client connection"

--- a/src/power_framework/core/connect.py
+++ b/src/power_framework/core/connect.py
@@ -64,7 +64,13 @@ def _client_for_path(path: Path) -> str:
 
 def _server_entry(client: str, vault_path: Path, executable: str) -> dict[str, Any]:
     """Return the client-specific, content-free local stdio server entry."""
-    command = [str(Path(executable)), "-m", "power_framework.mcp"]
+    executable_path = Path(executable)
+    if executable_path.name.startswith("python"):
+        # Preserve the explicit-interpreter compatibility path for existing
+        # configs; native suite installs use the public power-mcp launcher.
+        command = [str(executable_path), "-m", "power_framework.mcp"]
+    else:
+        command = [str(executable_path)]
     environment = {"POWER_VAULT_DIR": str(vault_path.resolve())}
     if client == "opencode":
         return {"type": "local", "command": command, "environment": environment, "enabled": True}

--- a/src/power_framework/core/integrations.py
+++ b/src/power_framework/core/integrations.py
@@ -1,0 +1,458 @@
+"""Safe, generic integration plans for the POWER suite.
+
+Every operation is dry-run by default.  The functions in this module return
+content-free plans first; apply functions require an explicit approval flag and
+re-check the plan's source/preimage before making an atomic change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import importlib.resources
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import venv
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .connect import ConnectClient, apply_connect_plan, build_connect_plan
+from .utils import atomic_write
+
+INTEGRATIONS_SCHEMA_VERSION = "power.integrations.v1"
+SKILL_SCHEMA_VERSION = "power.skill.v1"
+NATIVE_INSTALL_SCHEMA_VERSION = "power.native-install.v1"
+SKILL_NAME = "power"
+
+
+@dataclass(frozen=True)
+class SkillTree:
+    """Immutable in-memory representation of the packaged Skill tree."""
+
+    files: dict[str, bytes]
+    sha256: str
+
+
+def _aggregate_tree_hash(files: dict[str, bytes]) -> str:
+    """Hash paths and bytes in deterministic lexical order."""
+    digest = hashlib.sha256()
+    for relative in sorted(files):
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(files[relative]).digest())
+    return digest.hexdigest()
+
+
+def _walk_resource_tree(root: Any, prefix: str = "") -> dict[str, bytes]:
+    """Read a Traversable resource tree without assuming a filesystem path."""
+    files: dict[str, bytes] = {}
+    for child in sorted(root.iterdir(), key=lambda item: item.name):
+        relative = f"{prefix}/{child.name}" if prefix else child.name
+        if child.is_dir():
+            files.update(_walk_resource_tree(child, relative))
+        else:
+            files[relative] = child.read_bytes()
+    return files
+
+
+def packaged_skill_tree() -> SkillTree:
+    """Return the source Skill tree from checkout or wheel package data."""
+    repository_root = Path(__file__).resolve().parents[3]
+    source = repository_root / "skills" / SKILL_NAME
+    if source.is_dir():
+        files = {
+            path.relative_to(source).as_posix(): path.read_bytes()
+            for path in source.rglob("*")
+            if path.is_file()
+        }
+    else:
+        resource_root = (
+            importlib.resources.files("power_framework") / "data" / "skills" / SKILL_NAME
+        )
+        files = _walk_resource_tree(resource_root)
+    if not files or "SKILL.md" not in files:
+        raise FileNotFoundError("packaged POWER Skill tree is missing SKILL.md")
+    return SkillTree(files=files, sha256=_aggregate_tree_hash(files))
+
+
+def _tree_from_directory(root: Path) -> dict[str, bytes]:
+    """Read a target directory using relative POSIX paths."""
+    if not root.is_dir():
+        return {}
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file() and not path.is_symlink()
+    }
+
+
+def _is_managed_skill_tree(files: dict[str, bytes], source: SkillTree) -> bool:
+    """Recognize an existing POWER Skill tree without trusting its contents."""
+    if set(files) != set(source.files):
+        return False
+    header = files.get("SKILL.md", b"").decode("utf-8", errors="ignore")
+    return header.startswith("---\n") and "\nname: power\n" in header
+
+
+def _safe_target(path: str | Path, *, label: str) -> Path:
+    """Reject filesystem roots and symlinks for managed integration targets."""
+    target = Path(path).expanduser()
+    if target == target.parent or target == Path.home().resolve():
+        raise ValueError(f"{label} must be a dedicated child directory, not a filesystem root")
+    if target.exists() and target.is_symlink():
+        raise ValueError(f"{label} symlinks are not followed")
+    return target.resolve()
+
+
+def build_skill_check_plan(target: str | Path) -> dict[str, Any]:
+    """Build a read-only Skill install/check plan."""
+    skill = packaged_skill_tree()
+    target_path = _safe_target(target, label="Skill target")
+    target_files = _tree_from_directory(target_path)
+    target_hash = _aggregate_tree_hash(target_files) if target_files else None
+    if target_files == skill.files:
+        status = "no_change"
+    elif target_files and _is_managed_skill_tree(target_files, skill):
+        status = "upgrade_ready"
+    elif target_files:
+        status = "manual_review"
+    else:
+        status = "ready"
+    return {
+        "schema": SKILL_SCHEMA_VERSION,
+        "status": status,
+        "skill": SKILL_NAME,
+        "source": {"tree_sha256": skill.sha256, "files": sorted(skill.files)},
+        "target": {"path": str(target_path), "tree_sha256": target_hash},
+        "write_required": status in {"ready", "upgrade_ready"},
+        "overwrite_policy": "replace_only_hash_bound_managed_target",
+    }
+
+
+def apply_skill_install_plan(plan: dict[str, Any], *, approved: bool) -> dict[str, Any]:
+    """Atomically install a missing Skill tree after an explicit approval."""
+    if not approved:
+        raise PermissionError("skill install requires explicit approved=True")
+    if plan.get("schema") != SKILL_SCHEMA_VERSION:
+        raise ValueError("unsupported Skill plan schema")
+    target = _safe_target(plan["target"]["path"], label="Skill target")
+    current = build_skill_check_plan(target)
+    if current["status"] == "no_change":
+        return {"schema": SKILL_SCHEMA_VERSION, "status": "no_change", "target": str(target)}
+    if current["status"] == "manual_review":
+        raise PermissionError("Skill target exists with different content; manual review required")
+    if current["target"]["tree_sha256"] != plan["target"].get("tree_sha256"):
+        raise RuntimeError("Skill target changed after the plan was created")
+    if current["status"] not in {"ready", "upgrade_ready"}:
+        raise RuntimeError(f"unsupported Skill plan status: {current['status']}")
+    skill = packaged_skill_tree()
+    if skill.sha256 != plan["source"]["tree_sha256"]:
+        raise RuntimeError("Skill source changed after the plan was created")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{target.name}.staging-", dir=target.parent))
+    previous: Path | None = None
+    try:
+        for relative, content in skill.files.items():
+            destination = staging / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(content)
+            destination.chmod(0o755 if relative.startswith("scripts/") else 0o644)
+        if target.exists():
+            previous = target.parent / f".{target.name}.previous-{os.getpid()}"
+            os.replace(target, previous)
+        os.replace(staging, target)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        if previous is not None and previous.exists() and not target.exists():
+            os.replace(previous, target)
+        raise
+    if previous is not None:
+        shutil.rmtree(previous)
+    return {
+        "schema": SKILL_SCHEMA_VERSION,
+        "status": "applied",
+        "target": str(target),
+        "tree_sha256": skill.sha256,
+        "files": len(skill.files),
+    }
+
+
+def build_integrations_doctor() -> dict[str, Any]:
+    """Return read-only facts about the available suite integration surfaces."""
+    skill = packaged_skill_tree()
+    try:
+        mcp_version = importlib.metadata.version("mcp")
+    except importlib.metadata.PackageNotFoundError:
+        mcp_version = None
+    try:
+        power_version = importlib.metadata.version("power-framework")
+    except importlib.metadata.PackageNotFoundError:
+        power_version = None
+    home = Path.home()
+    venv_root = home / ".local" / "share" / "power" / "venv"
+    launchers = {
+        name: home / ".local" / "bin" / name for name in ("power", "power-mcp", "power-gui")
+    }
+    return {
+        "schema": INTEGRATIONS_SCHEMA_VERSION,
+        "status": "ok"
+        if mcp_version and all(path.is_file() for path in launchers.values())
+        else "incomplete",
+        "runtime": {
+            "power_framework": power_version,
+            "mcp_sdk": mcp_version,
+            "python": sys.version.split()[0],
+        },
+        "native": {
+            "venv": str(venv_root),
+            "venv_exists": venv_root.is_dir(),
+            "launchers": {
+                name: {"path": str(path), "exists": path.is_file()}
+                for name, path in launchers.items()
+            },
+        },
+        "skill": {
+            "source": f"skills/{SKILL_NAME}",
+            "tree_sha256": skill.sha256,
+            "files": len(skill.files),
+        },
+        "mcp": {"entry_point": "power-mcp", "transport": "stdio", "vault_env": "POWER_VAULT_DIR"},
+    }
+
+
+def build_mcp_config_integration_plan(
+    vault_path: str | Path,
+    *,
+    client: ConnectClient = "auto",
+    config_path: str | Path | None = None,
+    executable: str = "power-mcp",
+    remove: bool = False,
+) -> dict[str, Any]:
+    """Build the generic, hash-bound MCP client config plan."""
+    plan = build_connect_plan(
+        client,
+        Path(vault_path).expanduser().resolve(),
+        config_path=Path(config_path).expanduser() if config_path else None,
+        executable=executable,
+        action="remove" if remove else "install",
+    ).as_dict()
+    plan["integration"] = "mcp-config"
+    plan["entry_point"] = "power-mcp"
+    return plan
+
+
+def apply_mcp_config_integration_plan(plan: dict[str, Any], *, approved: bool) -> dict[str, Any]:
+    """Apply a previously planned MCP config transaction."""
+    return apply_connect_plan(plan, approved=approved)
+
+
+def _sha256_file(path: Path) -> str:
+    """Hash an exact wheel or artifact file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _wheel_dependencies(path: Path) -> list[str]:
+    """Read ordinary runtime dependencies from a wheel without importing it."""
+    with zipfile.ZipFile(path) as archive:
+        metadata_name = next(
+            name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+        )
+        metadata = archive.read(metadata_name).decode("utf-8")
+    dependencies = []
+    for line in metadata.splitlines():
+        if not line.startswith("Requires-Dist:"):
+            continue
+        requirement = line.split(":", 1)[1].strip()
+        if requirement.lower().startswith("power-framework"):
+            continue
+        dependencies.append(requirement)
+    return dependencies
+
+
+def build_native_install_plan(
+    *,
+    home: str | Path | None = None,
+    power_wheel: str | Path | None = None,
+    gui_wheel: str | Path | None = None,
+) -> dict[str, Any]:
+    """Build a dry-run native installer plan for one managed venv."""
+    install_home = _safe_target(home or Path.home() / ".power-install-home", label="installer home")
+    if home is None:
+        install_home = Path.home().resolve()
+    managed = install_home / ".local" / "share" / "power"
+    venv_root = managed / "venv"
+    launcher_dir = install_home / ".local" / "bin"
+    if not power_wheel:
+        return {
+            "schema": NATIVE_INSTALL_SCHEMA_VERSION,
+            "status": "blocked",
+            "reason": "an exact POWER wheel is required",
+            "native": {
+                "home": str(install_home),
+                "venv": str(venv_root),
+                "launcher_dir": str(launcher_dir),
+            },
+        }
+    power_path = Path(power_wheel).expanduser().resolve()
+    if not power_path.is_file() or power_path.suffix != ".whl":
+        raise ValueError("power_wheel must be an existing .whl file")
+    gui_path = Path(gui_wheel).expanduser().resolve() if gui_wheel else None
+    if gui_path is not None and (not gui_path.is_file() or gui_path.suffix != ".whl"):
+        raise ValueError("gui_wheel must be an existing .whl file")
+    state_path = managed / "suite-install.json"
+    return {
+        "schema": NATIVE_INSTALL_SCHEMA_VERSION,
+        "status": "ready" if not state_path.is_file() else "update",
+        "native": {
+            "home": str(install_home),
+            "venv": str(venv_root),
+            "launcher_dir": str(launcher_dir),
+            "state": str(state_path),
+        },
+        "artifacts": {
+            "power_wheel": {"path": str(power_path), "sha256": _sha256_file(power_path)},
+            "gui_wheel": (
+                {"path": str(gui_path), "sha256": _sha256_file(gui_path)} if gui_path else None
+            ),
+        },
+        "launchers": ["power", "power-mcp", "power-gui"] if gui_path else ["power", "power-mcp"],
+        "system_python_mutation": False,
+        "dry_run_default": True,
+    }
+
+
+def _write_executable(path: Path, content: str) -> None:
+    """Atomically install one executable launcher."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.staging-{os.getpid()}")
+    temporary.write_text(content, encoding="utf-8")
+    temporary.chmod(
+        stat.S_IRUSR
+        | stat.S_IWUSR
+        | stat.S_IXUSR
+        | stat.S_IRGRP
+        | stat.S_IXGRP
+        | stat.S_IROTH
+        | stat.S_IXOTH
+    )
+    os.replace(temporary, path)
+
+
+def apply_native_install_plan(
+    plan: dict[str, Any],
+    *,
+    approved: bool,
+    no_deps: bool = False,
+) -> dict[str, Any]:
+    """Create the managed venv, install exact wheels, and publish launchers."""
+    if not approved:
+        raise PermissionError("native install requires explicit approved=True")
+    if plan.get("schema") != NATIVE_INSTALL_SCHEMA_VERSION or plan.get("status") == "blocked":
+        raise ValueError("native install plan is not applicable")
+    native = plan["native"]
+    venv_root = Path(native["venv"])
+    launcher_dir = Path(native["launcher_dir"])
+    venv_python = venv_root / "bin" / "python"
+    if not venv_python.is_file():
+        venv.EnvBuilder(with_pip=True, clear=False, symlinks=True).create(venv_root)
+
+    power_artifact = plan["artifacts"]["power_wheel"]
+    artifacts = [power_artifact]
+    gui_artifact = plan["artifacts"].get("gui_wheel")
+    if gui_artifact:
+        artifacts.append(gui_artifact)
+    for artifact in artifacts:
+        path = Path(artifact["path"])
+        if _sha256_file(path) != artifact["sha256"]:
+            raise RuntimeError(f"artifact changed after the plan was created: {path}")
+        command = [
+            str(venv_python),
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--no-input",
+            "--upgrade",
+        ]
+        if no_deps:
+            command.append("--no-deps")
+        if artifact is power_artifact and not no_deps:
+            command.append(f"{path}[remote]")
+        elif artifact is gui_artifact and not no_deps:
+            command.append("--no-deps")
+            command.append(str(path))
+        else:
+            command.append(str(path))
+        subprocess.run(command, check=True, capture_output=True, text=True)  # noqa: S603
+        if artifact is gui_artifact and not no_deps:
+            dependencies = _wheel_dependencies(path)
+            if dependencies:
+                dependency_command = [
+                    str(venv_python),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--disable-pip-version-check",
+                    "--no-input",
+                    "--upgrade",
+                    *dependencies,
+                ]
+                subprocess.run(  # noqa: S603 - dependencies come from verified wheel metadata
+                    dependency_command,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+
+    venv_text = str(venv_root)
+    _write_executable(launcher_dir / "power", f"#!/bin/sh\nexec '{venv_text}/bin/power' \"$@\"\n")
+    _write_executable(
+        launcher_dir / "power-mcp",
+        f"#!/bin/sh\nexec '{venv_text}/bin/power-mcp' \"$@\"\n",
+    )
+    if plan["artifacts"].get("gui_wheel"):
+        _write_executable(
+            launcher_dir / "power-gui",
+            f"#!/bin/sh\nexec '{venv_text}/bin/power-gui' \"$@\"\n",
+        )
+    receipt = {
+        "schema": NATIVE_INSTALL_SCHEMA_VERSION,
+        "status": "applied",
+        "venv": str(venv_root),
+        "launchers": [
+            str(launcher_dir / name)
+            for name in ("power", "power-mcp", "power-gui")
+            if name != "power-gui" or plan["artifacts"].get("gui_wheel")
+        ],
+        "artifacts": plan["artifacts"],
+        "no_deps": no_deps,
+    }
+    state_path = Path(native["state"])
+    atomic_write(
+        state_path, json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    )
+    return receipt
+
+
+__all__ = [
+    "apply_mcp_config_integration_plan",
+    "apply_native_install_plan",
+    "apply_skill_install_plan",
+    "build_integrations_doctor",
+    "build_mcp_config_integration_plan",
+    "build_native_install_plan",
+    "build_skill_check_plan",
+    "packaged_skill_tree",
+]

--- a/src/power_framework/mcp/__main__.py
+++ b/src/power_framework/mcp/__main__.py
@@ -1,4 +1,4 @@
-"""P.O.W.E.R. MCP Server — Entry point. Run with: python -m power_framework.mcp"""
+"""Compatibility module entry point; native installs should use ``power-mcp``."""
 
 from __future__ import annotations
 

--- a/src/power_framework/mcp/entrypoint.py
+++ b/src/power_framework/mcp/entrypoint.py
@@ -1,0 +1,68 @@
+"""Public ``power-mcp`` console entry point and fail-closed preflight."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import TYPE_CHECKING
+
+from power_framework.core import __version__
+
+from .preflight import require_configured_vault_root
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="power-mcp",
+        description="Run the local POWER MCP server over stdio or the explicitly configured loopback HTTP profile.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"power-mcp {__version__}",
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=("preflight",),
+        help="Run a read-only vault-root preflight without starting the server.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run ``power-mcp`` or its read-only preflight command."""
+    args = _build_parser().parse_args(argv)
+    try:
+        vault_root = require_configured_vault_root()
+    except RuntimeError as exc:
+        sys.stderr.write(f"power-mcp preflight failed: {exc}\n")
+        return 2
+
+    if args.command == "preflight":
+        payload = json.dumps(
+            {
+                "status": "ok",
+                "transport": "stdio",
+                "vault_root": str(vault_root),
+                "power_version": __version__,
+            },
+            sort_keys=True,
+        )
+        sys.stdout.write(f"{payload}\n")
+        return 0
+
+    # Keep --version and preflight usable in the lean FTS-only installation;
+    # the official SDK is loaded only when the server process is requested.
+    from .power_server import run
+
+    run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/power_framework/mcp/power_server.py
+++ b/src/power_framework/mcp/power_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-P.O.W.E.R. MCP Server (FastMCP 3.x).
+P.O.W.E.R. MCP Server (official MCP Python SDK v2).
 
 Exposes MCP tools for AI agent interaction with the knowledge vault:
 - lint_vault: Health check for metadata, links, and orphans
@@ -18,24 +18,26 @@ Exposes MCP tools for AI agent interaction with the knowledge vault:
 - heal_frontmatter_tool: Auto-fix missing/invalid frontmatter
 - check_markdown_tool: Markdown quality audit
 
-Supports stdio transport (local) and HTTP transport (Docker, with /health endpoint).
+Uses the official MCP Python SDK v2 and supports stdio transport (local) plus
+Streamable HTTP transport (Docker, with /health endpoint).
 """
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import os
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Literal
+import re
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
-from fastmcp import FastMCP
-from fastmcp.exceptions import ToolError
-from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
+from mcp.types import CallToolResult, InputRequiredResult, TextContent, ToolAnnotations
 from starlette.responses import JSONResponse
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from starlette.requests import Request
@@ -45,31 +47,17 @@ from power_framework.core import (
     DEFAULT_SEARCH_MODE,
     PARA_FOLDERS,
     ApplicationService,
-    MemoryKind,
-    MemoryMetadata,
-    NoteType,
-    OKFMetadata,
     RateLimiter,
     RequestContext,
-    WritePolicy,
     __version__,
-    archive_stale_notes,
-    build_frontmatter,
-    commit_note_change,
     enforce_cpu_throttling_env,
     get_context,
-    heal_vault,
     normalize_search_mode,
     read_file_content,
-    resolve_path_in_vault,
     resolve_vault_path,
     run_blocking,
-    run_generate_hierarchical_index,
-    run_generate_sub_index,
     run_lint_report,
     run_rot_report,
-    run_vault_mutation,
-    scan_folder_notes,
     search_vault,
     validate_state,
     validate_vault_path,
@@ -81,26 +69,128 @@ from power_framework.core.constants import SKIP_FILES
 from power_framework.core.doctor import report_as_json, run_doctor
 from power_framework.core.domains import DomainConfigError
 from power_framework.core.ignore import should_skip
-from power_framework.core.synthesize import synthesize_session_ingest
 from power_framework.experimental.relations import (
     format_relation_suggestions,
     suggest_related,
     suggest_related_semantic,
 )
 
+from .preflight import require_configured_vault_root
+
 logger = logging.getLogger(__name__)
 
-mcp = FastMCP(
+_MCP_ANNOTATION_ALIASES = {
+    "readOnlyHint": "read_only_hint",
+    "destructiveHint": "destructive_hint",
+    "idempotentHint": "idempotent_hint",
+    "openWorldHint": "open_world_hint",
+}
+_ToolCallable = TypeVar("_ToolCallable", bound=Callable[..., Any])
+_ABSOLUTE_PATH_RE = re.compile(r"(?<![\w])/(?:[^\s'\"`,;)]*)+")
+
+
+def _normalize_tool_annotations(
+    annotations: ToolAnnotations | Mapping[str, Any] | None,
+) -> ToolAnnotations | None:
+    """Normalize legacy dict-shaped annotation calls for the official SDK."""
+    if annotations is None or isinstance(annotations, ToolAnnotations):
+        return annotations
+    normalized = {
+        _MCP_ANNOTATION_ALIASES.get(key, key): value for key, value in annotations.items()
+    }
+    return ToolAnnotations.model_validate(normalized)
+
+
+def _safe_mcp_error_text(error: Exception) -> str:
+    """Return actionable MCP error text without absolute paths or tracebacks."""
+    message = str(error).strip()
+    if not message or "Traceback (most recent call last)" in message:
+        return "POWER MCP tool failed; inspect the server log for details."
+    message = _ABSOLUTE_PATH_RE.sub("<path>", message)
+    return message[:512]
+
+
+class PowerMCPServer(MCPServer):
+    """Official MCP SDK v2 server with POWER compatibility and safety seams."""
+
+    def tool(
+        self,
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        annotations: ToolAnnotations | Mapping[str, Any] | None = None,
+        icons: list[Any] | None = None,
+        meta: dict[str, Any] | None = None,
+        structured_output: bool | None = None,
+    ) -> Callable[[_ToolCallable], _ToolCallable]:
+        """Register a tool while accepting the pre-v2 annotation spelling."""
+        return super().tool(
+            name=name,
+            title=title,
+            description=description,
+            annotations=_normalize_tool_annotations(annotations),
+            icons=icons,
+            meta=meta,
+            structured_output=structured_output,
+        )
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Any = None,
+    ) -> CallToolResult | InputRequiredResult:
+        """Execute a tool and convert SDK execution errors to safe results."""
+        try:
+            result = await super().call_tool(name, arguments, context)
+        except ToolError as exc:
+            logger.exception("MCP tool execution failed: %s", name)
+            return CallToolResult(
+                content=[TextContent(type="text", text=_safe_mcp_error_text(exc))],
+                is_error=True,
+            )
+        return result
+
+    def run(self, transport: str = "stdio", **kwargs: Any) -> None:
+        """Run official SDK transports while retaining POWER's ``http`` alias."""
+        if transport == "http":
+            transport = "streamable-http"
+        if transport not in {"stdio", "sse", "streamable-http"}:
+            raise ValueError(f"Unsupported MCP transport: {transport}")
+        supported_transport = cast("Literal['stdio', 'sse', 'streamable-http']", transport)
+        super().run(transport=supported_transport, **kwargs)
+
+    def custom_route(
+        self,
+        path: str,
+        methods: list[str],
+        name: str | None = None,
+        include_in_schema: bool = True,
+    ) -> Callable[
+        [Callable[[Request], Awaitable[Response]]], Callable[[Request], Awaitable[Response]]
+    ]:
+        """Expose a typed custom-route decorator because SDK v2 omits its return type."""
+        return cast(
+            "Callable[[Callable[[Request], Awaitable[Response]]], Callable[[Request], Awaitable[Response]]]",
+            super().custom_route(
+                path,
+                methods,
+                name=name,
+                include_in_schema=include_in_schema,
+            ),
+        )
+
+    def http_app(self, *, transport: str = "http", **kwargs: Any) -> Any:
+        """Compatibility alias for tests and integrations using the old API."""
+        if transport != "http":
+            raise ValueError(f"Unsupported HTTP transport alias: {transport}")
+        return self.streamable_http_app(**kwargs)
+
+
+mcp = PowerMCPServer(
     "power",
     version=__version__,
     instructions=f"P.O.W.E.R. {__version__} — Hybrid Knowledge Management Framework",
-    mask_error_details=True,
-)
-mcp.add_middleware(
-    ErrorHandlingMiddleware(
-        include_traceback=False,
-        transform_errors=True,
-    )
 )
 
 _write_limiter = RateLimiter(max_calls=10, period=60.0)
@@ -221,29 +311,6 @@ def _get_vault_path(vault_path: str | None = None) -> Path:
     return resolve_vault_path(args)
 
 
-def _require_configured_vault_root() -> Path:
-    """Require a canonical vault root before the MCP server accepts clients."""
-    configured_root = os.getenv("POWER_VAULT_DIR") or os.getenv("POWER_VAULT_PATH")
-    if not configured_root:
-        raise RuntimeError(
-            "POWER_VAULT_DIR (or POWER_VAULT_PATH) must be configured before starting the MCP server"
-        )
-    try:
-        return validate_vault_path(configured_root)
-    except (FileNotFoundError, NotADirectoryError, ValueError) as exc:
-        raise RuntimeError("POWER_VAULT_DIR must reference an existing vault directory") from exc
-
-
-def _resolve_note_target(vault_path: Path, name: str) -> Path:
-    """Resolve untrusted MCP note names only within approved PARA folders."""
-    try:
-        return resolve_path_in_vault(vault_path, name, allowed_directories=PARA_FOLDERS)
-    except ValueError as exc:
-        raise ToolError(
-            "Invalid note path; use an existing PARA directory and a Markdown filename."
-        ) from exc
-
-
 def _get_http_transport_config() -> tuple[str, int]:
     """Return a fail-closed local-only HTTP MCP transport configuration."""
     host = os.getenv("POWER_MCP_HOST", "127.0.0.1")
@@ -266,7 +333,7 @@ def _get_http_transport_config() -> tuple[str, int]:
 async def health_check(_request: Request) -> Response:
     """Report whether the configured vault boundary is ready for HTTP clients."""
     try:
-        _require_configured_vault_root()
+        require_configured_vault_root()
     except RuntimeError as exc:
         return JSONResponse({"status": "error", "detail": str(exc)}, status_code=503)
     return JSONResponse({"status": "ok"})
@@ -331,8 +398,12 @@ async def generate_index(vault_path: str | None = None) -> str:
         )
 
     path = _get_vault_path(vault_path)
-    # Serialize index regeneration within this vault while preserving other-vault parallelism.
-    return await run_vault_mutation(path, lambda: run_generate_hierarchical_index(path))
+    envelope = await run_blocking(
+        lambda: ApplicationService(path).generate_index(
+            context=RequestContext(actor="mcp", authority="apply")
+        )
+    )
+    return str(envelope.data["result"])
 
 
 @mcp.tool(
@@ -372,59 +443,26 @@ async def sync_vault(
         )
 
     path = _get_vault_path(vault_path)
-
-    def _run() -> str:
-        from power_framework.core.generation_index import (
-            IndexGenerationError,
-            list_invalid_sources,
-            sync_vault_atomically,
-        )
-
-        invalid_sources = list_invalid_sources(path)
-        if invalid_sources and not allow_partial:
-            details = "; ".join(
-                f"{rel_path} ({reason})" for rel_path, reason in sorted(invalid_sources.items())
-            )
-            raise ToolError(
-                "Vault sync failed closed: "
-                f"{len(invalid_sources)} note(s) are excluded and remain unsearchable. "
-                f"Excluded: {details}. Pass allow_partial=True only to publish the valid subset."
-            )
-
-        try:
-            report = sync_vault_atomically(
-                path,
-                sync_embeddings=not fts_only,
+    try:
+        envelope = await run_blocking(
+            lambda: ApplicationService(path).sync_vault(
+                fts_only=fts_only,
+                accept_dense_loss=accept_dense_loss,
                 force_rebuild=force_rebuild,
                 allow_partial=allow_partial,
-                accept_dense_loss=accept_dense_loss,
+                context=RequestContext(actor="mcp", authority="apply"),
             )
-        except IndexGenerationError as exc:
-            raise ToolError(f"Vault sync failed; previous index remains active: {exc}") from exc
-
-        lines = [
-            "=== Vault Sync ===",
-            f"Generation: {report.generation_id}",
-            f"Mode: {'FTS only' if fts_only else 'FTS + embeddings'}",
-            f"Notes scanned: {report.total_scanned}",
-            f"Notes indexed: {report.actual_files}",
-            f"Notes excluded (invalid metadata): {report.invalid_sources}",
-            f"Chunks: {report.actual_chunks}",
-        ]
-        if report.invalid_sources:
-            lines.append("")
-            lines.append("Exclusion reasons:")
-            lines.extend(
-                f"- {rel_path}: {reason}"
-                for rel_path, reason in sorted(report.excluded_sources.items())
-            )
-            lines.append(
-                "Excluded notes are not searchable. Run 'power index <vault> --strict' "
-                "to list them, or heal_frontmatter_tool to repair them."
-            )
-        return "\n".join(lines)
-
-    return await run_vault_mutation(path, _run)
+        )
+    except (
+        FileExistsError,
+        FileNotFoundError,
+        PermissionError,
+        RuntimeError,
+        ValueError,
+        OSError,
+    ) as exc:
+        raise ToolError(str(exc)) from exc
+    return str(envelope.data["result"])
 
 
 @mcp.tool(
@@ -468,28 +506,26 @@ async def ensure_sub_index(category: str, vault_path: str | None = None, page: i
     """Generate and read one bounded page of a P.A.R.A. sub-index."""
     path = _get_vault_path(vault_path)
     page = _validate_catalog_page(page)
-
-    if category not in PARA_FOLDERS:
-        raise ToolError(f"Invalid category: {category}. Must be one of: {', '.join(PARA_FOLDERS)}")
-
-    category_path = path / category
-    if not category_path.is_dir():
-        raise ToolError(f"Category folder not found: {category}")
-
-    folder_notes = await run_blocking(lambda: scan_folder_notes(path))
-    notes = folder_notes.get(category, [])
-
-    if not notes:
-        return f"No notes found in {category}."
-
-    def _gen_and_read() -> str:
-        result = run_generate_sub_index(path, category)
-        content = _read_catalog_page(category_path, page)
-        if content is None:
-            raise ToolError(f"Generated catalog landing page is missing for {category}")
-        return f"{result}\n\n{content}"
-
-    return await run_vault_mutation(path, _gen_and_read)
+    try:
+        envelope = await run_blocking(
+            lambda: ApplicationService(path).ensure_sub_index(
+                category,
+                page=page,
+                context=RequestContext(actor="mcp", authority="apply"),
+            )
+        )
+    except (
+        FileExistsError,
+        FileNotFoundError,
+        PermissionError,
+        RuntimeError,
+        ValueError,
+        OSError,
+    ) as exc:
+        raise ToolError(str(exc)) from exc
+    result = str(envelope.data["result"])
+    content = str(envelope.data.get("content", ""))
+    return f"{result}\n\n{content}" if content else result
 
 
 @mcp.tool(
@@ -519,63 +555,33 @@ async def ingest_note(
         )
 
     path = _get_vault_path(vault_path)
-    tags = tags or []
-
-    if not name.endswith(".md"):
-        name += ".md"
-
-    target_file = _resolve_note_target(path, name)
-
-    if target_file.exists():
-        raise ToolError(f"Note already exists at {name}")
-
-    timestamp = datetime.now(UTC)
-    metadata = OKFMetadata(
-        type=NoteType(note_type),
-        title=title,
-        description=description,
-        resource=resource,
-        tags=tags,
-        okf_version="0.2",
-        memory=MemoryMetadata(
-            kind=MemoryKind.SEMANTIC,
-            sources=["power://mcp/ingest_note"],
-            evidence=[f"sha256:{hashlib.sha256(content.encode('utf-8')).hexdigest()}"],
-            write_policy=WritePolicy.AGENT_PROPOSED,
-        ),
-        timestamp=timestamp,
-    )
-
-    frontmatter = build_frontmatter(metadata)
-    full_content = f"{frontmatter}\n\n{content}\n"
-
-    def _write_and_index() -> str:
-        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
-        log_entry = (
-            f"\n## [{date_str}] ingest | Created {title}\n"
-            f"- **Action:** Created note '{name}' of type {note_type} via MCP tool ingest_note.\n"
-            f"- **Result:** Saved note to {name} and compiled hierarchical index.\n"
+    try:
+        envelope = await run_blocking(
+            lambda: ApplicationService(path).ingest_note(
+                name=name,
+                note_type=note_type,
+                title=title,
+                description=description,
+                content=content,
+                resource=resource,
+                tags=tags,
+                context=RequestContext(actor="mcp", authority="apply"),
+            )
         )
-        receipt = commit_note_change(
-            path,
-            name,
-            full_content,
-            require_absent=True,
-            allowed_directories=PARA_FOLDERS,
-            operation="mcp.ingest_note",
-            log_entry=log_entry,
-        )
-        lint_result = run_lint_report(path)
-        return (
-            f"Note '{name}' has been successfully ingested!\n"
-            f"{receipt['index_summary']}\n"
-            f"Search projection: {receipt['search_mode']} ({receipt['search_generation']})\n"
-            f"Action appended to log.md when the log exists.\n\n"
-            f"Linting Check:\n{lint_result}"
-        )
-
-    # The shared transaction owns the mutation lock and all projections.
-    return await run_blocking(_write_and_index)
+    except (
+        FileExistsError,
+        FileNotFoundError,
+        PermissionError,
+        RuntimeError,
+        ValueError,
+        OSError,
+    ) as exc:
+        if "path" in str(exc).lower() or "traversal" in str(exc).lower():
+            raise ToolError(
+                "Invalid note path; use an existing PARA directory and a Markdown filename."
+            ) from exc
+        raise ToolError(str(exc)) from exc
+    return str(envelope.data["result"])
 
 
 @mcp.tool(
@@ -902,34 +908,34 @@ async def synthesize_session(
         )
 
     path = _get_vault_path(vault_path)
-    tags = tags or []
-    related_list = related or []
-
-    if not name.endswith(".md"):
-        name += ".md"
-
-    target_file = _resolve_note_target(path, name)
-    if target_file.exists():
-        raise ToolError(f"Note already exists at {name}")
-
-    timestamp = datetime.now(UTC)
-
-    def _write_and_index() -> str:
-        return synthesize_session_ingest(
-            name=name,
-            title=title,
-            description=description,
-            content=content,
-            note_type=note_type,
-            tags=tags,
-            related=related_list,
-            owner=owner,
-            vault_path=path,
-            timestamp=timestamp,
+    try:
+        envelope = await run_blocking(
+            lambda: ApplicationService(path).synthesize_session(
+                name=name,
+                title=title,
+                description=description,
+                content=content,
+                note_type=note_type,
+                tags=tags,
+                related=related,
+                owner=owner,
+                context=RequestContext(actor="mcp", authority="apply"),
+            )
         )
-
-    # The shared transaction owns the mutation lock and all projections.
-    return await run_blocking(_write_and_index)
+    except (
+        FileExistsError,
+        FileNotFoundError,
+        PermissionError,
+        RuntimeError,
+        ValueError,
+        OSError,
+    ) as exc:
+        if "path" in str(exc).lower() or "traversal" in str(exc).lower():
+            raise ToolError(
+                "Invalid note path; use an existing PARA directory and a Markdown filename."
+            ) from exc
+        raise ToolError(str(exc)) from exc
+    return str(envelope.data["result"])
 
 
 @mcp.tool(
@@ -959,9 +965,13 @@ async def rot_audit(vault_path: str | None = None, extended: bool = False) -> st
 async def archive_notes(dry_run: bool = True, vault_path: str | None = None) -> str:
     """Move stale/expired notes to 04_Archive. Use dry_run=True (default) to preview first."""
     path = _get_vault_path(vault_path)
-    if dry_run:
-        return await run_blocking(lambda: archive_stale_notes(path, dry_run=True))
-    return await run_vault_mutation(path, lambda: archive_stale_notes(path, dry_run=False))
+    envelope = await run_blocking(
+        lambda: ApplicationService(path).archive_notes(
+            dry_run=dry_run,
+            context=RequestContext(actor="mcp", authority="apply") if not dry_run else None,
+        )
+    )
+    return str(envelope.data["result"])
 
 
 @mcp.tool(
@@ -1012,9 +1022,13 @@ async def heal_frontmatter_tool(
 ) -> str:
     """Scan and heal missing/invalid frontmatter fields across vault notes. Use dry_run=True (default) to preview first."""
     path = _get_vault_path(vault_path)
-    if dry_run:
-        return await run_blocking(lambda: heal_vault(path, dry_run=True))
-    return await run_vault_mutation(path, lambda: heal_vault(path, dry_run=False))
+    envelope = await run_blocking(
+        lambda: ApplicationService(path).heal_frontmatter(
+            dry_run=dry_run,
+            context=RequestContext(actor="mcp", authority="apply") if not dry_run else None,
+        )
+    )
+    return str(envelope.data["result"])
 
 
 @mcp.tool(
@@ -1081,11 +1095,11 @@ def run() -> None:
     enforce_cpu_throttling_env()
     transport = os.getenv("POWER_MCP_TRANSPORT", "stdio")
     if transport == "http":
-        _require_configured_vault_root()
+        require_configured_vault_root()
         host, port = _get_http_transport_config()
         mcp.run(transport="http", host=host, port=port)
     elif transport == "stdio":
-        _require_configured_vault_root()
+        require_configured_vault_root()
         mcp.run(transport="stdio")
     else:
         raise ValueError("POWER_MCP_TRANSPORT must be either 'stdio' or 'http'")

--- a/src/power_framework/mcp/preflight.py
+++ b/src/power_framework/mcp/preflight.py
@@ -1,0 +1,24 @@
+"""Dependency-light checks shared by the public MCP launcher and server."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from power_framework.core import validate_vault_path
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def require_configured_vault_root() -> Path:
+    """Require one existing, explicitly configured vault directory."""
+    configured_root = os.getenv("POWER_VAULT_DIR") or os.getenv("POWER_VAULT_PATH")
+    if not configured_root:
+        raise RuntimeError(
+            "POWER_VAULT_DIR (or POWER_VAULT_PATH) must be configured before starting the MCP server"
+        )
+    try:
+        return validate_vault_path(configured_root)
+    except (FileNotFoundError, NotADirectoryError, ValueError) as exc:
+        raise RuntimeError("POWER_VAULT_DIR must reference an existing vault directory") from exc

--- a/tests/mcp_test_client.py
+++ b/tests/mcp_test_client.py
@@ -1,0 +1,48 @@
+"""Official MCP SDK v2 subprocess fixtures used by protocol contract tests."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+from mcp import ClientSession, StdioServerParameters, stdio_client, types
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+def _stdio_server_parameters(config: dict[str, Any]) -> StdioServerParameters:
+    """Convert the documented client shape into SDK subprocess parameters."""
+    if "mcpServers" in config:
+        server = config["mcpServers"]["power"]
+        environment = server["env"]
+    elif "mcp_servers" in config:
+        server = config["mcp_servers"]["power"]
+        environment = server["env"]
+    else:
+        raise AssertionError("test config must contain mcpServers or mcp_servers")
+    return StdioServerParameters(
+        command=server["command"],
+        args=server["args"],
+        env=environment,
+    )
+
+
+@asynccontextmanager
+async def stdio_session(
+    config: dict[str, Any],
+    *,
+    mode: str = "legacy",
+) -> AsyncIterator[ClientSession]:
+    """Connect to a real subprocess using legacy or 2026-era handshake mode."""
+    parameters = _stdio_server_parameters(config)
+    async with (
+        stdio_client(parameters) as (read_stream, write_stream),
+        ClientSession(read_stream, write_stream) as session,
+    ):
+        if mode == "legacy":
+            await session.initialize()
+        else:
+            discovered = await session.send_discover(mode)
+            session.adopt(types.DiscoverResult.model_validate(discovered))
+        yield session

--- a/tests/test_complexity_dashboard.py
+++ b/tests/test_complexity_dashboard.py
@@ -14,7 +14,7 @@ def test_complexity_dashboard_reports_frozen_metrics() -> None:
 
     assert report["schema_version"] == "power.complexity-dashboard.v1"
     assert report["baseline_revision"] == "v3.4.5"
-    assert report["current"]["cli_commands"] == 25
+    assert report["current"]["cli_commands"] == 26
     assert report["current"]["mcp_tools"] == 20
     assert report["canonical_workflows"] <= 7
     assert report["budget"]["duplicate_skill_sources_zero"] is True

--- a/tests/test_cross_process_mutation.py
+++ b/tests/test_cross_process_mutation.py
@@ -1,0 +1,75 @@
+"""Cross-process proof for the canonical vault mutation boundary."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_SCRIPT = "from power_framework.core.cli import main; raise SystemExit(main())"
+
+
+def _run_cli(arguments: list[str], environment: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run one source-checkout CLI child with a fixed executable and cwd."""
+    return subprocess.run(  # noqa: S603 - executable and arguments are test-local constants.
+        [sys.executable, "-c", CLI_SCRIPT, *arguments],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_parallel_cli_processes_preserve_one_canonical_vault_state(tmp_path: Path) -> None:
+    """Two independent processes can mutate one vault without lost notes/catalog state."""
+    vault = tmp_path / "vault"
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO_ROOT / "src"), environment.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+
+    initialized = _run_cli(["init", str(vault)], environment)
+    assert initialized.returncode == 0, initialized.stderr
+
+    commands = [
+        [
+            "ingest",
+            str(vault),
+            "--type",
+            "Resource",
+            "--title",
+            "Process one",
+            "--description",
+            "Cross-process acceptance note one",
+            "--tags",
+            "process-one",
+        ],
+        [
+            "ingest",
+            str(vault),
+            "--type",
+            "Resource",
+            "--title",
+            "Process two",
+            "--description",
+            "Cross-process acceptance note two",
+            "--tags",
+            "process-two",
+        ],
+    ]
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda command: _run_cli(command, environment), commands))
+
+    assert [result.returncode for result in results] == [0, 0], [
+        result.stderr for result in results
+    ]
+    assert (vault / "03_Resources" / "process_one.md").is_file()
+    assert (vault / "03_Resources" / "process_two.md").is_file()
+    catalog = (vault / "03_Resources" / "_index.md").read_text(encoding="utf-8")
+    assert "Process one" in catalog
+    assert "Process two" in catalog
+    assert (vault / ".power" / "mutation.lock").is_file()

--- a/tests/test_doc_drift.py
+++ b/tests/test_doc_drift.py
@@ -85,7 +85,7 @@ def test_current_docs_match_executable_interfaces_and_safe_onboarding(
     documents = gate["_read_current_documents"]()
 
     assert facts["source"] == "power_framework.core.capabilities"
-    assert len(facts["interfaces"]["cli_commands"]) == 25
+    assert len(facts["interfaces"]["cli_commands"]) == 26
     assert len(facts["interfaces"]["mcp_tools"]) == 20
     assert gate["check_interfaces"](documents, facts) == []
     assert gate["check_onboarding"](documents, facts) == []
@@ -142,11 +142,11 @@ def test_interface_gate_rejects_stale_architecture_count() -> None:
     gate = _load_gate()
     facts = gate["_load_code_facts"]()
     documents = gate["_read_current_documents"]()
-    documents["Architecture"] = documents["Architecture"].replace("25 commands", "15 commands", 1)
+    documents["Architecture"] = documents["Architecture"].replace("26 commands", "15 commands", 1)
 
     errors = gate["check_interfaces"](documents, facts)
 
-    assert any("Architecture" in error and "25 CLI commands" in error for error in errors)
+    assert any("Architecture" in error and "26 CLI commands" in error for error in errors)
 
 
 def test_interface_gate_rejects_stale_readme_mcp_count() -> None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -47,7 +47,7 @@ def test_json_report_is_versioned_and_machine_readable(tmp_path: Path, monkeypat
     assert parsed["vault"]["index_state"] == "missing"
     assert parsed["issues"][0]["code"] == "search_index_missing"
     assert parsed["capabilities"] == capabilities.manifest()
-    assert len(parsed["capabilities"]["interfaces"]["cli_commands"]) == 25
+    assert len(parsed["capabilities"]["interfaces"]["cli_commands"]) == 26
     assert len(parsed["capabilities"]["interfaces"]["mcp_tools"]) == 20
     contracts = parsed["capabilities"]["interfaces"]["mcp_tool_contracts"]
     assert [contract["name"] for contract in contracts] == parsed["capabilities"]["interfaces"][

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,99 @@
+"""Tests for dry-run, idempotent suite integration contracts."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from power_framework.core.integrations import (
+    apply_mcp_config_integration_plan,
+    apply_skill_install_plan,
+    build_integrations_doctor,
+    build_mcp_config_integration_plan,
+    build_skill_check_plan,
+    packaged_skill_tree,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_packaged_skill_tree_is_content_addressed() -> None:
+    skill = packaged_skill_tree()
+    assert "SKILL.md" in skill.files
+    assert len(skill.sha256) == 64
+    assert skill.files == packaged_skill_tree().files
+
+
+def test_skill_install_is_dry_run_atomic_and_idempotent(tmp_path: Path) -> None:
+    target = tmp_path / "agent" / "skills" / "power"
+    plan = build_skill_check_plan(target)
+    assert plan["status"] == "ready"
+    assert not target.exists()
+
+    receipt = apply_skill_install_plan(plan, approved=True)
+    assert receipt["status"] == "applied"
+    assert (target / "SKILL.md").is_file()
+    assert build_skill_check_plan(target)["status"] == "no_change"
+    second = apply_skill_install_plan(build_skill_check_plan(target), approved=True)
+    assert second["status"] == "no_change"
+
+
+def test_skill_install_never_overwrites_nonmatching_target(tmp_path: Path) -> None:
+    target = tmp_path / "skill"
+    target.mkdir()
+    (target / "user-file.txt").write_text("user content\n", encoding="utf-8")
+    plan = build_skill_check_plan(target)
+    assert plan["status"] == "manual_review"
+
+
+def test_skill_install_can_upgrade_only_a_hash_bound_managed_tree(tmp_path: Path) -> None:
+    target = tmp_path / "skill"
+    source = packaged_skill_tree()
+    target.mkdir()
+    for relative, content in source.files.items():
+        destination = target / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(
+            content + (b"\n" if relative == "references/runtime-contract.md" else b"")
+        )
+
+    plan = build_skill_check_plan(target)
+    assert plan["status"] == "upgrade_ready"
+    receipt = apply_skill_install_plan(plan, approved=True)
+    assert receipt["status"] == "applied"
+    assert build_skill_check_plan(target)["status"] == "no_change"
+
+
+def test_mcp_config_integration_uses_public_launcher_and_is_hash_bound(
+    sample_vault: Path, tmp_path: Path
+) -> None:
+    config = tmp_path / "settings.json"
+    plan = build_mcp_config_integration_plan(
+        sample_vault,
+        client="gemini",
+        config_path=config,
+    )
+    assert plan["integration"] == "mcp-config"
+    assert plan["status"] == "ready"
+    assert plan["desired_sha256"]
+    assert not config.exists()
+
+    receipt = apply_mcp_config_integration_plan(plan, approved=True)
+    assert receipt["status"] == "applied"
+    configured = json.loads(config.read_text(encoding="utf-8"))
+    assert configured["mcpServers"]["power"]["command"] == "power-mcp"
+    assert configured["mcpServers"]["power"]["args"] == []
+    second = build_mcp_config_integration_plan(
+        sample_vault,
+        client="gemini",
+        config_path=config,
+    )
+    assert second["status"] == "no_change"
+
+
+def test_integrations_doctor_is_read_only() -> None:
+    report = build_integrations_doctor()
+    assert report["schema"] == "power.integrations.v1"
+    assert report["mcp"]["entry_point"] == "power-mcp"
+    assert report["skill"]["tree_sha256"]

--- a/tests/test_mcp_application_boundary.py
+++ b/tests/test_mcp_application_boundary.py
@@ -1,0 +1,62 @@
+"""Static guardrails for the MCP adapter/application boundary."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+MCP_SOURCE = Path(__file__).parents[1] / "src" / "power_framework" / "mcp" / "power_server.py"
+FORBIDDEN_LOW_LEVEL_NAMES = {
+    "archive_stale_notes",
+    "commit_note_change",
+    "heal_vault",
+    "run_generate_hierarchical_index",
+    "run_generate_sub_index",
+    "run_vault_mutation",
+    "sync_vault_atomically",
+    "synthesize_session_ingest",
+}
+MUTATING_TOOLS = {
+    "generate_index": "generate_index",
+    "sync_vault": "sync_vault",
+    "ensure_sub_index": "ensure_sub_index",
+    "ingest_note": "ingest_note",
+    "synthesize_session": "synthesize_session",
+    "archive_notes": "archive_notes",
+    "heal_frontmatter_tool": "heal_frontmatter",
+}
+
+
+def test_mcp_mutations_do_not_import_or_call_core_implementation_details() -> None:
+    """Mutation orchestration belongs to ApplicationService, never the MCP adapter."""
+    source = MCP_SOURCE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(MCP_SOURCE))
+
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    called = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert not imported & FORBIDDEN_LOW_LEVEL_NAMES
+    assert not called & FORBIDDEN_LOW_LEVEL_NAMES
+
+    functions = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+    }
+    for tool_name, method_name in MUTATING_TOOLS.items():
+        calls = [
+            node
+            for node in ast.walk(functions[tool_name])
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == method_name
+        ]
+        assert calls, f"{tool_name} must delegate to ApplicationService.{method_name}"

--- a/tests/test_mcp_client_onboarding.py
+++ b/tests/test_mcp_client_onboarding.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from fastmcp import Client
 
 from power_framework.core.capabilities import manifest
+from tests.mcp_test_client import stdio_session
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ONBOARDING_DOC = REPO_ROOT / "docs" / "mcp-client-onboarding.md"
@@ -61,8 +61,8 @@ def test_documented_client_shapes_are_native_and_consistent() -> None:
 
     for name, config in configs.items():
         command, args, environment = _stdio_parts(name, config)
-        assert command == "/absolute/path/to/python"
-        assert args == ["-m", "power_framework.mcp"]
+        assert command == "/absolute/path/to/power-mcp"
+        assert args == []
         assert environment == {"POWER_VAULT_DIR": "/absolute/path/to/vault"}
         assert "POWER_VAULT_PATH" not in json.dumps(config)
 
@@ -76,10 +76,10 @@ async def test_each_documented_shape_reaches_golden_stdio_workflow(
     client_name: str, sample_vault: Path
 ) -> None:
     """Exercise discovery, read-only context, and proposal-without-write per shape."""
-    command, args, _documented_environment = _stdio_parts(
+    command, _args, _documented_environment = _stdio_parts(
         client_name, _documented_configs()[client_name]
     )
-    assert command == "/absolute/path/to/python"
+    assert command == "/absolute/path/to/power-mcp"
 
     process_environment = os.environ.copy()
     process_environment.update(
@@ -92,19 +92,22 @@ async def test_each_documented_shape_reaches_golden_stdio_workflow(
         "mcpServers": {
             "power": {
                 "command": sys.executable,
-                "args": args,
+                # The test process uses the compatibility module entrypoint so
+                # it remains runnable from the source checkout; docs use the
+                # installed public power-mcp launcher above.
+                "args": ["-m", "power_framework.mcp"],
                 "env": process_environment,
             }
         }
     }
 
-    async with Client(config) as client:
-        tools = await client.list_tools()
+    async with stdio_session(config, mode="legacy") as client:
+        tools = (await client.list_tools()).tools
         assert [tool.name for tool in tools] == manifest()["interfaces"]["mcp_tools"]
-        assert await client.list_resources() == []
-        assert await client.list_resource_templates() == []
-        assert await client.list_prompts() == []
-        assert all(tool.outputSchema and tool.annotations for tool in tools)
+        assert (await client.list_resources()).resources == []
+        assert (await client.list_resource_templates()).resource_templates == []
+        assert (await client.list_prompts()).prompts == []
+        assert all(tool.output_schema and tool.annotations for tool in tools)
 
         await client.call_tool("get_memory_context", {"query": "golden onboarding"})
         proposal_result = await client.call_tool(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,6 +1,4 @@
-"""
-Tests for P.O.W.E.R. MCP Server tool calls using FastMCP functions directly.
-"""
+"""Tests for the P.O.W.E.R. MCP Server and official SDK v2 wire contract."""
 
 from __future__ import annotations
 
@@ -13,12 +11,13 @@ import subprocess
 import sys
 from contextlib import closing
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock
 
 import httpx
 import pytest
-from fastmcp import Client
-from fastmcp.exceptions import ToolError
+from mcp import Client
+from mcp.server.mcpserver.exceptions import ToolError
 
 from power_framework.core import __version__
 from power_framework.core.capabilities import manifest
@@ -40,6 +39,7 @@ from power_framework.mcp.power_server import (
     synthesize_session,
     validate_memory_state,
 )
+from tests.mcp_test_client import stdio_session
 
 
 def _free_tcp_port() -> int:
@@ -62,20 +62,20 @@ def _mcp_process_env(vault_path: Path, transport: str, port: int | None = None) 
     return env
 
 
-async def _assert_wire_contract(client: Client[object]) -> None:
-    assert client.initialize_result is not None
-    assert client.initialize_result.serverInfo.version == __version__
-    tools = await client.list_tools()
-    resources = await client.list_resources()
-    resource_templates = await client.list_resource_templates()
-    prompts = await client.list_prompts()
+async def _assert_wire_contract(client: Any) -> None:
+    assert client.server_info is not None
+    assert client.server_info.version == __version__
+    tools = (await client.list_tools()).tools
+    resources = (await client.list_resources()).resources
+    resource_templates = (await client.list_resource_templates()).resource_templates
+    prompts = (await client.list_prompts()).prompts
 
     expected_names = manifest()["interfaces"]["mcp_tools"]
     assert [tool.name for tool in tools] == expected_names
     assert resources == []
     assert resource_templates == []
     assert prompts == []
-    assert all(tool.outputSchema for tool in tools)
+    assert all(tool.output_schema for tool in tools)
     assert all(tool.annotations for tool in tools)
     assert all(tool.meta and tool.meta.get("power.risk") for tool in tools)
 
@@ -122,56 +122,55 @@ async def test_mcp_tools_publish_standard_and_power_risk_annotations() -> None:
 
     archive = by_name["archive_notes"]
     assert archive.annotations is not None
-    assert archive.annotations.readOnlyHint is False
-    assert archive.annotations.destructiveHint is True
-    assert archive.annotations.idempotentHint is False
-    assert archive.annotations.openWorldHint is False
+    assert archive.annotations.read_only_hint is False
+    assert archive.annotations.destructive_hint is True
+    assert archive.annotations.idempotent_hint is False
+    assert archive.annotations.open_world_hint is False
     assert archive.meta == {
         "power.risk": {"local_only": True, "egress": "none", "approval": "explicit"}
     }
 
     search = by_name["search_vault_tool"]
     assert search.annotations is not None
-    assert search.annotations.readOnlyHint is True
+    assert search.annotations.read_only_hint is True
     assert search.meta["power.risk"]["egress"] == "model_download"
 
     proposal = by_name["propose_memory_change"]
     assert proposal.annotations is not None
-    assert proposal.annotations.readOnlyHint is False
-    assert proposal.annotations.destructiveHint is False
-    assert proposal.annotations.idempotentHint is True
+    assert proposal.annotations.read_only_hint is False
+    assert proposal.annotations.destructive_hint is False
+    assert proposal.annotations.idempotent_hint is True
     assert proposal.meta == {
         "power.risk": {"local_only": True, "egress": "none", "approval": "caller"}
     }
 
     for catalog_name in ("read_sub_index", "ensure_sub_index"):
-        catalog_parameters = by_name[catalog_name].parameters
-        assert catalog_parameters["properties"]["page"] == {"default": 1, "type": "integer"}
+        catalog_parameters = by_name[catalog_name].input_schema
+        assert catalog_parameters["properties"]["page"]["default"] == 1
+        assert catalog_parameters["properties"]["page"]["type"] == "integer"
         assert "page" not in catalog_parameters["required"]
 
     discovery = by_name["get_server_info"]
     assert discovery.annotations is not None
-    assert discovery.annotations.readOnlyHint is True
-    assert discovery.annotations.destructiveHint is False
-    assert discovery.annotations.idempotentHint is True
-    assert discovery.annotations.openWorldHint is False
+    assert discovery.annotations.read_only_hint is True
+    assert discovery.annotations.destructive_hint is False
+    assert discovery.annotations.idempotent_hint is True
+    assert discovery.annotations.open_world_hint is False
     assert discovery.meta == {
         "power.risk": {"local_only": True, "egress": "none", "approval": "none"}
     }
-    assert discovery.parameters["properties"]["probe_provider"] == {
-        "default": False,
-        "type": "boolean",
-    }
-    assert "probe_provider" not in discovery.parameters.get("required", [])
+    assert discovery.input_schema["properties"]["probe_provider"]["default"] is False
+    assert discovery.input_schema["properties"]["probe_provider"]["type"] == "boolean"
+    assert "probe_provider" not in discovery.input_schema.get("required", [])
 
 
 async def test_mcp_wire_discovery_preserves_tool_contract_and_empty_collections() -> None:
     async with Client(power_server.mcp) as client:
-        tools = await client.list_tools()
-        resources = await client.list_resources()
-        resource_templates = await client.list_resource_templates()
-        prompts = await client.list_prompts()
-        tools_again = await client.list_tools()
+        tools = (await client.list_tools()).tools
+        resources = (await client.list_resources()).resources
+        resource_templates = (await client.list_resource_templates()).resource_templates
+        prompts = (await client.list_prompts()).prompts
+        tools_again = (await client.list_tools()).tools
 
     expected_names = manifest()["interfaces"]["mcp_tools"]
     assert [tool.name for tool in tools] == expected_names
@@ -180,7 +179,7 @@ async def test_mcp_wire_discovery_preserves_tool_contract_and_empty_collections(
     assert resources == []
     assert resource_templates == []
     assert prompts == []
-    assert all(tool.outputSchema for tool in tools)
+    assert all(tool.output_schema for tool in tools)
     assert all(tool.annotations for tool in tools)
     assert all(tool.meta and tool.meta.get("power.risk") for tool in tools)
 
@@ -189,8 +188,8 @@ async def test_mcp_server_advertises_truthful_package_version() -> None:
     from power_framework.core import __version__
 
     async with Client(power_server.mcp) as client:
-        assert client.initialize_result is not None
-        assert client.initialize_result.serverInfo.version == __version__
+        assert client.server_info is not None
+        assert client.server_info.version == __version__
 
 
 async def test_get_server_info_is_read_only_and_does_not_probe_by_default(
@@ -242,7 +241,11 @@ async def test_get_server_info_can_request_the_no_download_provider_probe(
     assert not any(issue["code"] == "embedding_binding_not_requested" for issue in result["issues"])
 
 
-async def test_mcp_stdio_process_preserves_wire_contract(sample_vault: Path) -> None:
+@pytest.mark.parametrize("protocol_mode", ["legacy", "2026-07-28"])
+async def test_mcp_stdio_process_preserves_wire_contract(
+    sample_vault: Path,
+    protocol_mode: str,
+) -> None:
     config = {
         "mcpServers": {
             "power": {
@@ -253,7 +256,7 @@ async def test_mcp_stdio_process_preserves_wire_contract(sample_vault: Path) -> 
         }
     }
 
-    async with Client(config) as client:
+    async with stdio_session(config, mode=protocol_mode) as client:
         await _assert_wire_contract(client)
         info_result = await client.call_tool("get_server_info")
         assert info_result.content
@@ -395,7 +398,9 @@ async def test_ensure_sub_index_can_return_requested_page(
         )
         return "Generated test catalog"
 
-    monkeypatch.setattr(power_server, "run_generate_sub_index", fake_generate)
+    from power_framework.core import application
+
+    monkeypatch.setattr(application, "run_generate_sub_index", fake_generate)
 
     result = await ensure_sub_index(category="01_Projects", page=2, vault_path=str(sample_vault))
 

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -30,11 +30,14 @@ def test_optional_profiles_are_explicit() -> None:
     project = _project_metadata()
     extras = project["optional-dependencies"]
 
-    assert {"semantic", "rerank", "gpu", "fleet", "bench", "remote", "experimental"} <= set(extras)
+    assert {"semantic", "rerank", "gpu", "fleet", "bench", "mcp", "remote", "experimental"} <= set(
+        extras
+    )
     assert any(str(item).startswith("onnxruntime>=") for item in extras["semantic"])
     assert any(str(item).startswith("onnxruntime-gpu>=") for item in extras["gpu"])
     assert any(str(item).startswith("fastembed>=") for item in extras["rerank"])
-    assert any(str(item).startswith("fastmcp>=") for item in extras["remote"])
+    assert any(str(item).startswith("mcp>=2.0") for item in extras["mcp"])
+    assert any(str(item).startswith("mcp>=2.0") for item in extras["remote"])
 
 
 def test_fts_path_runs_when_optional_neural_imports_are_blocked(tmp_path: Path) -> None:

--- a/tests/test_power_mcp_entrypoint.py
+++ b/tests/test_power_mcp_entrypoint.py
@@ -1,0 +1,64 @@
+"""Public power-mcp launcher and fail-closed preflight contracts."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+from power_framework.mcp.entrypoint import main
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_console_script_points_to_public_entrypoint() -> None:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle)["project"]
+
+    assert project["scripts"]["power-mcp"] == "power_framework.mcp.entrypoint:main"
+
+
+def test_mcp_extra_is_explicit_and_official_sdk_is_not_fastmcp() -> None:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle)["project"]
+
+    extras = project["optional-dependencies"]
+    assert any(str(item).startswith("mcp>=2.0") for item in extras["mcp"])
+    assert any(str(item).startswith("mcp>=2.0") for item in extras["remote"])
+    assert all("fastmcp" not in str(item).lower() for item in extras["remote"])
+
+
+def test_preflight_requires_an_explicit_existing_vault(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("POWER_VAULT_DIR", raising=False)
+    monkeypatch.delenv("POWER_VAULT_PATH", raising=False)
+    assert main(["preflight"]) == 2
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setenv("POWER_VAULT_DIR", str(vault))
+    assert main(["preflight"]) == 0
+
+
+def test_console_preflight_is_available_in_a_subprocess(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    env = os.environ.copy()
+    env["POWER_VAULT_DIR"] = str(vault)
+    env["PYTHONPATH"] = str(REPO_ROOT / "src")
+    result = subprocess.run(
+        [sys.executable, "-m", "power_framework.mcp.entrypoint", "preflight"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert payload["vault_root"] == str(vault.resolve())
+    assert result.stderr == ""

--- a/uv.lock
+++ b/uv.lock
@@ -1642,11 +1642,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -10,18 +10,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "aiofile"
-version = "3.11.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "caio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -94,34 +82,12 @@ wheels = [
 ]
 
 [[package]]
-name = "authlib"
-version = "1.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "joserfc" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
-]
-
-[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
-]
-
-[[package]]
-name = "backports-tarfile"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
 ]
 
 [[package]]
@@ -135,15 +101,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/29/13/232505664e8e2a0c7a2eb0c505cfade9d715538f89a5d62bc4c272968f62/backrefs-8.0-py312-none-any.whl", hash = "sha256:87f0fae8c5f207fe9f4b2887efc71d42f4900ac78faa1af08d675ef303692dc5", size = 398084, upload-time = "2026-07-26T19:54:19.954Z" },
     { url = "https://files.pythonhosted.org/packages/8a/69/47a3dc20abc4fa5486655fde681bd55e63211b46c886d8c02223d6468431/backrefs-8.0-py313-none-any.whl", hash = "sha256:601ce68ca12385dbda06ce264406b4c4210cf5b79fd0fd627592365c92f29a88", size = 400040, upload-time = "2026-07-26T19:54:21.194Z" },
     { url = "https://files.pythonhosted.org/packages/1c/cf/e5f9b68a5b0e939a2fb933a66c20180d0c9241bf8927f7a47fa48c1675e9/backrefs-8.0-py314-none-any.whl", hash = "sha256:9ec96efa080938be92323e8e730e57718c9c88eb15ad70bbef4e1766df591408", size = 411903, upload-time = "2026-07-26T19:54:23.221Z" },
-]
-
-[[package]]
-name = "beartype"
-version = "0.22.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
 ]
 
 [[package]]
@@ -185,40 +142,6 @@ wheels = [
 [package.optional-dependencies]
 filecache = [
     { name = "filelock" },
-]
-
-[[package]]
-name = "cachetools"
-version = "7.1.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/af/861ebc2e318a5c3300e3eb63bc4d30f3d70a46d13b360093728ac0705eed/cachetools-7.1.6.tar.gz", hash = "sha256:c7a79e7f30ba9943c1cefd08cc36f006aaae086e017af9166f1d59d6170c47e1", size = 40572, upload-time = "2026-07-23T22:47:53.737Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/f2/2086ba18a925a73586c4d4e61d25f4a6058e56fd00d77ce8f1d361ab4c9b/cachetools-7.1.6-py3-none-any.whl", hash = "sha256:2c12e255780330af28b91bb7fb96cce4c766f04e38396b9a24510190a5827096", size = 16954, upload-time = "2026-07-23T22:47:52.397Z" },
-]
-
-[[package]]
-name = "caio"
-version = "0.9.25"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
-    { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
-    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
-    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
-    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
-    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
-    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
-    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
-    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -594,21 +517,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cyclopts"
-version = "4.22.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "docstring-parser" },
-    { name = "rich" },
-    { name = "rich-rst" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/69/98/ca72a91d5c25a2ae1baf19d27b31f12288cb9d8a3168b65b3cd54d40d277/cyclopts-4.22.2.tar.gz", hash = "sha256:0721e90e7209885e78f7637cfba255c12e89206b633e35d185305e349ba20ecd", size = 194511, upload-time = "2026-07-24T20:53:08.739Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/75/a11bfb5045e58b4ef69337b848985918e829fe9a90572a761d17c1a992f5/cyclopts-4.22.2-py3-none-any.whl", hash = "sha256:9c2cdf6a621886cd0af631a67437eb7d0084f33f9e8fba2d2562a1aecf75f2ff", size = 233906, upload-time = "2026-07-24T20:53:07.064Z" },
-]
-
-[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -624,49 +532,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
-]
-
-[[package]]
-name = "dnspython"
-version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
-]
-
-[[package]]
-name = "email-validator"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dnspython" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
-]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -688,69 +553,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/26/25/58865e36b6e8a9a0d0ff905b5601aa30db97956327c0df42ec4ed6accc21/fastembed-0.8.0.tar.gz", hash = "sha256:75966edfa8b006ee78514c726bd7f6a50721dadc89305279052be9db72fd53e8", size = 75115, upload-time = "2026-03-23T16:34:41.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/e8/26b7d78bb8972498c467ca34cb12ee2e60d26ba5eae6d8443189a1af37a5/fastembed-0.8.0-py3-none-any.whl", hash = "sha256:40bee672657574a1009e35ec50030a55f2b426842cb011845379817641bbbbd0", size = 116572, upload-time = "2026-03-23T16:34:40.69Z" },
-]
-
-[[package]]
-name = "fastmcp"
-version = "3.4.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastmcp-slim", extra = ["client", "server"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/23/14/c1ffb91b7d1fece86c81e1f9df5474f30fd97e4cdaa398814bbbeee88568/fastmcp-3.4.5.tar.gz", hash = "sha256:a95f2bc876bef42e8b50f7872f24f3f2fe3b1d37408c734e8b9d9e03014b72d3", size = 28800521, upload-time = "2026-07-27T19:20:01.231Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/4f/73450a436c963c0382d15a882fc5d08f15aadc329194df1b54495a7c8383/fastmcp-3.4.5-py3-none-any.whl", hash = "sha256:5d3d438eb2917e63e6faf53e8cb8fe26d887ec3232f848093a4eecad7fa34861", size = 8017, upload-time = "2026-07-27T19:19:57.942Z" },
-]
-
-[[package]]
-name = "fastmcp-slim"
-version = "3.4.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "platformdirs" },
-    { name = "pydantic", extra = ["email"] },
-    { name = "pydantic-settings" },
-    { name = "python-dotenv" },
-    { name = "rich" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/81/1d/f3e271fbcd01ce01a4cf623b336d8e1305c192aa5d5e8e0223b7167462e9/fastmcp_slim-3.4.5.tar.gz", hash = "sha256:5badc3bceee61f61297eeb9494f499325f3ce1cafabf4611b31f6c3e9d7dff59", size = 591622, upload-time = "2026-07-27T19:15:19.455Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/3b/16d8aa8224094519f30b078138e725b8a731bf0a13f1f850e58b5f9b3cc4/fastmcp_slim-3.4.5-py3-none-any.whl", hash = "sha256:bc31217827c4999812543c83ee95ed9a47f3ed1e3fd0bd4f64371e375b748eca", size = 766478, upload-time = "2026-07-27T19:15:18.015Z" },
-]
-
-[package.optional-dependencies]
-client = [
-    { name = "authlib" },
-    { name = "exceptiongroup" },
-    { name = "httpx" },
-    { name = "mcp" },
-    { name = "opentelemetry-api" },
-    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "starlette" },
-]
-server = [
-    { name = "authlib" },
-    { name = "cyclopts" },
-    { name = "exceptiongroup" },
-    { name = "griffelib" },
-    { name = "httpx" },
-    { name = "joserfc" },
-    { name = "jsonref" },
-    { name = "jsonschema-path" },
-    { name = "mcp" },
-    { name = "openapi-pydantic" },
-    { name = "opentelemetry-api" },
-    { name = "packaging" },
-    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pyperclip" },
-    { name = "python-multipart" },
-    { name = "pyyaml" },
-    { name = "starlette" },
-    { name = "uncalled-for" },
-    { name = "uvicorn" },
-    { name = "watchfiles" },
-    { name = "websockets" },
 ]
 
 [[package]]
@@ -789,15 +591,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
-]
-
-[[package]]
-name = "griffelib"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -847,6 +640,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -862,12 +668,29 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -909,69 +732,12 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "jaraco-classes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
-]
-
-[[package]]
-name = "jaraco-context"
-version = "6.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
-]
-
-[[package]]
-name = "jaraco-functools"
-version = "4.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
-]
-
-[[package]]
-name = "jeepney"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -984,27 +750,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "joserfc"
-version = "1.7.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
-]
-
-[[package]]
-name = "jsonref"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
 ]
 
 [[package]]
@@ -1023,21 +768,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jsonschema-path"
-version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "pathable" },
-    { name = "pyyaml" },
-    { name = "referencing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/39/79/cd02a4df6d9270efdc7d3feefe6edd730b0820c39eeaa107a2faee8322d5/jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c", size = 19597, upload-time = "2026-05-19T20:45:00.971Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/2c/9e69d73c4297508be9e3b64a970ea3971b3eb8db64ffc5802d40bd25981f/jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2", size = 24077, upload-time = "2026-05-19T20:44:59.225Z" },
-]
-
-[[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1047,24 +777,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "keyring"
-version = "25.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
-    { name = "jaraco-classes" },
-    { name = "jaraco-context" },
-    { name = "jaraco-functools" },
-    { name = "jeepney", marker = "sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -1264,15 +976,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1282,9 +994,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1470,15 +1195,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/21/54/1d71cd143752361c0aebef16ad3f55926a6faf7b112d355745c1f8a25f7f/mmh3-5.2.1-cp314-cp314t-win32.whl", hash = "sha256:29bc3973676ae334412efdd367fcd11d036b7be3efc1ce2407ef8676dabfeb82", size = 41934, upload-time = "2026-03-05T15:55:53.564Z" },
     { url = "https://files.pythonhosted.org/packages/9d/e4/63a2a88f31d93dea03947cccc2a076946857e799ea4f7acdecbf43b324aa/mmh3-5.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:28cfab66577000b9505a0d068c731aee7ca85cd26d4d63881fab17857e0fe1fb", size = 43036, upload-time = "2026-03-05T15:55:55.252Z" },
     { url = "https://files.pythonhosted.org/packages/a0/0f/59204bf136d1201f8d7884cfbaf7498c5b4674e87a4c693f9bde63741ce1/mmh3-5.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dfd51b4c56b673dfbc43d7d27ef857dd91124801e2806c69bb45585ce0fa019b", size = 40391, upload-time = "2026-03-05T15:55:56.697Z" },
-]
-
-[[package]]
-name = "more-itertools"
-version = "11.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -1792,18 +1508,6 @@ wheels = [
 ]
 
 [[package]]
-name = "openapi-pydantic"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
-]
-
-[[package]]
 name = "opentelemetry-api"
 version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1840,15 +1544,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
-]
-
-[[package]]
-name = "pathable"
-version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
 ]
 
 [[package]]
@@ -2032,8 +1727,9 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "build" },
-    { name = "fastmcp" },
+    { name = "httpx" },
     { name = "jsonschema" },
+    { name = "mcp" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mypy" },
@@ -2056,11 +1752,14 @@ gpu = [
     { name = "onnxruntime-gpu" },
     { name = "tokenizers" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 qwen3 = [
     { name = "qwen3-embed" },
 ]
 remote = [
-    { name = "fastmcp" },
+    { name = "mcp" },
 ]
 rerank = [
     { name = "fastembed" },
@@ -2079,8 +1778,9 @@ semantic = [
 [package.dev-dependencies]
 dev = [
     { name = "build" },
-    { name = "fastmcp" },
+    { name = "httpx" },
     { name = "jsonschema" },
+    { name = "mcp" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mypy" },
@@ -2098,12 +1798,14 @@ requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastembed", marker = "extra == 'rerank'", specifier = ">=0.5.0,<1.0.0" },
-    { name = "fastmcp", marker = "extra == 'dev'", specifier = ">=3.2,<4.0" },
-    { name = "fastmcp", marker = "extra == 'remote'", specifier = ">=3.2,<4.0" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "huggingface-hub", marker = "extra == 'gpu'", specifier = ">=0.20.0" },
     { name = "huggingface-hub", marker = "extra == 'rerank'", specifier = ">=0.20.0" },
     { name = "huggingface-hub", marker = "extra == 'semantic'", specifier = ">=0.20.0" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.23.0" },
+    { name = "mcp", marker = "extra == 'dev'", specifier = ">=2.0,<3.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2.0,<3.0" },
+    { name = "mcp", marker = "extra == 'remote'", specifier = ">=2.0,<3.0" },
     { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6.0" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.7.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
@@ -2131,13 +1833,14 @@ requires-dist = [
     { name = "tokenizers", marker = "extra == 'semantic'", specifier = ">=0.15.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
 ]
-provides-extras = ["dev", "semantic", "rerank", "gpu", "fleet", "bench", "remote", "experimental", "qwen3"]
+provides-extras = ["dev", "semantic", "rerank", "gpu", "fleet", "bench", "mcp", "remote", "experimental", "qwen3"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "build", specifier = ">=1.2.0" },
-    { name = "fastmcp", specifier = ">=3.2,<4.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },
+    { name = "mcp", specifier = ">=2.0,<3.0" },
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-material", specifier = ">=9.7.0" },
     { name = "mypy", specifier = ">=1.13.0" },
@@ -2179,31 +1882,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
     { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
     { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
-]
-
-[[package]]
-name = "py-key-value-aio"
-version = "0.4.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/e2/d689d922894a7ecde73b6daeaf9b13dab5aae06fe6aaaf7514722644d382/py_key_value_aio-0.4.5.tar.gz", hash = "sha256:c6563a2c6abe5da5e20f4f9e875c2a9b425a2244a54fadbf46cf140a9eea45d7", size = 107547, upload-time = "2026-05-27T16:37:08.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/95/b8ba862968712caa12a19666175334fa979e1f198b896a430adb3bacfe87/py_key_value_aio-0.4.5-py3-none-any.whl", hash = "sha256:ab862adbcb8c72547d1c57821f22cbbb71ab86509039c96f36e914e0336c8dd7", size = 170005, upload-time = "2026-05-27T16:37:06.629Z" },
-]
-
-[package.optional-dependencies]
-filetree = [
-    { name = "aiofile" },
-    { name = "anyio" },
-]
-keyring = [
-    { name = "keyring" },
-]
-memory = [
-    { name = "cachetools" },
 ]
 
 [[package]]
@@ -2292,11 +1970,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
-]
-
-[package.optional-dependencies]
-email = [
-    { name = "email-validator" },
 ]
 
 [[package]]
@@ -2402,20 +2075,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2458,15 +2117,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
-]
-
-[[package]]
-name = "pyperclip"
-version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
 ]
 
 [[package]]
@@ -2547,15 +2197,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
@@ -2584,15 +2225,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
     { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
     { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
-]
-
-[[package]]
-name = "pywin32-ctypes"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -2720,19 +2352,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
-]
-
-[[package]]
-name = "rich-rst"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pygments" },
-    { name = "rich" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/d6/d0b9fafc73b65767200da027acab1db1bdb1048f4fea5ebf659df01c700e/rich_rst-2.1.0.tar.gz", hash = "sha256:f4d117b49697f338769759fa5cacf5197da4888b347b9fda2e50aef5cd8d93bd", size = 302732, upload-time = "2026-07-05T02:59:44.308Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/68/1fc93dd759605b5d00fc98b50200739e41ed32bd22d6ba35ca6c3932371b/rich_rst-2.1.0-py3-none-any.whl", hash = "sha256:7ecd1343ee12c879d0e7ae74c3eb6d263b023d2929c6d114212eb1fd91057255", size = 272987, upload-time = "2026-07-05T02:59:42.792Z" },
 ]
 
 [[package]]
@@ -2884,19 +2503,6 @@ wheels = [
 ]
 
 [[package]]
-name = "secretstorage"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3043,6 +2649,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20260724"
 source = { registry = "https://pypi.org/simple" }
@@ -3070,15 +2685,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "uncalled-for"
-version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
 ]
 
 [[package]]
@@ -3146,222 +2752,10 @@ wheels = [
 ]
 
 [[package]]
-name = "watchfiles"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/3d/8024c801df84d1587740d0359e7fdd80afeae3d159011f3d5376dd82f18e/watchfiles-1.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:704fd259e332e01f9b9c178f4bce9e49027e5587cc2600eeeaf8e76e1c846201", size = 400242, upload-time = "2026-05-18T04:31:19.014Z" },
-    { url = "https://files.pythonhosted.org/packages/87/5b/f4dfd45323e949984a3a7f9dc31d1cbb049921e7d98253488dda72ccdaa9/watchfiles-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6543cf55d170003296d185c0af981f3e1311564907e1f4e08671fc7693a890a5", size = 394562, upload-time = "2026-05-18T04:30:08.46Z" },
-    { url = "https://files.pythonhosted.org/packages/98/d8/19483ef075d601c409bce8bcbb5c0f81a10876fff870400568f08ce484a1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d8c2394a065ca86f5d2910ff263ae67c127e1376ccc4f9fc35c71db879f80a", size = 456611, upload-time = "2026-05-18T04:30:45.723Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/6a/cc81fbe7ee42f2f22e661a6e12def7807e01b14b2f39e0ff83fd373fd307/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:772b80df316480d894a0e3165fdd19cf77f5d17f9a787f94029465ad0e3529d1", size = 461379, upload-time = "2026-05-18T04:31:29.292Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/57/7e669002082c0a0f4fb5113bb70125f7110124b846b0a11bc5ae8e90eac1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d158cd89df6053823533e06fb1d73c549133bff5f0396170c0e53d9559340717", size = 493556, upload-time = "2026-05-18T04:30:05.44Z" },
-    { url = "https://files.pythonhosted.org/packages/45/7d/f60a2b19807b21fe8281f3a8da4f59eef0d5f96825ac4680ba2d4f2ebf91/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d516b3283a758e087841aedb8031549fb41ced08f3db10aa6d2bf32dc042525b", size = 575255, upload-time = "2026-05-18T04:30:40.568Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/49/77f5b5e6efbcd57482f74948ebb1b97e5c0046d6b61475042d830c84b3ff/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53b2290c92e0506d102cd448fbc610d87079553f86caa39d67440856a8b8bba5", size = 467052, upload-time = "2026-05-18T04:31:17.942Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/5a/73e2959af1b97fd5d556f9a8bdba017be23ceeef731869d5eaa0a753d5a3/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a711b51aec4370d0dcda5b6c09463206f133a5759341d7744b953a7b62e1100e", size = 456858, upload-time = "2026-05-18T04:30:30.182Z" },
-    { url = "https://files.pythonhosted.org/packages/50/57/1bc8c27fad7e6c19bddee15d276dbb6ab72480ec01c127afff1673aee417/watchfiles-1.2.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:e2ca07fa7d89195ec0865d3d285666286740bfa83d83e5cee204043a31ecc165", size = 467579, upload-time = "2026-05-18T04:32:15.897Z" },
-    { url = "https://files.pythonhosted.org/packages/09/6c/3c2e44edba3553c5e3c3b8c8a2a6dee6b9e12ae2cf4bd2378bebf9dc3038/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e0618518f282c4ebff60f5e5b1247b6d91bb8b9f4476947563a1e74acc66f3c6", size = 633253, upload-time = "2026-05-18T04:31:37.123Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c2/d8c84a882ab39bbefcc4915ab3e91830b7a7e990c5570b0b69075aba3faf/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0d191c054d0715c3c95c99df9b8dbf6fd096d8c1e021e8f212e1bd8bc444ccb5", size = 660713, upload-time = "2026-05-18T04:31:24.62Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/07/f97736a5fc605364fe67b25e9fa4a6965dfd4840d50c406ada507e9d735f/watchfiles-1.2.0-cp311-cp311-win32.whl", hash = "sha256:9342472aff9b093c5acd4f6d8f70ae0937964ab56542502bcf5579782da69ae8", size = 277222, upload-time = "2026-05-18T04:31:21.131Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/99/2b04981977fc2608afd60360d928c6aecf6b950292ca221d98f4005f6694/watchfiles-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:dbd6c97045dad81227c8d040173da044c1de08de64a5ea8b555da4aee1d5fa22", size = 290274, upload-time = "2026-05-18T04:31:45.966Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/74/f7f58a7075ee9cf612b0cfcddb78b8cd8234f0742d6f0075cf0da2dde1c6/watchfiles-1.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:57a2d9fa4fb4c2ecae57b13dfff2c7ab53e21a2ba674fe9f05506680fcdcc0d7", size = 283460, upload-time = "2026-05-18T04:31:39.126Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
-    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
-    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
-    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
-    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
-    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
-    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
-    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
-    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
-    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
-    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
-    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
-    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
-    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
-    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
-    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
-    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
-    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
-    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
-    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
-    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
-    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
-    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
-    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
-    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
-    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
-    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
-    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
-    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
-    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
-    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
-    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
-    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
-    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
-    { url = "https://files.pythonhosted.org/packages/23/f4/7513ef1e85fc4c6331b59479d6d72661fc391fbe543678052ac72c8b6c19/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4674d49eb94706dfe666c069fc0a1b646ffcf920473492e209f6d5f60d3f0cc2", size = 403050, upload-time = "2026-05-18T04:30:36.753Z" },
-    { url = "https://files.pythonhosted.org/packages/27/0b/a54103cfd732bb703c7a749222011a0483ef3705948dae3b203158601119/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:094b9b70103d4e963499bdea001ee3c2697b144cd9ae6218a62c0f89ec9e31db", size = 396629, upload-time = "2026-05-18T04:32:03.268Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/2c/73f31a3b893886206c3f54d73e8ad8dee58cdb2f69ad2622e0a8a9e07f4e/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0ef001f8c25ad0fa9529f914c1600647ecd0f542d11c19b7894768c67b6acb7", size = 457318, upload-time = "2026-05-18T04:31:01.932Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/f9/45d021e4a5cc7b9dd567f7cbb06d3b75f751a690063fb6cc7ec60f4e46b7/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a88fc94e647bc4eec523f1caa540258eb71d14278b9daf72fa1e2658a98df0f0", size = 457771, upload-time = "2026-05-18T04:30:56.331Z" },
-]
-
-[[package]]
-name = "websockets"
-version = "16.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/f7/bc3a25c5ec26ce62ce487690becc2f3710bbc7b33338f005ad390db0b986/websockets-16.1.1.tar.gz", hash = "sha256:db234eda965dcce15df96bb9709f587cd87d4d52aaf0e80e2f34ec04c7670c57", size = 182204, upload-time = "2026-07-17T22:51:05.858Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/03/47debfe28e9d6d354be5d777b67fd44c359b9eb299a5d103500bd7cc3e37/websockets-16.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d0fcf657e9f13ff4b177960ab2200237b12994232dfb6df16f1cfe1d4339f93c", size = 179566, upload-time = "2026-07-17T22:48:49.596Z" },
-    { url = "https://files.pythonhosted.org/packages/72/93/31efa1ed78c17e5cfc229fd449e3966e1b9cc15753204cd585cc8dd01f4a/websockets-16.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b852788aa51764e2d8e4cf5493d559326bcae5e38d16ba25ffa322b034df272a", size = 177250, upload-time = "2026-07-17T22:48:50.942Z" },
-    { url = "https://files.pythonhosted.org/packages/01/4a/542378ab3972b0c1cf1df3df3eff9591cea0d30c58c3aa3c4ddbc244e787/websockets-16.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1427fb4cf0d72f66333e2cacc3ff5f575bf2d7008166ce991a4a470b21d51a22", size = 177528, upload-time = "2026-07-17T22:48:52.59Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d9/162321f63c7eed558e9e1798ed7a1e34a4f6dab51f35419e4ed7a4907979/websockets-16.1.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:da4ca1a9d72f9030b3146b8d7022719a9f3d478f61efe6f7dd51d243f61c51b2", size = 186859, upload-time = "2026-07-17T22:48:53.915Z" },
-    { url = "https://files.pythonhosted.org/packages/de/09/87df740f7430ce564bd52402e9c9458d4d0459cc7d2ee29e530c8204851b/websockets-16.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:86d7f0f8bdb25d2c632b72527325e4776430fd5bc61b9118de4e2b8ddb5f5b01", size = 188095, upload-time = "2026-07-17T22:48:55.384Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/12/3d2703af7cc095f3c81904c92208cc1ae79affbc67376944b50ee9301f73/websockets-16.1.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7dfcad78ea1492ee3a9ec765cb7f51bbc17d477107aaf6b22abf7b2558d1c5a0", size = 191385, upload-time = "2026-07-17T22:48:56.742Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/69/986aa0234a964a00f5149cfc46e136e96c8faad1c783474550f40d31aef4/websockets-16.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fb9a0a6dc3d1b3986cb88091b6899f0396651e0f74e2c9766ab8d6ffc3842e29", size = 188653, upload-time = "2026-07-17T22:48:58.134Z" },
-    { url = "https://files.pythonhosted.org/packages/35/6b/10f9d03e3970a69ba67bd3b46b87a929b586d0300fadbfe14f57c1f85490/websockets-16.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29dfa8114c4a620c69591c5973860f768eac29d3fd6904f37f34266cb219c512", size = 187426, upload-time = "2026-07-17T22:48:59.515Z" },
-    { url = "https://files.pythonhosted.org/packages/56/db/bb3aad62bf63d8bb3f0634b2eabffcfb3677a34bd19492110ff6869cf703/websockets-16.1.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6ff9417c0ada4d0f7d212f928303e5579bdf3ace4c802fa4afabb30995da58c3", size = 184882, upload-time = "2026-07-17T22:49:00.916Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/4c/c09a2ea9bfbeccce52fdc383e5f28af4bc8843338aabac28c81489af6120/websockets-16.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fe0b50da2d84535fb4f7b4bfa951280f97ce3d558a0443b541166d609e67b57", size = 187584, upload-time = "2026-07-17T22:49:02.283Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/8b/31bb4eb4d9eaacf1fdd39d115772a8aeaedfc19b5dc262e57ffbc8a9d42c/websockets-16.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:34420aaa64440ebd51ac72ca8a45ef4626429438c9b02e633ae412ed43f925d3", size = 186174, upload-time = "2026-07-17T22:49:03.973Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/e4/dc02d725610a1ad49e193ef91a548194d71bdc6cdf27da83067dd1f73995/websockets-16.1.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a6a61aff018180c9c50b7b0da33bfd29d378af3497429c95006c589a23a11648", size = 187986, upload-time = "2026-07-17T22:49:05.553Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/73/30ed84c8bfd14c73d4af29d5ed9323c3073b48e0b7b23b67070f4e7fd59b/websockets-16.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:04fd29a0e2fe9414a95b00e92c67ae51bf900c50c0f8a4b2dafdad621f49ea1d", size = 185565, upload-time = "2026-07-17T22:49:06.959Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/d3/4be8d4959f51e31b4f8fc0ece12b45bd3b6c0d15ea23b9990d9c11fc805f/websockets-16.1.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5c31aa7e39ee3e8a358573257f1c0bb5c52430d1b637030dd9c8cc2c282926be", size = 186598, upload-time = "2026-07-17T22:49:08.293Z" },
-    { url = "https://files.pythonhosted.org/packages/26/fa/abb38597a52d84ed9cfacadc7a0c6f2db282c0ab23cdf72b58a666a21227/websockets-16.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d14bfb217eb4701e850f1525c9d29d79c44794cdf1c299ead25f39f8c78dea81", size = 186834, upload-time = "2026-07-17T22:49:09.766Z" },
-    { url = "https://files.pythonhosted.org/packages/59/80/1119ad08a228b90c4eb77fbe48df7836731a605f5f881ba701ca826a4a65/websockets-16.1.1-cp311-cp311-win32.whl", hash = "sha256:2e28e602bb13da44fbe518c1781a88e3b9d4c3d48d02c9bad83e546164336f57", size = 179940, upload-time = "2026-07-17T22:49:11.196Z" },
-    { url = "https://files.pythonhosted.org/packages/71/b2/e511c1c6f64a95c2f3fc54bffda0e14eaa7e9442be605c29270f7589b918/websockets-16.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:7421fad442de870a8cbf2287d1cad7e706ece0dbfeba5e911df132cbdc1cb56a", size = 180239, upload-time = "2026-07-17T22:49:12.519Z" },
-    { url = "https://files.pythonhosted.org/packages/17/9d/681cda21c9eee743203a6cb79b9d3d05adad9aa60ec660c6c9bf4dd619ca/websockets-16.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cc97814dfb786a83b6e2dc2e79351e1b83e6d715647d6887fcabd83026417a00", size = 179600, upload-time = "2026-07-17T22:49:13.92Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/8d/6195a88b45e8d2a8f745fc2046e36f885a3c9763e6767d2c46229bf9510c/websockets-16.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e047dc87ef7ca50f4d309bf775ad4a71711c58556d75d7bd0604b2317f43e94b", size = 177272, upload-time = "2026-07-17T22:49:15.453Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e3/fe2d498c64dea0095c9a9f9a351af4cd6eef31b618395582bc1f38ba45ff/websockets-16.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:01fbdcbac298efe19360b94bc0039c8f746f0220ba570f327577bfee81059175", size = 177542, upload-time = "2026-07-17T22:49:16.875Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/ed/f1831681fce0e3242346e5458486003c5f124ed69e5e0b847fd029db4973/websockets-16.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0f62863e8a00a6d33c3d6566ec0b89f23787b747ffe0c3bc71ec0e76b82c94b1", size = 187137, upload-time = "2026-07-17T22:49:18.323Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/79/4ff9dcc1bb46f6b4c536936dde1fd60f9b564f3304307274db97f4c9496d/websockets-16.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8087e82f842609734c9b5a1330464f8e94e346ba0e18c832c08bafa4b0d63c15", size = 188374, upload-time = "2026-07-17T22:49:19.65Z" },
-    { url = "https://files.pythonhosted.org/packages/62/c3/5c49b6efb36cab733d23773f6de575e1dba65736ead17d5d2b2a1daef779/websockets-16.1.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2bb5d041a8307d2e18782e7ce777f6fdb1e8c2f5d09291484b18c294b789d9aa", size = 191155, upload-time = "2026-07-17T22:49:21.331Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f6/56ccceda3a4838d18f1d40821480da4775397e8b1eecf4031e20c50e2e90/websockets-16.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1db4de4a0e95673f7545d393c49eeb0c2f18ac1ef93073218c79d5cdb2ee75ab", size = 189011, upload-time = "2026-07-17T22:49:22.889Z" },
-    { url = "https://files.pythonhosted.org/packages/86/d6/ad5286241a2bce1107e2798d3bfbd62cf79aee167bdb654f8cb1e9dbf949/websockets-16.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f17dbe07eb3ea7f99e4df9b7e0efefe80fbf30d37a8cc4d561a0aed310bc8847", size = 187766, upload-time = "2026-07-17T22:49:24.339Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/67/d65c970b7e347fdca69479beb7811c2060529956730a7a4e3ae7c66b0e31/websockets-16.1.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4b57693728576d84ede0a77987ab16881b783d2cd9f1dc180a8fbbc3f79c4428", size = 185173, upload-time = "2026-07-17T22:49:25.743Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/5b/14af3cd4ee69d8ea9baca58f3dc3cfb1ba78332a347fd478cb096549d60e/websockets-16.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2a636ff1e7a5c4edf71ef0e79adae7f25dba93b4fcbe3dc958733477ffeb0eaf", size = 187809, upload-time = "2026-07-17T22:49:27.147Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/11/be301710d70de97e3e7b3586e6d492c9c06d6a61bf1c2202c36cf0c75607/websockets-16.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:d6bec75c290fe484a8ba4cacdf838501e17c06ecfbbf31eede81a9e431bd7751", size = 186412, upload-time = "2026-07-17T22:49:28.611Z" },
-    { url = "https://files.pythonhosted.org/packages/db/07/fe1435bf6fe738a3d3b54dbe0c18dabf12cba4d909ac8b58b539ce27c1f4/websockets-16.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:54509b8e92fee4453e152b7558ddef37ce9705a044922f2095a6105e3f80c96f", size = 188290, upload-time = "2026-07-17T22:49:29.965Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/0a/81f394aff8efcbb01208c1ced77df0a3c7fcce584a88c7273663697946c2/websockets-16.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f0aa4aad3b1b69ad3fd85a0fd0952ec64331c762bd77ec51cc814170873890b2", size = 185844, upload-time = "2026-07-17T22:49:31.447Z" },
-    { url = "https://files.pythonhosted.org/packages/39/5c/dd485b995473f415510251fe9bd708f2d24458f439fce958daf8d66dc7c6/websockets-16.1.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:42290eb6db4ccaca7012656738214f8514082fb6fa40cdeb61bb9a471b52e383", size = 186823, upload-time = "2026-07-17T22:49:33.104Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/0b/f78de76ff446f1e66af12b43c48a35f31744de93cfdec2f4ea67d5d7bbf1/websockets-16.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:53260c8930da5771cec89439bff99c20c8cb03ddb9588b980697355a83cd4bd3", size = 187102, upload-time = "2026-07-17T22:49:34.616Z" },
-    { url = "https://files.pythonhosted.org/packages/37/a1/4cf892007778eaf84ad162bfc98046e0ed89b63ac55949e3236626b2a23f/websockets-16.1.1-cp312-cp312-win32.whl", hash = "sha256:1d27fa8462ad6a1cb36206a3d0640b2333340def181fae11ed7f9adeaa5c0747", size = 179943, upload-time = "2026-07-17T22:49:36.213Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/de/6abe251d28c3a3f217096575400b27750b18e0b1d2fff3a2a239960fea07/websockets-16.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:b436f6ec4fc3a6b4237c84d3f83170ed2b40bb584222f0ac47a0c8a5921980c7", size = 180243, upload-time = "2026-07-17T22:49:37.626Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/fd/6ec6c6d2850aea25b1b2aa9901a016980bb87d01e89b3eb00470b1b5d471/websockets-16.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ab59169ace05dcb49a1d4118f0bde139557adf45091bd85747e36bf5de984dd1", size = 179587, upload-time = "2026-07-17T22:49:38.959Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/d8/1d299d2dd34087db39831a34cc645ef8a6f89d78efada6983093513cd81c/websockets-16.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5e3b7d601f6f84156b08cc4a5e541c2b50ad7b36cfc302b657a12477c904a5df", size = 177272, upload-time = "2026-07-17T22:49:40.293Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/86/0a70d3ae2f0f2256bb41302d9804dbca65d4360281e7feb3e1f94102ac46/websockets-16.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cd2ca96a082a36964aca83e992f72abeb61b7306c1a6cba4c7d06a7b93750cac", size = 177530, upload-time = "2026-07-17T22:49:41.786Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/c2/c676c69444d9db448b3f0a55a98dcc534affce0bce961d9d2f0b8499b10a/websockets-16.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f5d497865f05bb222cab7016c6034542e84e5f29f49c6fd3f4939cda7197b5b8", size = 187197, upload-time = "2026-07-17T22:49:43.658Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/13/88137fbaf726ebe29d62c1117fa11fa2bbb6209dc79d4ad738efbe36a2aa/websockets-16.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bae954c382e013d5ea5b190d2830526bfa45ad121c326da0049b8c769f185db6", size = 188433, upload-time = "2026-07-17T22:49:45.147Z" },
-    { url = "https://files.pythonhosted.org/packages/01/6d/46c2f2ce6751cb26f39293e1ecbf8544cb01321397cd476c2756b98c216d/websockets-16.1.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e09f753a169951eb4f28c2c774f71069304f66e7277e0f5a2892423599cfa854", size = 189868, upload-time = "2026-07-17T22:49:46.581Z" },
-    { url = "https://files.pythonhosted.org/packages/29/2b/170a9e8097636cfde4dc3c592b6e00b18a44a2f5407606d96ca542dd5838/websockets-16.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:024193f8551a2b0eafbdd160911012c4e6c228c28430c84433253299a9e42d6a", size = 189059, upload-time = "2026-07-17T22:49:47.972Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/48/f0d4ebc9ab4b473b8861b9e20fdb663d515d42f7befdf62cdb60fee7a1ec/websockets-16.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:aabe464bfd13bd25f4821faf111da6fefdc389f870265a53105580e45b0a2e49", size = 187814, upload-time = "2026-07-17T22:49:49.344Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ba/39a41d3ae8e72696a9492581900611c5a91e2b07563b0bcd2523adea9854/websockets-16.1.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a28fcbc9b6baf54a2e23f8655f308e4ccc6afdd7266f8fe7954f320dcda0f785", size = 185229, upload-time = "2026-07-17T22:49:50.787Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/36/ac15b604f850d1907f0a85ed721cefe47cd45034b3620069b829746cccbe/websockets-16.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:79eace538c6a97e96d0d03d4f9d314f9677f5ed85a8a984992ffd90b13cb8a56", size = 187874, upload-time = "2026-07-17T22:49:52.228Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/f3/3fbd5d71d59299c3770faa5884d4f45070236ca5a35ab3a61830812c409a/websockets-16.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:496af849a472b531f758dbd4d61338f5000538cb1a7b3d20d9d32a264517f509", size = 186469, upload-time = "2026-07-17T22:49:53.776Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/fc/dd90349bba58af2a53ef2ddd9c32716c81eb6d59a0687939fff561860878/websockets-16.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5283810d2646741a0d8da2aa733d6aefa0545809afccb2a5d105a26bc45125f1", size = 188347, upload-time = "2026-07-17T22:49:55.202Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/f3/f73ba86427682da59b78c11d77ba56d5b801c32e84afe79b274bbd6a9bb2/websockets-16.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4e3b680b1e0a27457e727a0d572fd81dffa87b6dbf8b228ab57da64f7d85aead", size = 185903, upload-time = "2026-07-17T22:49:56.75Z" },
-    { url = "https://files.pythonhosted.org/packages/34/7c/f95eb20e80104173b3a0a092291f89ea4047ef6e608e0a57ca06eb14eecb/websockets-16.1.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:69159730a823dde3ea8d08783e8d47ef135a6d7e8d44eb127e32b321c9db8e3e", size = 186855, upload-time = "2026-07-17T22:49:58.467Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/35/dd875b3e050ff232d60fa377707f890e369f74d134f1be32e8f68879747c/websockets-16.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ed5bb271084b46530ee2ddc0410537a9961152c5ccba2fc98c5276d992ccba87", size = 187140, upload-time = "2026-07-17T22:50:00.016Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/dc/5cbfcb41824502f6af93b8f3943a4d06c67c23c7d2e31eb18748c4a5b2a7/websockets-16.1.1-cp313-cp313-win32.whl", hash = "sha256:cfb70b4eb56cac4da0a83588f3ad50d46beb0690391082f3d4e2d488c70b68ea", size = 179928, upload-time = "2026-07-17T22:50:01.685Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c1/71e5deb5b7f8f226997ab64908c184ac3105c0155ce2d486f318e5dd08a8/websockets-16.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:d9531d9cbeac99af6f038fb1bc351403531f7d634a2c2e10e2f7c854c6ed5b68", size = 180242, upload-time = "2026-07-17T22:50:03.117Z" },
-    { url = "https://files.pythonhosted.org/packages/73/a2/ba78a164eeea4620df4a4df4bd2ed6017438c4655cc0f36f2c0bc0432355/websockets-16.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:443aefe96b7fdb132e2a70806cca1f2af49bb3f28e47abcd7c2e9dcf4d8fa1b8", size = 179635, upload-time = "2026-07-17T22:50:05.001Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/08/d26d7a7628cd4ac34cbbdb63ac80914ca842ed8e42938c40a53567806df3/websockets-16.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6456ff333092d509127d75a638cb411afae8ff17f092635015d1902efec8a293", size = 177320, upload-time = "2026-07-17T22:50:06.427Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/45/ebec83e6269536aa5932533c67b0af5c781f3e73fdbcd68672dcf43f4f44/websockets-16.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fce6c48559c86d1ac3632ccb1bebc7d5442fbe79bd9bb0e40379ee54be2a4051", size = 177544, upload-time = "2026-07-17T22:50:07.834Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d5/abc614d2297f6c1c3e01e61260364457a47c25cc1cf6a879038902bc6aa8/websockets-16.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:92b820d345f7a3fc7b8163949ee92df910f290c3fc517b3d5301c78065adafe1", size = 187270, upload-time = "2026-07-17T22:50:09.275Z" },
-    { url = "https://files.pythonhosted.org/packages/52/71/4c99af3b87dff1b2927981f6876607d4acb45338c665242168d3982f7758/websockets-16.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a606d9c24035242a3e256e9d5b77ed9cd6bccfcb7cf993e5ca3c0f6f68fb6a7", size = 188509, upload-time = "2026-07-17T22:50:10.722Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/b4/5c8ca14b0df7eb84ed0524165c5359150210140817a3312aee57bf62a1cf/websockets-16.1.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:414e596c75f74e0994084694189d7dc9229fb278e33064d6784b73ffbba3ca31", size = 189882, upload-time = "2026-07-17T22:50:12.293Z" },
-    { url = "https://files.pythonhosted.org/packages/25/c1/bedfba9e70557129cb8083748d167bdcc01483dedf0f0df143676df05cbe/websockets-16.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:536676848fc5961aca9d20389951f59169508f765637a172403dc5434d722fa0", size = 189114, upload-time = "2026-07-17T22:50:13.789Z" },
-    { url = "https://files.pythonhosted.org/packages/df/09/aa835b2787835aebd839114be5de51b797cb480b63ba42b26d34dfe147cb/websockets-16.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:97fd3a0e8b53efa41970ac1dff3d8cf0d2884cadeb4caaf95db7ad1526926ee3", size = 187861, upload-time = "2026-07-17T22:50:15.179Z" },
-    { url = "https://files.pythonhosted.org/packages/20/26/f6408330694dbc9830857d9d23bc14ac4f6875127a480cfdda8d5ca21198/websockets-16.1.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7b1b19636af86a3c7995d4d028dbe376f39b4bf31541146f9c123582a6c94562", size = 185286, upload-time = "2026-07-17T22:50:16.741Z" },
-    { url = "https://files.pythonhosted.org/packages/17/9a/e0675e70dd8a80762cf35bb18799d3f290a4890ffe6439bc51d222796083/websockets-16.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:41c8e77f17294c0ac18008a7309b99b34ee72247ef10b6dff4c3f8b5ac29896b", size = 187935, upload-time = "2026-07-17T22:50:18.213Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c1/3234cfb86afde01b81e9bddcc6e534c440975d60a13991259e833069ab3e/websockets-16.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:9f63bcef7f4b02b06b35fc01c93b96c43b5e88e1e8868676caacf493d5a31f3a", size = 186444, upload-time = "2026-07-17T22:50:19.67Z" },
-    { url = "https://files.pythonhosted.org/packages/89/87/9c15206e1d778923d8daa9657de07aa62ea815e13448319c98458c37b281/websockets-16.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dab9eb87869da2d6ed3af3f3adf28414baae6ec9d4df355ffc18889132f3436c", size = 188409, upload-time = "2026-07-17T22:50:21.28Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/00/cf5de5c67676de2d3eef8b2a518f168f6796595447a5b7161ba0d012915c/websockets-16.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:43e3a9fdd7cbf7ba6040c31fae0faf84ca1474fef777c4e37912f1540f854499", size = 185958, upload-time = "2026-07-17T22:50:22.719Z" },
-    { url = "https://files.pythonhosted.org/packages/62/c0/731b6ddede2e4136912ec4cff2cffbda35af73546be4762c3d7bd3bd79af/websockets-16.1.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:056ae37939ed7e9974f364f5864e76e49182622d8f9751ac1903c0d09b013985", size = 186911, upload-time = "2026-07-17T22:50:24.108Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/7f/39c634472c4469a24a7c09cecddffb08fac6d0e74f73881a94ee8a40a196/websockets-16.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a0eadbbf2c30f01efa58e1f110eb6fa293261f6b0b1aa38f7f48707107690af9", size = 187204, upload-time = "2026-07-17T22:50:25.548Z" },
-    { url = "https://files.pythonhosted.org/packages/26/89/9667c256c256dafcc62d21328ce7a40067da857969b68ee9af375b0aaf72/websockets-16.1.1-cp314-cp314-win32.whl", hash = "sha256:195c978b065fa40910582464f99d6b15c8b314c68e0546549a55ed83f4735328", size = 179603, upload-time = "2026-07-17T22:50:27.086Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/dd/1c099d6c0fc5deb6b46ccdbb6981fdb4b12c917869cb3952408409dc18db/websockets-16.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:4e8d01cc3bcae7bbf8167f944aeafefed590fae5693552bba9794a9df68371cc", size = 179948, upload-time = "2026-07-17T22:50:28.521Z" },
-    { url = "https://files.pythonhosted.org/packages/35/25/9956b2d5e0529d5d23924f21bba1440d4c5c88a562e4f08550871ffa97a7/websockets-16.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0ffd3031ea8bda8d61762e84220186105ba3b748b3c8da2ae4f7816fac03e573", size = 179963, upload-time = "2026-07-17T22:50:29.982Z" },
-    { url = "https://files.pythonhosted.org/packages/17/06/55ffc976c488b6aee9ea05761ff7c4e88e7c1fd82818c8ca7b556ad2f90c/websockets-16.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:84a2cef8deffbd9ab8ee0ea546a2a6a7030c28f44e6cdd4547dbfeb489eb8999", size = 177497, upload-time = "2026-07-17T22:50:31.396Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e8/f7dac2e980bacc92bdc26cebae4ae4d50cae5380732c50980598fc0bbae4/websockets-16.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3df13f73af9b3b38ab1195eb299ecb67a4330c911c97ae04043ff74085728abe", size = 177698, upload-time = "2026-07-17T22:50:32.829Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/39/26762f734113e22da2b942c3aca85798e0c0405d64c256549540ff31e5a1/websockets-16.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:23253dd5bcae3f9aaee0a1d30967a8dbd52e5d3cff93a2e5b84df57b77d4750d", size = 187561, upload-time = "2026-07-17T22:50:34.24Z" },
-    { url = "https://files.pythonhosted.org/packages/11/94/c3f330851806b9b02138b774d593478323e73c99238681b4b93efe64e02d/websockets-16.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c1c5705e314449e3308872fe084b8571ce078ee4fc55a98a769bdefe5917392", size = 188732, upload-time = "2026-07-17T22:50:36.088Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/f2/eb2c450f052de334ae33cf200ece6e87b0e14d186807074e4eb1cd2cdea2/websockets-16.1.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:69e52d175a0a7d1e13b4b67ad41c560b7d98e8c6f6126eb0bda496c784faf8c7", size = 190872, upload-time = "2026-07-17T22:50:38.008Z" },
-    { url = "https://files.pythonhosted.org/packages/70/31/2ac8cecf3a74f7fed9132129fc3d90b3998a1554570c11a69b2a8c20332d/websockets-16.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1f79c89b5eb034d1722938a891916582f8f7f503f58ca22518a63c3f2cd18499", size = 189305, upload-time = "2026-07-17T22:50:39.53Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/cf/8ab19650d3c0d4562c92e70ab47c257c4aa5c6a713ed87fe63766b31fefc/websockets-16.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39f2a024af5c345ffe8fcf1ee18c049c024c94df393bb09b044a6917c77bde43", size = 188033, upload-time = "2026-07-17T22:50:40.912Z" },
-    { url = "https://files.pythonhosted.org/packages/66/d7/a49a38a6127a4acb134fb1912b215d900cc657605cff32445bf519f3acc4/websockets-16.1.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:952303a7318d4cbe1011400839bb2051c9f84fa0a35923267f5daba34b15d458", size = 185748, upload-time = "2026-07-17T22:50:42.559Z" },
-    { url = "https://files.pythonhosted.org/packages/95/3e/ad1fa40388c7f2e0bb2c7930d0090b6c5498594bd1cdaec18864df3d9e97/websockets-16.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:249116b4a76063d930a46391ad56e135c286e4562a18309029fc2c73f4ed4c62", size = 188285, upload-time = "2026-07-17T22:50:43.974Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b8/d5db28ca264b9104f82196f92dc8843e35fd391f763d42e4ad358f5bc97e/websockets-16.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:61922544a0587a13fd3f53e4c0e5e606510c7b0d9d22c8444e5fae22a06b38cb", size = 186777, upload-time = "2026-07-17T22:50:45.474Z" },
-    { url = "https://files.pythonhosted.org/packages/42/9c/726cb39d0cc43ae848dce4aa2acb04eecc6738b1264ec6d700bf6bcfb9f8/websockets-16.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:46dcaa042cd1de6c59e7d9269fa63ff7572b6df40510600b678f0826b3c7af51", size = 188682, upload-time = "2026-07-17T22:50:46.973Z" },
-    { url = "https://files.pythonhosted.org/packages/be/c7/1168704de8c2dd483edabe4a22cbe4465dd8be8dd95561d214f9fe092871/websockets-16.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:38565aca3e01ea8734e578fb2118dade0ecb0250533f29e22b8d1a7a196cf4d0", size = 186377, upload-time = "2026-07-17T22:50:48.413Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/40/f9ff2d630ffce4e7dfea0b2288e1caf9ebbf9ff8a9ec9396136ce8b94935/websockets-16.1.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:42f599f4d48c7e1a3338fdaac3acd075be3b3cf02d4b274f3bf2767aedd3d217", size = 187148, upload-time = "2026-07-17T22:50:49.845Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/71/e177c8299f78d7cbe2d14df228643c10c70c0e86e108e092056bbcc16e46/websockets-16.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dcc04fedf83effaeb9cce98abc9469bb1b42ef85f03e01c8c1f4438ef7555737", size = 187578, upload-time = "2026-07-17T22:50:51.619Z" },
-    { url = "https://files.pythonhosted.org/packages/49/b2/b6987faf330f5af5c787a2610124c2e8403d51724f9001ec4fff6311fe7a/websockets-16.1.1-cp314-cp314t-win32.whl", hash = "sha256:8483c2096363120eea8b07c06ae7304d520f686665fffd4811fad423930a65d7", size = 179729, upload-time = "2026-07-17T22:50:53.269Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/6e/fbac6ed878dd362fbad7d415fa4f84d38e3e33fed8cde45c64e783acf826/websockets-16.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bcce07e23e5769375158f5efdcdafa8d5cd014b93c6683865b840ed65b96f231", size = 180072, upload-time = "2026-07-17T22:50:54.969Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ed/71fea6e141590cafc40b14dc5943b0845606bee87bdb52a21b6a73eb4311/websockets-16.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:820fb8450edddae3812fd58cbc08e2bf22812cb248ecb5f06dbb82119a56e869", size = 177185, upload-time = "2026-07-17T22:50:56.665Z" },
-    { url = "https://files.pythonhosted.org/packages/01/ec/00e7eeca200facf9266a83e4cbbf1bed0e67fba1d4d45031d3e5b3d81b5c/websockets-16.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:125f22dbefaf1554fea66fc83851490edb284ce4f501d37ffed2752f418332d9", size = 177459, upload-time = "2026-07-17T22:50:58.197Z" },
-    { url = "https://files.pythonhosted.org/packages/75/fd/5774c4b33f7c0d8f0c51809c8b3a93456c48e3543579262cfa64eb5f522e/websockets-16.1.1-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:30bbe120437b5648a77d3519b7024ea09530e0b5b18d3698c5a0ae536fe0cc2e", size = 178294, upload-time = "2026-07-17T22:50:59.641Z" },
-    { url = "https://files.pythonhosted.org/packages/37/c3/48e2c03d2bd79bb45948841c592d24156312dd5f58cdf8f549febe652fb6/websockets-16.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b6b9dadbef0cccd9f4c4ee96b08898afa73e26803bbe0f6aeb5bb12b0074206d", size = 179190, upload-time = "2026-07-17T22:51:01.129Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/3f/73e511ecf2496ceac57dd4ed8388efe2bcf0769338a2dbf242c8366ae87e/websockets-16.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56cd5fc4f10a9ea8aa0804bddb7b42506cf9e136046f3b4c27de8fec9e2ecba5", size = 180330, upload-time = "2026-07-17T22:51:02.603Z" },
-    { url = "https://files.pythonhosted.org/packages/be/4d/2d0d67834092e354d2b0498f014a41249a89556bc406cf86f3e1557bb463/websockets-16.1.1-py3-none-any.whl", hash = "sha256:6abbd3e82c731c8e531714466acd5d87b5e88ac3243465337ba71d68e23ae7e3", size = 173814, upload-time = "2026-07-17T22:51:04.184Z" },
-]
-
-[[package]]
 name = "win32-setctime"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Summary
- implement the requested POWER 3.6.7/3.6.8/3.7.0 suite contracts on a clean feature branch
- migrate MCP to the official SDK v2 and route mutations through ApplicationService
- add governed integrations, native managed install, Skill mirroring, receipts, and release evidence
- record the candidate validation boundary and intentionally leave public publication/lifecycle gates explicit

## Validation
- POWER CPU suite: 1150 passed, 11 skipped, 2 warnings
- focused MCP/integration/cross-process: 69 passed
- mypy, Ruff, doc-drift, packaging and fresh-HOME native proof passed

## Release boundary
This is a draft PR until the release version/tag contract and GitHub CI readback are completed. No secrets are included; GitHub credentials are loaded only from the host `.env` at release time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `power integrations` command with diagnostics, MCP configuration, Skill installation, and native installation workflows.
  * Added the `power-mcp` launcher with vault preflight validation and JSON output.
  * Added vault indexing, synchronization, note ingestion, session synthesis, archiving, and frontmatter healing operations.
  * Added safer atomic installation and cross-process mutation handling.

* **Documentation**
  * Updated MCP setup guidance, architecture references, CLI documentation, and release validation materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->