### PR TITLE
fix: rewrite staged console shims after native install

### DIFF
--- a/src/power_framework/core/integrations.py
+++ b/src/power_framework/core/integrations.py
@@ -371,20 +371,29 @@ def _write_executable(path: Path, content: str) -> None:
     os.replace(temporary, path)
 
 
-def _rewrite_venv_shebangs(venv_root: Path) -> None:
-    """Point generated console scripts at the activated venv after a move."""
+def _rewrite_venv_shebangs(venv_root: Path, *, staging_root: Path | None = None) -> None:
+    """Point generated console scripts at the activated venv after a move.
+
+    Recent pip versions may emit shell shims whose interpreter path appears on
+    the second line rather than in the shebang.  Replace the exact staging
+    root in every regular ``bin`` file so both shim formats survive the
+    atomic staging-venv move, including homes containing spaces or Unicode.
+    """
     python_path = venv_root / "bin" / "python"
+    staging_bytes = str(staging_root).encode("utf-8") if staging_root is not None else None
+    active_bytes = str(venv_root).encode("utf-8")
     bin_dir = venv_root / "bin"
     for script in bin_dir.iterdir():
         if script.is_symlink() or not script.is_file():
             continue
-        content = script.read_bytes()
+        original = content = script.read_bytes()
+        if staging_bytes and staging_bytes in content:
+            content = content.replace(staging_bytes, active_bytes)
         first_line, separator, remainder = content.partition(b"\n")
-        if not separator or not first_line.startswith(b"#!"):
-            continue
-        if b"/bin/python" not in first_line:
-            continue
-        script.write_bytes(b"#!" + str(python_path).encode("utf-8") + b"\n" + remainder)
+        if separator and first_line.startswith(b"#!") and b"/bin/python" in first_line:
+            content = b"#!" + str(python_path).encode("utf-8") + b"\n" + remainder
+        if content != original:
+            script.write_bytes(content)
 
 
 def apply_native_install_plan(
@@ -499,7 +508,7 @@ def apply_native_install_plan(
         if venv_root.exists():
             os.replace(venv_root, previous_venv)
         os.replace(staging_venv, venv_root)
-        _rewrite_venv_shebangs(venv_root)
+        _rewrite_venv_shebangs(venv_root, staging_root=staging_venv)
         activated = True
         for name in launcher_names:
             os.replace(launcher_stage / name, launcher_dir / name)

--- a/tests/test_suite_contract.py
+++ b/tests/test_suite_contract.py
@@ -153,3 +153,21 @@ def test_moved_venv_console_scripts_use_active_interpreter(tmp_path: Path) -> No
     _rewrite_venv_shebangs(venv_root)
 
     assert script.read_text(encoding="utf-8").startswith(f"#!{venv_root}/bin/python\n")
+
+
+def test_moved_venv_shell_shims_drop_staging_root(tmp_path: Path) -> None:
+    staging_root = tmp_path / ".venv.staging-with spaces-Ж"
+    venv_root = tmp_path / "active with spaces-Ж" / "venv"
+    bin_dir = venv_root / "bin"
+    bin_dir.mkdir(parents=True)
+    script = bin_dir / "power"
+    script.write_text(
+        f"#!/bin/sh\n'''exec' \"{staging_root}/bin/python\" \"$0\" \"$@\"\n' '''\n",
+        encoding="utf-8",
+    )
+
+    _rewrite_venv_shebangs(venv_root, staging_root=staging_root)
+
+    rewritten = script.read_text(encoding="utf-8")
+    assert str(staging_root) not in rewritten
+    assert f"{venv_root}/bin/python" in rewritten


### PR DESCRIPTION
## Summary
- fix native exact-pair installer activation after atomic staging venv move
- rewrite staging-root references in pip shell shims as well as traditional shebangs
- cover spaces/Unicode home paths with a regression test

## Validation
- ruff check and format check pass
- suite contract tests: 6 passed
- public 3.7.1/0.7.7 wheel bootstrap with patched source installer passed
- managed power/power-mcp and GUI import versions are 3.7.1, 3.7.1, and 0.7.7
- FTS init/ingest/sync/search, native GUI health/readiness and two start/stop cycles passed
- official MCP SDK v2: 20 tools and proposal-only flow passed

The public v3.7.1 wheel remains immutable; this correction is intentionally a follow-up patch release gate.