### PR TITLE
fix: support tag-bound release recovery dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing immutable release tag to validate and publish"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -18,6 +23,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          ref: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -169,6 +175,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -200,6 +208,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
 
       - name: Download platform upgrade evidence
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -228,10 +238,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PYTHONPATH: src:.
+      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          ref: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -291,7 +303,7 @@ jobs:
         run: |
           mkdir -p dist
           python scripts/generate_release_baseline.py \
-            --tag "$GITHUB_REF_NAME" \
+            --tag "$RELEASE_TAG" \
             --validation-report "$RUNNER_TEMP/power367-phase8-technical/power367-validation.json" \
             --sbom dist/power-framework.spdx.json \
             --upgrade-matrix-aggregate "$RUNNER_TEMP/power367-upgrade/power367-release-upgrade-aggregate.json" \
@@ -314,7 +326,7 @@ jobs:
       - name: Select tag-matched release notes
         id: release_notes
         shell: bash
-        run: echo "path=docs/release-${GITHUB_REF_NAME#v}.md" >> "$GITHUB_OUTPUT"
+        run: echo "path=docs/release-${RELEASE_TAG#v}.md" >> "$GITHUB_OUTPUT"
 
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
@@ -324,6 +336,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
+          tag_name: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
           body_path: ${{ steps.release_notes.outputs.path }}
           generate_release_notes: false
           files: |
@@ -335,14 +348,14 @@ jobs:
       - name: Generate release receipt
         run: |
           python scripts/generate_release_receipt.py \
-            --tag "$GITHUB_REF_NAME" \
+            --tag "$RELEASE_TAG" \
             --assets-dir dist \
             --output dist/power-framework.release-receipt.json
 
       - name: Upload release receipt
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
           files: dist/power-framework.release-receipt.json
 
       - name: Read back GitHub release metadata and assets
@@ -350,9 +363,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh release view "$GITHUB_REF_NAME" --json tagName,body,assets \
+          gh release view "$RELEASE_TAG" --json tagName,body,assets \
             > dist/power-framework.github-readback.json
-          python - "$GITHUB_REF_NAME" <<'PY'
+          python - "$RELEASE_TAG" <<'PY'
           import json
           import pathlib
           import sys


### PR DESCRIPTION
Allow a manually dispatched recovery run from main to validate and publish an existing immutable tag, while checking out that tag for every job and using it for all baseline, release, receipt, and readback operations.