### PR TITLE
ci: repair tag release profile acceptance harness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,6 +421,19 @@ jobs:
           print("locked model snapshots prefetched")
           PY
 
+      - name: Checkout current acceptance harness for tag recovery
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+          path: .release-acceptance-harness
+          sparse-checkout: |
+            scripts/profile_acceptance.py
+            tests/__init__.py
+            tests/mcp_test_client.py
+          sparse-checkout-cone-mode: false
+
       - name: Prove Profile A/B against the exact Web image
         id: profile_acceptance
         env:
@@ -433,9 +446,10 @@ jobs:
           POWER_RERANKER_DEVICE: cpu
           WEB_IMAGE_REF: ${{ steps.web_image.outputs.reference }}
           WEB_IMAGE_DIGEST: ${{ steps.web_image.outputs.digest }}
+          ACCEPTANCE_HARNESS_ROOT: ${{ github.event_name == 'workflow_dispatch' && '.release-acceptance-harness' || '.' }}
         run: |
           image_ref="${WEB_IMAGE_REF%@*}@${WEB_IMAGE_DIGEST}"
-          uv run python scripts/profile_acceptance.py \
+          uv run python "$ACCEPTANCE_HARNESS_ROOT/scripts/profile_acceptance.py" \
             --image "$image_ref" \
             --image-digest "$WEB_IMAGE_DIGEST" \
             --model-cache "$HF_HOME" \

--- a/scripts/profile_acceptance.py
+++ b/scripts/profile_acceptance.py
@@ -266,6 +266,26 @@ def stop_container(container: str) -> None:
     )
 
 
+def prepare_vault_for_container(vault: Path) -> None:
+    """Share the disposable bind mount with the container and host runner.
+
+    The Web proof runs as UID 10001 and then reads the canonical vault from
+    the host to verify the governed mutation.  The vault is disposable and
+    isolated, so its entries must remain traversable, readable, and removable
+    by both identities after ownership changes.
+    """
+    try:
+        run(["sudo", "chown", "-R", "10001:10001", str(vault)])
+        run(["sudo", "chmod", "-R", "a+rwX", str(vault)])
+    except FileNotFoundError:
+        for path in [vault, *sorted(vault.rglob("*"))]:
+            if not path.exists():
+                continue
+            os.chown(path, 10001, 10001)
+            mode = path.stat().st_mode
+            os.chmod(path, mode | (0o777 if path.is_dir() else 0o666))
+
+
 def inspect_container(container: str) -> tuple[str, list[str], bool, str]:
     """Return user, dropped capabilities, read-only flag, and PID command line."""
     payload = json.loads(run(["docker", "inspect", container]))[0]
@@ -344,12 +364,7 @@ def main() -> int:
                 env={**host_environment, "POWER_VAULT_DIR": str(vault)},
             )
             asyncio.run(mcp_acceptance(mcp, vault, host_environment))
-            try:
-                run(["sudo", "chown", "-R", "10001:10001", str(vault)])
-            except FileNotFoundError:
-                for path in [vault, *sorted(vault.rglob("*"))]:
-                    if path.exists():
-                        os.chown(path, 10001, 10001)
+            prepare_vault_for_container(vault)
 
             stop_container(container)
             subprocess.run(  # noqa: S603 -- fixed Docker executable and generated volume name.

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -84,6 +84,8 @@ def test_release_workflow_publishes_sbom_and_attestation() -> None:
     assert "subject-digest:" in release_text
     assert "scripts/profile_acceptance.py" in release_text
     assert "Prefetch locked model snapshots for real Web acceptance" in release_text
+    assert "Checkout current acceptance harness for tag recovery" in release_text
+    assert "ACCEPTANCE_HARNESS_ROOT" in release_text
     assert "--profile-evidence" in release_text
     assert "attestations: write" in release_text
     assert "id-token: write" in release_text

--- a/tests/test_profile_acceptance.py
+++ b/tests/test_profile_acceptance.py
@@ -1,0 +1,55 @@
+"""Unit coverage for the disposable Web acceptance fixture."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from scripts import profile_acceptance
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_prepare_vault_uses_privileged_shared_mount_permissions(
+    tmp_path: Path, monkeypatch
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    note = vault / "note.md"
+    note.write_text("fixture\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, env: dict[str, str] | None = None) -> str:
+        del env
+        calls.append(command)
+        return ""
+
+    monkeypatch.setattr(profile_acceptance, "run", fake_run)
+
+    profile_acceptance.prepare_vault_for_container(vault)
+
+    assert calls == [
+        ["sudo", "chown", "-R", "10001:10001", str(vault)],
+        ["sudo", "chmod", "-R", "a+rwX", str(vault)],
+    ]
+
+
+def test_prepare_vault_fallback_keeps_host_access(monkeypatch, tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir(mode=0o700)
+    note = vault / "note.md"
+    note.write_text("fixture\n", encoding="utf-8")
+    note.chmod(0o600)
+
+    def missing_sudo(command: list[str], *, env: dict[str, str] | None = None) -> str:
+        del command, env
+        raise FileNotFoundError("sudo")
+
+    monkeypatch.setattr(profile_acceptance, "run", missing_sudo)
+    monkeypatch.setattr(profile_acceptance.os, "chown", lambda *_args: None)
+
+    profile_acceptance.prepare_vault_for_container(vault)
+
+    assert os.stat(vault).st_mode & 0o777 == 0o777
+    assert os.stat(note).st_mode & 0o777 == 0o666


### PR DESCRIPTION
Fixes the failed v3.7.8 recovery release gate. The disposable bind-mounted vault remains accessible to both UID 10001 and the host runner after chown, and controlled workflow_dispatch recovery runs the current acceptance harness while keeping package/image inputs pinned to the requested signed tag. Adds regression coverage.