### PR TITLE
ci: recover tag-bound release with GHCR credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing signed tag to publish"
+        required: true
+        type: string
 
 permissions: {}
 
@@ -23,7 +29,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -187,7 +193,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -226,7 +232,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
 
       - name: Download platform upgrade evidence
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -260,12 +266,12 @@ jobs:
       attestations: write
       artifact-metadata: write
     env:
-      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -362,7 +368,7 @@ jobs:
 
       - name: Authenticate to GHCR for the Web-only image
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.POWER_RELEASE_GHCR_TOKEN || github.token }}
         run: printf '%s' "$GH_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
 
       - name: Build and publish the Web-only image
@@ -566,7 +572,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
           body_path: ${{ steps.release_notes.outputs.path }}
           generate_release_notes: false
           files: |
@@ -594,7 +600,7 @@ jobs:
       - name: Upload release receipt
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
           files: dist/power-framework.release-receipt.json
 
       - name: Read back GitHub release metadata and assets

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -123,10 +123,13 @@ def test_release_publish_is_blocked_by_a_tag_validation_job() -> None:
     assert 'select(.key_id == "2D49E810C7F2527E")' in release_text
     assert "7AF1EDA195FE29FF093FB1CA2D49E810C7F2527E" in release_text
     assert 'gpg --batch --import "$key_file"' in release_text
-    assert "workflow_dispatch" not in release_text
-    assert "inputs.release_tag" not in release_text
+    assert "workflow_dispatch" in release_text
+    assert "inputs.release_tag" in release_text
     assert "permissions: {}" in release_text
-    assert "RELEASE_TAG: ${{ github.ref_name }}" in release_text
+    assert (
+        "RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}"
+        in release_text
+    )
     assert "--passed-mandatory profile-a-mcp-stdio" in release_text
     assert "--passed-mandatory web-semantic-acceptance" in release_text
     assert "--passed-mandatory web-rerank-acceptance" in release_text
@@ -189,7 +192,7 @@ def test_ci_uses_locked_dependencies_and_clean_package_smoke() -> None:
     assert "pip install build ." not in release_text
     assert "PYTHONPATH: src:." not in release_text
     assert "--system-site-packages" not in release_text
-    assert "POWER_RELEASE_GHCR_TOKEN" not in release_text
+    assert "GH_TOKEN: ${{ secrets.POWER_RELEASE_GHCR_TOKEN || github.token }}" in release_text
     assert "BUILD_DATE" not in release_text
     assert "SOURCE_DATE_EPOCH" in release_text
     assert "OCI_CREATED" in release_text


### PR DESCRIPTION
## Recovery for the signed v3.7.8 release

The first tag-bound run `33201588198` passed validation and upgrade-matrix, then stopped at GHCR with `permission_denied: write_package` because the existing private user-owned package does not grant the repository `GITHUB_TOKEN` write access.

This PR:

- keeps the existing signed tag immutable;
- adds an explicit `workflow_dispatch` recovery input for an existing signed tag;
- checks out that exact tag in every job and keeps all release/readback bindings tag-bound;
- accepts the repository secret `POWER_RELEASE_GHCR_TOKEN` for GHCR, falling back to `GITHUB_TOKEN` when package Actions access is configured.

After merge, the exact `v3.7.8` tag will be dispatched again and all release evidence will be read back.