### PR TITLE
fix: normalize release attestation readback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -709,7 +709,10 @@ jobs:
 
           receipt = json.loads((root / "power-framework.release-receipt.json").read_text())
           assert receipt["release"]["tag"] == tag
-          assert receipt["attestations"] == manifest["attestations"]
+          manifest_attestations = [
+              item.removeprefix("github:") for item in manifest["attestations"]
+          ]
+          assert receipt["attestations"] == manifest_attestations
           print("public artifact and manifest readback verified")
           PY
           registry_digest="$(docker buildx imagetools inspect "$WEB_IMAGE_REF" | python3 -c 'import sys; print(next(line.split()[1] for line in sys.stdin if line.startswith("Digest:")))')"

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -94,6 +94,7 @@ def test_release_workflow_publishes_sbom_and_attestation() -> None:
     assert "artifact-metadata: write" in release_text
     assert "gh release view" in release_text
     assert "GitHub release readback verified" in release_text
+    assert 'item.removeprefix("github:") for item in manifest["attestations"]' in release_text
 
 
 def test_release_package_sbom_scans_the_wheel_as_a_file() -> None:


### PR DESCRIPTION
## Summary
- normalize `github:<id>` manifest attestations to the bare IDs emitted in the release receipt
- add a CI policy regression assertion

## Verification
- `uv run pytest --no-cov tests/test_ci_policy.py tests/test_release_receipt.py -q`
- `uv run ruff check src/ tests/ scripts/ benchmarks/power35/`
- `uv run ruff format --check src/ tests/ scripts/ benchmarks/power35/`

This unblocks the final public release readback for the existing immutable tag `v3.7.8`.