### PR TITLE
release: record stable suite identities and readback

### DIFF
--- a/release/evidence/public-readback-3.7.1.json
+++ b/release/evidence/public-readback-3.7.1.json
@@ -1,0 +1,48 @@
+{
+  "schema": "power.public-readback.v1",
+  "captured_at": "2026-08-22T11:33:53Z",
+  "power": {
+    "repository": "weby-homelab/power-framework",
+    "tag": "v3.7.1",
+    "commit": "8e172b82b98c8980a83e433744ea2ed6cdedce82",
+    "release": "https://github.com/weby-homelab/power-framework/releases/tag/v3.7.1",
+    "workflow_run": "https://github.com/weby-homelab/power-framework/actions/runs/32570047613",
+    "assets": {
+      "power_framework-3.7.1-py3-none-any.whl": "486a41b070a00dc519e7ec23adccac89a07a3842e47745734a3ee495ae5ad481",
+      "power_framework-3.7.1.tar.gz": "1cfb507f298611b2ddc1800ae202fab3610f9aa5580b5a1a6e0722f6490b19bb",
+      "power-framework.spdx.json": "e2c3722e861682f8382a601221b620e3a3d29d2a8991f7b500663e1ee1a0e0a3",
+      "power-framework.release-receipt.json": "14293a6502767111319617db1a48b4c04df9218f60d6fe0344e39fc9542b03af"
+    },
+    "release_receipt": "power-framework.release-receipt.json",
+    "provenance": "attest-build-provenance passed in workflow run 32570047613"
+  },
+  "gui": {
+    "repository": "weby-homelab/ai-second-brain-gui",
+    "tag": "v0.7.6",
+    "commit": "78c74eab8881258b7e2014044aed4837a0cbcb30",
+    "release": "https://github.com/weby-homelab/ai-second-brain-gui/releases/tag/v0.7.6",
+    "workflow_run": "https://github.com/weby-homelab/ai-second-brain-gui/actions/runs/32570290365",
+    "assets": {
+      "power_gui-0.7.6-py3-none-any.whl": "03244984c089766980dbbe4cd28de51fd9d294519e46f60aa64de6fe6154b591",
+      "power_gui-0.7.6.tar.gz": "461fd33adde25d53860ce14c0ac3ff98ae6e95bc704dbf1092325e7487623904",
+      "power-gui.spdx.json": "50ed0bd3dd7d8026e3789052fe5bae86b9258927895cd0114e21145a2e966701",
+      "power-gui.release-receipt.json": "543fe514c98fe7cbe8b7477bff667bf90f9198ef987894d9ebbf5fb8ef68e0de"
+    },
+    "release_receipt": "power-gui.release-receipt.json",
+    "provenance": "attest-build-provenance passed in workflow run 32570290365"
+  },
+  "container": {
+    "image": "webyhomelab/power-gui:0.7.6",
+    "digest": "sha256:5377536a6552c7c86c892fb1c1eec5fd2ed54e81784c4a9be939a090d826b470",
+    "platforms": ["linux/amd64", "linux/arm64"],
+    "workflow_run": "https://github.com/weby-homelab/ai-second-brain-gui/actions/runs/32570290281",
+    "live_e2e": "passed",
+    "registry_readback": "Docker Registry Docker-Content-Digest matched workflow digest"
+  },
+  "pair": {
+    "application_schema": "power.application.v2",
+    "power_source_matches_tag": true,
+    "gui_source_matches_tag": true,
+    "container_core_source": "8e172b82b98c8980a83e433744ea2ed6cdedce82"
+  }
+}

--- a/release/evidence/python-matrix-3.7.1.json
+++ b/release/evidence/python-matrix-3.7.1.json
@@ -1,0 +1,35 @@
+{
+  "schema": "power.python-matrix.v1",
+  "suite_version": "3.7.1",
+  "python": {
+    "3.11": {
+      "status": "unsupported",
+      "reason": "Outside the final Requires-Python contract; candidate matrix resolution did not produce a supported runtime."
+    },
+    "3.12": {
+      "status": "unsupported",
+      "reason": "Outside the final Requires-Python contract; candidate matrix resolution did not produce a supported runtime."
+    },
+    "3.13": {
+      "status": "supported",
+      "core_targeted_tests": "10 passed",
+      "gui_targeted_tests": "19 passed",
+      "release_full_matrix": "passed",
+      "evidence": [
+        "https://github.com/weby-homelab/power-framework/actions/runs/32570047613",
+        "https://github.com/weby-homelab/ai-second-brain-gui/actions/runs/32570290365"
+      ]
+    },
+    "3.14": {
+      "status": "supported",
+      "core_local_full_suite": "1155 passed, 11 skipped",
+      "gui_local_full_suite": "58 passed, 3 skipped",
+      "release_full_matrix": "passed",
+      "evidence": [
+        "https://github.com/weby-homelab/power-framework/actions/runs/32570047613"
+      ]
+    }
+  },
+  "requires_python": ">=3.13,<3.15",
+  "decision": "Support is intentionally limited to Python 3.13 and 3.14; 3.11 and 3.12 are not stable claims."
+}

--- a/release/power.suite.manifest.json
+++ b/release/power.suite.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "power.suite.manifest.v1",
-  "status": "candidate",
+  "status": "stable",
   "suite_version": "3.7.1",
   "application_schema": "power.application.v2",
   "python": {
@@ -10,19 +10,27 @@
     "distribution": "power-framework",
     "version": "3.7.1",
     "filename": "power_framework-3.7.1-py3-none-any.whl",
-    "sha256": "dc8ce03936d410bb12f71699b7ad07f9ecf5ab7a008dac00f8dccd15769a9f04",
+    "sha256": "486a41b070a00dc519e7ec23adccac89a07a3842e47745734a3ee495ae5ad481",
     "requires_python": ">=3.13,<3.15",
-    "source_sha": "be1496ae067ee66075a969335afafe315a4ac669",
-    "tag": null
+    "source_sha": "8e172b82b98c8980a83e433744ea2ed6cdedce82",
+    "tag": "v3.7.1",
+    "sdist_filename": "power_framework-3.7.1.tar.gz",
+    "sdist_sha256": "1cfb507f298611b2ddc1800ae202fab3610f9aa5580b5a1a6e0722f6490b19bb",
+    "sbom_filename": "power-framework.spdx.json",
+    "sbom_sha256": "e2c3722e861682f8382a601221b620e3a3d29d2a8991f7b500663e1ee1a0e0a3"
   },
   "gui": {
     "distribution": "power-gui",
     "version": "0.7.6",
     "filename": "power_gui-0.7.6-py3-none-any.whl",
-    "sha256": "253be84d3ada1c9720327cfc0ca6d4d20567aa4fd7dab6aef79b1f6f8914507d",
+    "sha256": "03244984c089766980dbbe4cd28de51fd9d294519e46f60aa64de6fe6154b591",
     "requires_python": ">=3.13,<3.15",
-    "source_sha": "334d7b388b9ed33a2881f1aecd494ef567975ac2",
-    "tag": null
+    "source_sha": "78c74eab8881258b7e2014044aed4837a0cbcb30",
+    "tag": "v0.7.6",
+    "sdist_filename": "power_gui-0.7.6.tar.gz",
+    "sdist_sha256": "461fd33adde25d53860ce14c0ac3ff98ae6e95bc704dbf1092325e7487623904",
+    "sbom_filename": "power-gui.spdx.json",
+    "sbom_sha256": "50ed0bd3dd7d8026e3789052fe5bae86b9258927895cd0114e21145a2e966701"
   },
   "skill": {
     "tree_sha256": "4ac2ad7e851f4bc17f32cd54369263a94738929f34df2b5844f66f702819331e",
@@ -39,8 +47,19 @@
     "application_schema": "power.application.v2"
   },
   "publication": {
-    "core_tag": null,
-    "gui_tag": null,
-    "stable_readback": false
+    "core_tag": "v3.7.1",
+    "gui_tag": "v0.7.6",
+    "stable_readback": true,
+    "core_release_run": "32570047613",
+    "gui_release_run": "32570290365",
+    "gui_image_run": "32570290281",
+    "core_release_url": "https://github.com/weby-homelab/power-framework/releases/tag/v3.7.1",
+    "gui_release_url": "https://github.com/weby-homelab/ai-second-brain-gui/releases/tag/v0.7.6"
+  },
+  "container": {
+    "image": "webyhomelab/power-gui:0.7.6",
+    "digest": "sha256:5377536a6552c7c86c892fb1c1eec5fd2ed54e81784c4a9be939a090d826b470",
+    "platforms": ["linux/amd64", "linux/arm64"],
+    "readback": "https://github.com/weby-homelab/ai-second-brain-gui/actions/runs/32570290281"
   }
 }

--- a/release/power.suite.release-receipt.json
+++ b/release/power.suite.release-receipt.json
@@ -1,0 +1,73 @@
+{
+  "schema": "power.suite.release-receipt.v1",
+  "suite_version": "3.7.1",
+  "released_at": "2026-08-22T11:33:53Z",
+  "power": {
+    "repository": "https://github.com/weby-homelab/power-framework",
+    "tag": "v3.7.1",
+    "commit": "8e172b82b98c8980a83e433744ea2ed6cdedce82",
+    "version": "3.7.1",
+    "wheel": "power_framework-3.7.1-py3-none-any.whl",
+    "wheel_sha256": "486a41b070a00dc519e7ec23adccac89a07a3842e47745734a3ee495ae5ad481",
+    "sdist": "power_framework-3.7.1.tar.gz",
+    "sdist_sha256": "1cfb507f298611b2ddc1800ae202fab3610f9aa5580b5a1a6e0722f6490b19bb",
+    "sbom": "power-framework.spdx.json",
+    "sbom_sha256": "e2c3722e861682f8382a601221b620e3a3d29d2a8991f7b500663e1ee1a0e0a3",
+    "release_receipt": "power-framework.release-receipt.json",
+    "provenance": "https://github.com/weby-homelab/power-framework/actions/runs/32570047613"
+  },
+  "gui": {
+    "repository": "https://github.com/weby-homelab/ai-second-brain-gui",
+    "tag": "v0.7.6",
+    "commit": "78c74eab8881258b7e2014044aed4837a0cbcb30",
+    "version": "0.7.6",
+    "wheel": "power_gui-0.7.6-py3-none-any.whl",
+    "wheel_sha256": "03244984c089766980dbbe4cd28de51fd9d294519e46f60aa64de6fe6154b591",
+    "sdist": "power_gui-0.7.6.tar.gz",
+    "sdist_sha256": "461fd33adde25d53860ce14c0ac3ff98ae6e95bc704dbf1092325e7487623904",
+    "image": "webyhomelab/power-gui:0.7.6",
+    "image_digest": "sha256:5377536a6552c7c86c892fb1c1eec5fd2ed54e81784c4a9be939a090d826b470",
+    "platforms": ["linux/amd64", "linux/arm64"],
+    "sbom": "power-gui.spdx.json",
+    "sbom_sha256": "50ed0bd3dd7d8026e3789052fe5bae86b9258927895cd0114e21145a2e966701",
+    "release_receipt": "power-gui.release-receipt.json",
+    "provenance": "https://github.com/weby-homelab/ai-second-brain-gui/actions/runs/32570290365"
+  },
+  "runtime": {
+    "python_range": ">=3.13,<3.15",
+    "linux_support_boundary": "Linux native and Linux multi-arch container profiles",
+    "application_schema": "power.application.v2"
+  },
+  "mcp": {
+    "sdk_identity": "mcp==2.0.0",
+    "entry_point": "power-mcp",
+    "transport": "stdio",
+    "tool_count": 20,
+    "tool_contract_sha256": "bb4a0790eeb7c47138917508d8556a1f45c8a311995f552388499183b195755c",
+    "protocol_stdout": "clean",
+    "application_service_bypass_count": 0
+  },
+  "skill": {
+    "source": "skills/power",
+    "packaged": true,
+    "tree_sha256": "4ac2ad7e851f4bc17f32cd54369263a94738929f34df2b5844f66f702819331e",
+    "install": "passed",
+    "upgrade": "passed",
+    "foreign_target_protection": "passed"
+  },
+  "dependencies": {
+    "constraints_artifact": "power-suite.constraints.txt",
+    "constraints_sha256": "cae5417ce4df81c8b1ca18d74021503c9be40fc941b6bc1b9ff9dec2395373a5",
+    "lockfile": "uv.lock"
+  },
+  "validation": {
+    "native_clean_install": "passed",
+    "mcp_subprocess": "passed",
+    "systemd_user": "passed",
+    "container_e2e": "passed",
+    "cross_runtime": "passed",
+    "public_readback": "passed",
+    "human_quality": "not claimed",
+    "m2_human_opened": false
+  }
+}


### PR DESCRIPTION
Record the exact public POWER/GUI artifact pair, multi-arch image digest, stable Suite manifest, Python matrix, and cross-repository release receipt after successful public readback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Power Suite 3.7.1 is now marked stable, with finalized package, source, SBOM, and container metadata.
  * Release records include artifact checksums, provenance, validation results, and publication details.
* **Compatibility**
  * Supported Python versions are 3.13 and 3.14.
  * Python 3.11 and 3.12 are not supported.
* **Verification**
  * Added evidence for release integrity, live end-to-end checks, registry validation, and container platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->