### PR TITLE
docs: record POWER 3.7.1 immutable NO-GO

### DIFF
--- a/docs/release-3.7.1.md
+++ b/docs/release-3.7.1.md
@@ -1,15 +1,24 @@
-# POWER 3.7.1 release boundary
+# POWER 3.7.1 release boundary — NO-GO
 
 This document records the evidence boundary for the 3.6.7 -> 3.7.1
-stabilization line. It is deliberately written as a candidate-release note:
-the source tree may be validated locally before the signed tag, immutable
-artifacts, and public readback exist.
+stabilization line. The immutable public `v3.7.1` component release exists, but
+the requested POWER Suite 3.7.1 Stable claim is **NO-GO**.
+
+The public consumer gate reproduced a mandatory native-install failure on
+Python 3.14 with a HOME path containing spaces and Unicode: installation
+reported `applied`, while the moved `power`, `power-mcp`, and `power-gui`
+console shims still referenced the removed `.venv.staging-*` environment. The
+content-free reproduction is recorded in
+`release/evidence/public-native-failure-3.7.1.json`.
+
+This immutable result cannot be repaired by moving or rewriting `v3.7.1`.
+Later patch lines are separate historical corrections and do not promote this
+3.7.1 suite to Stable.
 
 ## Publication gate
 
-The release is not published by this document. A stable claim requires all of
-the following to be read back from the public release after the corresponding
-workflow succeeds:
+The following are the required stable gates; the native gate failed, so the
+stable claim is not permitted:
 
 - the signed `v3.7.1` tag and matching source revision;
 - the exact wheel, source archive, suite manifest, receipt, SPDX SBOM, and
@@ -18,6 +27,10 @@ workflow succeeds:
 - the immutable container digest, SBOM, and attestation;
 - the final clean-tag validation report, including native, MCP, GUI, lifecycle,
   concurrency, recovery, and upgrade evidence.
+
+Component artifact publication/readback is not sufficient to close the suite
+gate. The exact public component identities remain recorded for audit and are
+not presented as a Stable Suite claim.
 
 Local synthetic tests or a disposable vault do not constitute a
 real-vault quality or human-quality claim. Human-quality evidence remains
@@ -31,5 +44,5 @@ Python versions. macOS and Windows remain outside the supported release boundary
 The Windows guide is retained as an informational rollback and migration
 reference only.
 
-Until the public readback gate is complete, downstream documentation must use
-the candidate wording and must not describe `v3.7.1` as available.
+Downstream documentation must use candidate/NO-GO wording and must not
+describe the POWER `v3.7.1` Suite as Stable or available.

--- a/release/audit-3.7.1-input.md
+++ b/release/audit-3.7.1-input.md
@@ -51,3 +51,17 @@ publishes the real immutable pair.
 4. Keep secrets in `/root/gemma/.env`; this audit input does not copy or expose
    them.
 
+## Post-publication immutable outcome
+
+The Stage 0 table above is a historical baseline captured before publication;
+it is not rewritten. The later public component identities were read back as:
+
+| Component | Public tag | Tag commit | Result |
+| --- | --- | --- | --- |
+| POWER core | `v3.7.1` | `8e172b82b98c8980a83e433744ea2ed6cdedce82` | Component assets read back; Suite native gate **FAIL** |
+| POWER GUI | `v0.7.7` | `339388ee4f77401a033ed50d4cac25ad3b82fefd` | Component assets/image read back; Suite pair remains **NO-GO** |
+
+The published build therefore differs from the pre-publication candidate
+source rows above. The exact native failure reproduction and content-free
+receipt are in `release/evidence/public-native-failure-3.7.1.json`. The
+immutable tag is not moved, deleted, or recreated.

--- a/release/evidence/public-native-failure-3.7.1.json
+++ b/release/evidence/public-native-failure-3.7.1.json
@@ -1,0 +1,38 @@
+{
+  "schema": "power.public-native-failure.v1",
+  "captured_at": "2026-08-22T17:09:10+03:00",
+  "test": "immutable POWER v3.7.1 and GUI v0.7.7 public wheels; disposable HOME contains spaces and Unicode",
+  "power": {
+    "repository": "weby-homelab/power-framework",
+    "tag": "v3.7.1",
+    "commit": "8e172b82b98c8980a83e433744ea2ed6cdedce82",
+    "wheel": "power_framework-3.7.1-py3-none-any.whl",
+    "wheel_sha256": "486a41b070a00dc519e7ec23adccac89a07a3842e47745734a3ee495ae5ad481"
+  },
+  "gui": {
+    "repository": "weby-homelab/ai-second-brain-gui",
+    "tag": "v0.7.7",
+    "commit": "339388ee4f77401a033ed50d4cac25ad3b82fefd",
+    "wheel": "power_gui-0.7.7-py3-none-any.whl",
+    "wheel_sha256": "8e7904a12abf30e4e458125c36d621ae383caff764a46471223b919dc7591853"
+  },
+  "runtime": {
+    "python": "3.14.4",
+    "platform": "Linux x86_64",
+    "home_shape": "dedicated HOME path with spaces and Unicode"
+  },
+  "result": {
+    "install_exit_code": 0,
+    "install_status": "applied",
+    "launcher_exit_code": 127,
+    "affected_launchers": ["power", "power-mcp", "power-gui"],
+    "staging_reference": ".local/share/power/.venv.staging-<generated-id>/bin/python",
+    "absolute_staging_path_exists_after_install": false,
+    "failure_class": "moved_console_shell_shim_retained_removed_staging_root",
+    "launcher_sha256": "70d18174ec2efdc8b61fbf9fc1b2f998bd231e6db26ec9f064c4e1db2d24ceba",
+    "stderr_sha256": "96fcf5f9583470cfab28387b5401e96a988cdf8d09672514af2a15352159cbea"
+  },
+  "decision": "NO-GO",
+  "human_quality_claim": "none",
+  "m2_human_opened": false
+}

--- a/release/power-suite-3.7.1-final-report.md
+++ b/release/power-suite-3.7.1-final-report.md
@@ -1,0 +1,86 @@
+# P.O.W.E.R. 3.7.1 Stable Release Report
+
+Date: 2026-08-22 (Europe/Kyiv)
+
+## Final decision
+
+**NO-GO — POWER 3.7.1 Stable was not achieved.**
+
+The immutable public POWER `v3.7.1` component and compatible GUI `v0.7.7`
+artifacts are available and their component publication readback succeeded.
+The Suite is not Stable because the mandatory public native clean-install gate
+fails. Rewriting the immutable tag or silently replacing its artifacts is
+prohibited.
+
+## Source identities
+
+| Component | Tag | Commit | Version |
+| --- | --- | --- | --- |
+| POWER | `v3.7.1` | `8e172b82b98c8980a83e433744ea2ed6cdedce82` | `3.7.1` |
+| GUI | `v0.7.7` | `339388ee4f77401a033ed50d4cac25ad3b82fefd` | `0.7.7` |
+
+No immutable tag was rewritten. Later `3.7.2`/`3.7.3` corrective lines are
+separate historical releases and are not used to certify this target.
+
+## Exact public artifacts
+
+- POWER wheel: `power_framework-3.7.1-py3-none-any.whl`, SHA-256
+  `486a41b070a00dc519e7ec23adccac89a07a3842e47745734a3ee495ae5ad481`.
+- POWER sdist: SHA-256
+  `1cfb507f298611b2ddc1800ae202fab3610f9aa5580b5a1a6e0722f6490b19bb`.
+- GUI wheel: `power_gui-0.7.7-py3-none-any.whl`, SHA-256
+  `8e7904a12abf30e4e458125c36d621ae383caff764a46471223b919dc7591853`.
+- GUI sdist: SHA-256
+  `be61e84747c82caced4949deb1ef606fb284805867ffb9fb29bbab0995a261de`.
+- Constraints: `power-suite-3.7.1-gui-0.7.7.constraints.txt`, SHA-256
+  `e0ded6bc17bbbfc38a0834dcd32fad50e2fc3a2d23b03145deca76920e948898`.
+- Core/GUI SBOM, release receipts, provenance, and container readback are
+  recorded in `release/evidence/public-readback-3.7.1.json`.
+
+## Mandatory gate results
+
+| Gate | Result | Evidence |
+| --- | --- | --- |
+| Exact pair and public artifact readback | PASS (component scope) | `release/evidence/public-readback-3.7.1.json` |
+| Native clean install from public wheels | **FAIL** | `release/evidence/public-native-failure-3.7.1.json` |
+| `power-mcp` / MCP contract | PASS for tested component surface; not sufficient to promote Suite | prior release evidence and component receipts |
+| Packaged Skill | PASS for the tested 3.7.1 component | component evidence; no human-quality claim |
+| Native GUI lifecycle | NOT RUN after the blocking native failure | mandatory gate remains open |
+| Cross-runtime concurrency/recovery | NOT RUN as final public Stable proof | mandatory gate remains open |
+| Upgrade and rollback | NOT RUN as final public Stable proof | mandatory gate remains open |
+| GUI security/accessibility final public flow | NOT RUN as final public Stable proof | mandatory gate remains open |
+
+The reproduced failure is deterministic: on Python 3.14.4, the installer
+returns `applied`, but the moved `power`, `power-mcp`, and `power-gui` shims
+retain a generated `.venv.staging-*` interpreter path. That staging path no
+longer exists, so the public launcher exits `127`.
+
+## Boundaries and policy
+
+- Supported evidence boundary: Linux x86_64, Python 3.14.4 for the reproduced
+  failure; no universal Linux claim is made.
+- Managed native target remains `~/.local/share/power/venv` with launchers under
+  `~/.local/bin`; the public 3.7.1 clean-install gate does not satisfy it.
+- Automatic product updates: disabled; no safe suite-aware updater was proven.
+- A2A, Federation, MCP Apps, Windows, and macOS: no Stable claims.
+- Human retrieval quality: none claimed.
+- `M2_HUMAN` opened: **NO**; sealed material remains excluded by policy.
+- New material product features: **0**.
+
+## Stale-claim correction
+
+The repository suite manifest is explicitly marked `candidate` with
+`release_decision: NO-GO` and `stable_readback: false`. The suite receipt records
+the component identities but marks the release `NO-GO`; neither artifact claims
+that POWER 3.7.1 Stable exists.
+
+## Open blockers
+
+1. The immutable public 3.7.1 native installer fails on a supported path shape.
+2. Because the P0 native gate failed, final Stable lifecycle, cross-runtime,
+   upgrade, rollback, and post-publication proof cannot be promoted for this
+   target.
+
+## Final decision
+
+**NO-GO. POWER 3.7.1 is not Stable.**

--- a/release/power.suite.manifest.json
+++ b/release/power.suite.manifest.json
@@ -1,7 +1,9 @@
 {
   "schema": "power.suite.manifest.v1",
-  "status": "stable",
+  "status": "candidate",
   "suite_version": "3.7.1",
+  "release_decision": "NO-GO",
+  "no_go_reason": "The immutable public v3.7.1 native clean-install gate fails: moved console shims retain the removed staging venv when HOME contains spaces or Unicode.",
   "application_schema": "power.application.v2",
   "python": {
     "requires_python": ">=3.13,<3.15"
@@ -49,7 +51,8 @@
   "publication": {
     "core_tag": "v3.7.1",
     "gui_tag": "v0.7.7",
-    "stable_readback": true,
+    "stable_readback": false,
+    "readback_status": "component_publication_verified_suite_gate_failed",
     "core_release_run": "32570047613",
     "gui_release_run": "32571844771",
     "gui_image_run": "32571844803",

--- a/release/power.suite.release-receipt.json
+++ b/release/power.suite.release-receipt.json
@@ -1,6 +1,8 @@
 {
   "schema": "power.suite.release-receipt.v1",
   "suite_version": "3.7.1",
+  "release_status": "NO-GO",
+  "no_go_reason": "The immutable public v3.7.1 native clean-install gate fails for a HOME path containing spaces and Unicode.",
   "released_at": "2026-08-22T12:08:03Z",
   "power": {
     "repository": "https://github.com/weby-homelab/power-framework",
@@ -61,12 +63,16 @@
     "lockfile": "uv.lock"
   },
   "validation": {
-    "native_clean_install": "passed",
+    "native_clean_install": "failed: moved console shell shims reference the removed staging venv",
     "mcp_subprocess": "passed",
-    "systemd_user": "passed",
-    "container_e2e": "passed",
-    "cross_runtime": "passed",
-    "public_readback": "passed",
+    "systemd_user": "not_run_after_native_blocker",
+    "container_e2e": "component_readback_passed_not_suite_stable",
+    "cross_runtime": "not_run",
+    "public_readback": "component_assets_passed_native_gate_failed",
+    "gui_lifecycle": "not_run",
+    "concurrency": "not_run",
+    "recovery": "not_run",
+    "upgrade": "not_run",
     "human_quality": "not claimed",
     "m2_human_opened": false
   }


### PR DESCRIPTION
## Summary
- Record the immutable public POWER v3.7.1 / GUI v0.7.7 component identities without moving or rewriting tags.
- Correct stale suite Stable claims to candidate/NO-GO.
- Add content-free evidence for the reproduced public native clean-install failure (install applied, launcher exit 127, removed staging venv reference).
- Add the final evidence-backed NO-GO report.

## Validation
- `uv lock --check`
- `uv run ruff check src tests scripts`
- `uv run ruff format --check src tests scripts`
- `uv run python scripts/check_doc_drift.py`
- `uv run pytest --no-cov -q tests/test_suite_contract.py` (6 passed)
- `uv run python scripts/verify_upgrade_matrix.py`
- `uv run mkdocs build --strict`

No new version, tag, release, image, or product feature is created by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Status**
  * Marked POWER 3.7.1 as **NO-GO** and retained it as a candidate rather than Stable.
  * Documented the failed native clean-install gate affecting paths with spaces or Unicode.
  * Recorded successful component publication and readback alongside the overall release failure.

* **Documentation**
  * Added final release reporting, audit details, evidence, hashes, and immutable tag information.
  * Clarified that later corrections cannot promote the immutable release to Stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->