### PR TITLE
fix: align snapshot revisions and release SBOM input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,7 +350,7 @@ jobs:
       - name: Generate package SPDX SBOM bound to the exact wheel
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          path: ${{ runner.temp }}/power-framework-package.whl
+          file: ${{ runner.temp }}/power-framework-package.whl
           format: spdx-json
           output-file: dist/power-framework.spdx.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a sibling file share a name prefix (issue #360).
 - Passed the packaged wheel to `anchore/sbom-action` through its file input,
   restoring the failed package SBOM release gate.
+- Salted dense chunk IDs with their ordinal and automatically rebuilds stale
+  dense manifests, so repeated identical sections cannot overwrite embeddings.
+- Documented pausing live-vault writers while `power sync` captures and verifies
+  its source snapshot.
 
 ## [3.7.7] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the P.O.W.E.R. Framework will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Aligned generation and source-projection snapshot digests on one
+  lexicographic relative-path order, so promotion succeeds when a directory
+  and a sibling file share a name prefix (issue #360).
+- Passed the packaged wheel to `anchore/sbom-action` through its file input,
+  restoring the failed package SBOM release gate.
+
 ## [3.7.7] - 2026-08-23
 
 ### Changed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -261,6 +261,12 @@ exclusion reasons. Full sync downloads and validates the pinned embedding assets
 as needed. It can be resource intensive. The default is fail-closed when any
 note is excluded; use `--allow-partial` only when a partial index is deliberate.
 
+On a live vault, pause any editor, filesystem watcher, or external sync daemon
+that can write Markdown while `power sync` is running. POWER rechecks the source
+snapshot before publication and deliberately rejects a build whose inputs changed;
+after pausing the writer, rerun the same command. The previous active generation
+remains readable when this guard fires.
+
 ### `rot`
 
 Report redundant, outdated, and trivial notes.

--- a/src/power_framework/core/constants.py
+++ b/src/power_framework/core/constants.py
@@ -68,6 +68,10 @@ SKIP_FILES: frozenset[str] = frozenset({"index.md", "log.md", "_index.md", "POWE
 
 SYSTEM_SKIP_PARTS: tuple[str, ...] = (".git", "05_Templates", ".system_generated")
 
+# Dense chunk IDs include their ordinal so repeated identical sections cannot
+# overwrite one another in the globally keyed chunk_embeddings table.
+DENSE_INDEX_SCHEMA_VERSION = "3"
+
 
 def is_catalog_filename(filename: str) -> bool:
     """Return whether *filename* is a generated hierarchical catalog page."""

--- a/src/power_framework/core/generation_index.py
+++ b/src/power_framework/core/generation_index.py
@@ -268,7 +268,7 @@ def _source_inventory(vault_dir: Path) -> SourceInventory:
 
 def _snapshot_hash(sources: dict[str, str]) -> str:
     digest = hashlib.blake2b(digest_size=32)
-    for rel_path, content_hash in sources.items():
+    for rel_path, content_hash in sorted(sources.items()):
         digest.update(rel_path.encode("utf-8"))
         digest.update(b"\0")
         digest.update(content_hash.encode("ascii"))

--- a/src/power_framework/core/index_sync.py
+++ b/src/power_framework/core/index_sync.py
@@ -13,7 +13,7 @@ from collections import Counter
 from typing import TYPE_CHECKING, Any, cast
 
 from .chunker import SemanticChunker
-from .constants import is_catalog_filename
+from .constants import DENSE_INDEX_SCHEMA_VERSION, is_catalog_filename
 from .ignore import should_skip
 from .parser import read_file_content, validate_metadata
 from .source_projection import scan_projection, write_projection
@@ -52,11 +52,16 @@ def _compute_tf_vector(tokens: list[str]) -> dict[str, float]:
     return {word: count / total for word, count in counter.items()}
 
 
-def _stable_chunk_id(source_content_hash: str, section_identity: str, chunk_text: str) -> str:
-    """Return a content-addressed chunk identifier independent of vault paths."""
+def _stable_chunk_id(
+    source_content_hash: str,
+    section_identity: str,
+    chunk_text: str,
+    ordinal: int = 0,
+) -> str:
+    """Return a stable chunk ID that distinguishes repeated section content."""
     normalized_chunk = " ".join(chunk_text.split()).casefold()
     normalized_section = " ".join(section_identity.split()).casefold()
-    payload = "\x00".join((source_content_hash, normalized_section, normalized_chunk))
+    payload = "\x00".join((source_content_hash, normalized_section, str(ordinal), normalized_chunk))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
@@ -98,8 +103,14 @@ def _sync_vault_to_db(
     cursor = conn.cursor()
     if sync_embeddings:
         chunk_cnt = cursor.execute("SELECT COUNT(*) FROM chunk_embeddings").fetchone()[0]
-        if force_rebuild or chunk_cnt == 0:
-            logger.info("Dense embeddings missing or force rebuild requested: resetting mtime ...")
+        dense_manifest = dict(
+            cursor.execute("SELECT manifest_key, manifest_value FROM dense_index_manifest")
+        )
+        schema_stale = dense_manifest.get("schema_version") != DENSE_INDEX_SCHEMA_VERSION
+        if force_rebuild or chunk_cnt == 0 or schema_stale:
+            logger.info(
+                "Dense embeddings missing, stale, or force rebuild requested: resetting mtime ..."
+            )
             try:
                 cursor.execute("DELETE FROM doc_embeddings")
                 cursor.execute("DELETE FROM chunk_embeddings")
@@ -339,6 +350,7 @@ def _sync_vault_to_db(
                             source_content_hash,
                             _chunk_section_identity(chunk_text, i),
                             chunk_text,
+                            ordinal=i,
                         ),
                         rel_path,
                         chunk_text,
@@ -376,7 +388,7 @@ def _sync_vault_to_db(
         cursor.executemany(
             "INSERT OR REPLACE INTO dense_index_manifest (manifest_key, manifest_value) VALUES (?, ?)",
             [
-                ("schema_version", "2"),
+                ("schema_version", DENSE_INDEX_SCHEMA_VERSION),
                 ("embedding_dimension", str(embedding_bytes // 4)),
                 ("chunk_count", str(dense_count)),
                 ("embedding_provider", provider),

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from threading import RLock
 from typing import TYPE_CHECKING, Any
 
-from .constants import is_catalog_filename
+from .constants import DENSE_INDEX_SCHEMA_VERSION, is_catalog_filename
 from .db import _init_db
 from .domains import DomainConfigError, resolve_search_policy
 from .generation_index import (
@@ -425,7 +425,7 @@ def validate_dense_index(vault_dir: Path, resolved_db: _ResolvedDb | None = None
     dimension = min_size // 4
     expected_provider, expected_model = configured_embedding_identity()
     required_manifest = {
-        "schema_version": "2",
+        "schema_version": DENSE_INDEX_SCHEMA_VERSION,
         "embedding_dimension": str(dimension),
         "chunk_count": str(rows),
         "embedding_provider": expected_provider,

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -92,6 +92,13 @@ def test_release_workflow_publishes_sbom_and_attestation() -> None:
     assert "GitHub release readback verified" in release_text
 
 
+def test_release_package_sbom_scans_the_wheel_as_a_file() -> None:
+    release_text = (WORKFLOWS_DIR / "release.yml").read_text(encoding="utf-8")
+
+    assert "file: ${{ runner.temp }}/power-framework-package.whl" in release_text
+    assert "path: ${{ runner.temp }}/power-framework-package.whl" not in release_text
+
+
 def test_release_publish_is_blocked_by_a_tag_validation_job() -> None:
     release_text = (WORKFLOWS_DIR / "release.yml").read_text(encoding="utf-8")
 

--- a/tests/test_generation_index.py
+++ b/tests/test_generation_index.py
@@ -604,10 +604,14 @@ def test_state_transaction_setup_failure_keeps_previous_pointer_and_search(
 def test_chunk_identity_is_content_addressed_and_path_independent() -> None:
     first = _stable_chunk_id("source-hash-a", "Overview", "# Overview\nStable content")
     same = _stable_chunk_id("source-hash-a", "Overview", "# Overview\nStable content")
+    repeated = _stable_chunk_id(
+        "source-hash-a", "Overview", "# Overview\nStable content", ordinal=1
+    )
     changed_source = _stable_chunk_id("source-hash-b", "Overview", "# Overview\nStable content")
     changed_section = _stable_chunk_id("source-hash-a", "Details", "# Overview\nStable content")
 
     assert first == same
+    assert first != repeated
     assert first != changed_source
     assert first != changed_section
     assert "::chunk_" not in first

--- a/tests/test_generation_index.py
+++ b/tests/test_generation_index.py
@@ -52,6 +52,43 @@ def _active_db(vault: Path) -> Path:
     return active
 
 
+def test_snapshot_hash_matches_projection_for_prefix_colliding_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A directory and file sharing a prefix must publish one source revision."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    vault = tmp_path / "prefix-collision"
+    note_paths = (
+        vault / "01_Projects" / "Abazivka" / "nested.md",
+        vault / "01_Projects" / "Abazivka-logistics-hub.md",
+    )
+    for path in note_paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "---\n"
+            "type: Project\n"
+            f"title: {path.stem}\n"
+            "description: prefix collision regression\n"
+            "timestamp: 2026-08-28T00:00:00Z\n"
+            "---\n\nshared-prefix\n",
+            encoding="utf-8",
+        )
+
+    report = sync_vault_atomically(vault, sync_embeddings=False)
+
+    with closing(sqlite3.connect(_active_db(vault))) as conn:
+        projected_revision = conn.execute(
+            "SELECT meta_value FROM source_projection_meta WHERE meta_key = 'source_revision'"
+        ).fetchone()[0]
+        projected_paths = {row[0] for row in conn.execute("SELECT rel_path FROM source_metadata")}
+    assert report.source_snapshot_hash == projected_revision
+    assert projected_paths == {
+        "01_Projects/Abazivka/nested.md",
+        "01_Projects/Abazivka-logistics-hub.md",
+    }
+
+
 def test_vault_identity_and_database_namespace_are_stable_and_isolated(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_low_ram_sync.py
+++ b/tests/test_low_ram_sync.py
@@ -10,9 +10,11 @@ i5-5200U). After the fix, embeddings are produced in batches via
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from typing import TYPE_CHECKING
 
 from power_framework.core import index_sync, searcher
+from power_framework.core.constants import DENSE_INDEX_SCHEMA_VERSION
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -120,6 +122,94 @@ def test_sync_adaptive_batch_on_memory_error(monkeypatch, tmp_path):
     assert len(fake.batch_calls) >= 1
     # And critically: it never fell back to per-item embed().
     assert fake.embed_calls == 0
+
+
+def test_repeated_sections_get_distinct_chunk_ids(monkeypatch, tmp_path):
+    """Identical sections in one note must not overwrite each other's vectors."""
+    vault = tmp_path / "vault"
+    notes = vault / "03_Resources"
+    notes.mkdir(parents=True)
+    repeated_body = " ".join(["identical-section-token"] * 210)
+    (notes / "repeated.md").write_text(
+        "---\n"
+        "type: Resource\n"
+        "title: Repeated sections\n"
+        "description: duplicate section regression\n"
+        "timestamp: 2026-01-01T00:00:00Z\n"
+        "---\n\n"
+        f"## Repeated\n{repeated_body}\n\n"
+        f"## Repeated\n{repeated_body}\n",
+        encoding="utf-8",
+    )
+
+    fake = _FakeManager()
+    _patch_manager(monkeypatch, fake)
+    db = tmp_path / "power_search.db"
+    monkeypatch.setenv("POWER_SEARCH_DB", str(db))
+
+    with closing(sqlite3.connect(db)) as conn:
+        searcher._init_db(conn)
+        searcher._sync_vault_to_db(vault, conn, sync_embeddings=True)
+        rows = conn.execute("SELECT chunk_id, rel_path FROM chunk_embeddings").fetchall()
+
+    assert len(rows) == 2
+    assert len({row[0] for row in rows}) == 2
+
+
+def test_stale_dense_manifest_rebuilds_chunk_identity_schema(monkeypatch, tmp_path):
+    """Changing chunk identity rules must rebuild unchanged notes automatically."""
+    vault = tmp_path / "vault"
+    notes = vault / "03_Resources"
+    notes.mkdir(parents=True)
+    note = notes / "stable.md"
+    note.write_text(
+        "---\n"
+        "type: Resource\n"
+        "title: Stable note\n"
+        "description: stale manifest regression\n"
+        "timestamp: 2026-01-01T00:00:00Z\n"
+        "---\n\n"
+        "stable dense content\n",
+        encoding="utf-8",
+    )
+
+    fake = _FakeManager()
+    _patch_manager(monkeypatch, fake)
+    db = tmp_path / "power_search.db"
+    monkeypatch.setenv("POWER_SEARCH_DB", str(db))
+
+    with closing(sqlite3.connect(db)) as conn:
+        searcher._init_db(conn)
+        mtime = note.stat().st_mtime
+        conn.execute(
+            "INSERT INTO file_metadata(rel_path, mtime) VALUES (?, ?)",
+            ("03_Resources/stable.md", mtime),
+        )
+        conn.execute(
+            "INSERT INTO chunk_embeddings(chunk_id, rel_path, embedding, content, mtime) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("legacy-chunk-id", "03_Resources/stable.md", b"legacy", "legacy", mtime),
+        )
+        conn.executemany(
+            "INSERT INTO dense_index_manifest(manifest_key, manifest_value) VALUES (?, ?)",
+            [
+                ("schema_version", "2"),
+                ("embedding_dimension", "3"),
+                ("chunk_count", "1"),
+                ("embedding_provider", "_FakeManager"),
+                ("embedding_model", "unknown"),
+            ],
+        )
+        conn.commit()
+
+        searcher._sync_vault_to_db(vault, conn, sync_embeddings=True)
+        manifest = dict(
+            conn.execute("SELECT manifest_key, manifest_value FROM dense_index_manifest")
+        )
+        chunk_ids = {row[0] for row in conn.execute("SELECT chunk_id FROM chunk_embeddings")}
+
+    assert manifest["schema_version"] == DENSE_INDEX_SCHEMA_VERSION
+    assert "legacy-chunk-id" not in chunk_ids
 
 
 def test_sync_fts_only_skips_embedding(monkeypatch, tmp_path):

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from power_framework.core import index_sync, searcher
+from power_framework.core.constants import DENSE_INDEX_SCHEMA_VERSION
 from power_framework.core.db import _init_db
 from power_framework.core.generation_index import (
     ActiveGeneration,
@@ -586,7 +587,7 @@ class TestSearchModeContract:
             conn.executemany(
                 "INSERT INTO dense_index_manifest VALUES (?, ?)",
                 [
-                    ("schema_version", "2"),
+                    ("schema_version", DENSE_INDEX_SCHEMA_VERSION),
                     ("embedding_dimension", "4"),
                     ("chunk_count", "3"),
                     ("embedding_provider", "PinnedProvider"),
@@ -639,7 +640,7 @@ class TestSearchModeContract:
             conn.executemany(
                 "INSERT INTO dense_index_manifest VALUES (?, ?)",
                 [
-                    ("schema_version", "2"),
+                    ("schema_version", DENSE_INDEX_SCHEMA_VERSION),
                     ("embedding_dimension", "4"),
                     ("chunk_count", "1"),
                     ("embedding_provider", "PinnedProvider"),
@@ -1416,7 +1417,7 @@ class TestVectorSearch:
         )
         conn.executemany(
             "INSERT INTO dense_index_manifest(manifest_key, manifest_value) VALUES (?, ?)",
-            [("schema_version", "2"), ("chunk_count", "1")],
+            [("schema_version", DENSE_INDEX_SCHEMA_VERSION), ("chunk_count", "1")],
         )
         conn.commit()
 


### PR DESCRIPTION
## Summary

- Canonicalize source ordering before computing the generation snapshot hash, preventing promotion failures when a directory and a file share a name prefix.
- Pass the exact wheel to Anchore SBOM action through its `file` input instead of `path`.
- Salt dense chunk IDs with their ordinal so repeated identical sections cannot overwrite one another, and automatically rebuild stale dense manifests.
- Document pausing live-vault writers while `power sync` captures and verifies its source snapshot.
- Add regression and CI-policy tests and document all fixes.

## Validation

- `1186 passed, 4 skipped, 17 deselected` (full test suite excluding real neural/benchmark tests)
- Ruff check and format check passed
- Documentation drift check passed
- `mkdocs build --strict` passed

Fixes #360