### PR TITLE
ci: clean recovery harness before release baseline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,6 +456,14 @@ jobs:
             --version "${RELEASE_TAG#v}" \
             --output "$RUNNER_TEMP/power-profile-acceptance.json"
 
+      - name: Remove tag recovery harness checkout
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          test -d .release-acceptance-harness
+          rm -rf -- .release-acceptance-harness
+          test ! -e .release-acceptance-harness
+
       - name: Generate Web SPDX SBOM bound to the exact image
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -86,6 +86,8 @@ def test_release_workflow_publishes_sbom_and_attestation() -> None:
     assert "Prefetch locked model snapshots for real Web acceptance" in release_text
     assert "Checkout current acceptance harness for tag recovery" in release_text
     assert "ACCEPTANCE_HARNESS_ROOT" in release_text
+    assert "Remove tag recovery harness checkout" in release_text
+    assert "rm -rf -- .release-acceptance-harness" in release_text
     assert "--profile-evidence" in release_text
     assert "attestations: write" in release_text
     assert "id-token: write" in release_text


### PR DESCRIPTION
Fixes the next real failure in the v3.7.8 recovery run: the temporary sparse acceptance checkout made the tag worktree dirty, so the tag-bound baseline correctly failed closed. Remove only the disposable recovery checkout before baseline generation and assert the policy contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated manually triggered release workflows to remove temporary recovery-harness files after acceptance checks.
* **Tests**
  * Added validation to ensure the temporary harness cleanup step remains present in the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->