### PR TITLE
fix: align v3.7.8 docs and SSE contract

### DIFF
--- a/docs/api/reranker.md
+++ b/docs/api/reranker.md
@@ -1,16 +1,56 @@
 # Reranker
 
-## `RerankerManager`
+Cross-encoder reranking modules and backend factory.
 
-Cross-Encoder reranker. The local Jina model
-**`jinaai/jina-reranker-v2-base-multilingual`** is CC-BY-NC-4.0 and is not a
-production default. It is loaded only when
-`POWER_ALLOW_NONCOMMERCIAL_MODELS=1` is set for permitted non-commercial use.
-Otherwise configure a licensed reranker; the code fails before downloading the
-NC model.
+| Function / Class | Returns | Description |
+| --- | --- | --- |
+| `get_reranker()` | `RerankerProtocol` | Factory function returning the canonical `BGEM3Reranker` (or configured opt-in backend) |
+| `BGEM3Reranker` | `BGEM3Reranker` | Canonical default reranker: `BAAI/bge-reranker-v2-m3` via ONNX Runtime (MIT/Apache compatible) |
+| `RerankerManager` | `RerankerManager` | Legacy/opt-in non-commercial adapter for `jinaai/jina-reranker-v2-base-multilingual` (CC-BY-NC-4.0) |
+| `LexicalReranker` | `LexicalReranker` | Fallback lexical/token-overlap reranker without neural model downloads |
 
-`POWER_EMBED_PROVIDER=qwen3` selects `Qwen3-Reranker-0.6B-ONNX`; its license
-and revision still require an independent release-policy decision.
+## `get_reranker()`
+
+Factory function returning the active reranker backend implementing `RerankerProtocol`.
+
+```python
+get_reranker() -> RerankerProtocol
+```
+
+Returns the canonical `BGEM3Reranker` by default. When `POWER_RERANKER=colbert` is configured and available, returns `ColBERTLateInteractionReranker`. When `POWER_RERANKER=jina` is set and permitted, returns `RerankerManager`.
+
+## `BGEM3Reranker`
+
+Canonical cross-encoder reranker using `onnx-community/bge-reranker-v2-m3-ONNX` (pinned revision `6f5ff65298512715a1e669753bc754d2bc8f367b`). Fully license-clean (MIT/Apache compatible) with cross-lingual UA↔EN support, running on ONNX Runtime and `tokenizers` without requiring PyTorch.
+
+### Constructor
+
+```python
+BGEM3Reranker(
+    repo: str = "onnx-community/bge-reranker-v2-m3-ONNX",
+    revision: str = "6f5ff65298512715a1e669753bc754d2bc8f367b",
+)
+```
+
+- `repo`: Hugging Face repository ID for the exported ONNX model.
+- `revision`: Git commit hash or revision for the pinned model assets.
+
+### Methods
+
+#### `rerank(query: str, documents: list[str]) -> list[float]`
+
+Predict relevance scores for document strings against a query in bounded batches (`POWER_RERANKER_BATCH_SIZE`, default 8).
+
+- **Parameters**:
+    - `query` (str): Search query.
+    - `documents` (list[str]): Candidate document texts to evaluate.
+- **Returns**: A list of floats representing normalized relevance scores (probabilities in `[0.0, 1.0]`) for each document.
+
+## `RerankerManager` (Legacy / Opt-in Non-Commercial Adapter)
+
+Cross-encoder adapter for `jinaai/jina-reranker-v2-base-multilingual` or Qwen3 reranker. The Jina model is CC-BY-NC-4.0 and is **not** a production default.
+
+It is loaded only when **both** `POWER_RERANKER=jina` and `POWER_ALLOW_NONCOMMERCIAL_MODELS=1` are explicitly set for permitted non-commercial use. Otherwise, lazy model initialization on the first `rerank()` call raises `NonCommercialModelDisabledError`.
 
 ### Constructor
 
@@ -18,15 +58,14 @@ and revision still require an independent release-policy decision.
 RerankerManager(model_name: str = "jinaai/jina-reranker-v2-base-multilingual")
 ```
 
-- `model_name`: the cross-encoder to load when the license policy permits it.
+- `model_name`: Cross-encoder model name to load when the license policy permits it.
 
 ### Methods
 
 #### `rerank(query: str, documents: list[str]) -> list[float]`
 
-Predict relevance scores for a list of document strings against a query.
+Predict relevance scores for document strings against a query.
 
-- **Parameters**:
-    - `query` (str): The search query.
-    - `documents` (list of strings): The documents to evaluate.
-- **Returns**: A list of floats representing the predicted relevance score for each document (higher score means more relevant).
+## `LexicalReranker`
+
+License-clean (MIT) fallback reranker with no neural model download. Ranks documents by token overlap and length prior.

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -17,7 +17,7 @@ Utility functions for path safety, file I/O, and security.
 
 | Name                    | Source Module  | Value / Description                                         |
 | ----------------------- | -------------- | ----------------------------------------------------------- |
-| `__version__`           | `utils.py`     | `"2.0.3"`                                                   |
+| `__version__`           | `utils.py`     | `"3.7.8"`                                                   |
 | `EXCLUDED_DIRS`         | `constants.py` | `frozenset` of directory names excluded from scanning       |
 | `EXCLUDED_ORPHAN_FILES` | `constants.py` | `frozenset` of filenames excluded from orphan checks        |
 | `PARA_FOLDERS`          | `models.py`    | `tuple` of standard P.A.R.A. category folder names          |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -420,6 +420,30 @@ only way to see what a prune would target before running it.
 ### `doctor`
 
 Run a read-only diagnostic pass for the runtime and, optionally, one vault.
+The command does not create a vault identity, cache namespace, search database,
+or model files. The embedding probe uses only an already-cached pinned model;
+otherwise the report says that binding is not verified and recommends running
+`power sync` separately.
+
+```text
+power doctor [PATH] [--json] [--probe-provider]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--json` | Emit the versioned machine-readable report to stdout. |
+| `--probe-provider` | Explicitly probe the configured provider without downloading a model. |
+
+The report distinguishes compiled ONNX providers from the provider bound by a
+real embedding session. With `--json`, stdout contains the versioned report
+contract [`doctor-report-v1.json`](schemas/doctor-report-v1.json), including the
+complete `excluded_notes` ledger and stable issue codes for agents and CI.
+Human-readable output is a summary of the same report.
+
+Exit `0` means the requested diagnostics are healthy. Exit `1` means the
+runtime, binding, vault, index, or coverage state is unavailable or degraded;
+an uncached model and excluded notes are therefore visible failures, not silent
+successes. Use `power sync PATH --strict` as the repair gate.
 
 ### `control-plane`
 
@@ -451,25 +475,14 @@ power migrate-state PATH
 
 Print a deterministic, hash-bound maintenance plan. Add `--apply` to apply only
 reversible `safe_auto` actions; retention and archive candidates remain plan-only.
-The command does not create a vault identity, cache namespace, search database,
-or model files. The embedding probe uses only an already-cached pinned model;
-otherwise the report says that binding is not verified and recommends running
-`power sync` separately.
 
 ```text
-power doctor [PATH] [--json]
+power maintenance PATH [--apply]
 ```
 
-The report distinguishes compiled ONNX providers from the provider bound by a
-real embedding session. With `--json`, stdout contains the versioned report
-contract [`doctor-report-v1.json`](schemas/doctor-report-v1.json), including the
-complete `excluded_notes` ledger and stable issue codes for agents and CI.
-Human-readable output is a summary of the same report.
-
-Exit `0` means the requested diagnostics are healthy. Exit `1` means the
-runtime, binding, vault, index, or coverage state is unavailable or degraded;
-an uncached model and excluded notes are therefore visible failures, not silent
-successes. Use `power sync PATH --strict` as the repair gate.
+| Flag | Description |
+| --- | --- |
+| `--apply` | Apply `safe_auto` actions with explicit approval. Retention and archive candidates remain plan-only. |
 
 ### `connect`
 

--- a/docs/documentation-inventory.ua.md
+++ b/docs/documentation-inventory.ua.md
@@ -49,7 +49,7 @@
 - Старий MCP-інвентар замінено на фактичні `20` інструментів; CLI
   задокументовано як `26` top-level команд.
 - До surface додано `power integrations` для unified native, Skill і launcher plans.
-- `reranked` більше не називається стандартним режимом: код використовує `semantic`,
+- `reranked` більше не називається стандартним режимом: код використовує `auto`,
   а reranking вмикається явно.
 - Видалено небезпечне оновлення через destructive reset, непереносний `/tmp`,
   `%USERPROFILE%` у PowerShell і запуск MCP через глобальний `py` замість точного

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -77,7 +77,7 @@ This guide is verified against the `v3.7.8` release contract. CI checks these
 facts against the executable capability manifest so an agent does not inherit
 an older migration recipe:
 
-- the current surface is 25 top-level CLI commands and 20 MCP tools;
+- the current surface is 26 top-level CLI commands and 20 MCP tools;
 - the default search mode is `auto`; it uses verified dense when ready and
   otherwise labelled FTS; `semantic` and `reranked` are explicit opt-ins;
 - database and cache paths are runtime-owned. Use `power doctor DESTINATION

--- a/docs/migration-guide.ua.md
+++ b/docs/migration-guide.ua.md
@@ -77,7 +77,7 @@ rollback path.
 executable capability manifest, щоб агент не успадковував старий migration
 recipe:
 
-- поточна surface — 25 top-level CLI commands і 20 MCP tools;
+- поточна surface — 26 top-level CLI commands і 20 MCP tools;
 - режим пошуку за замовчуванням — `auto`; він використовує verified dense лише
   коли runtime готовий, інакше повертає labelled FTS; `semantic` та `reranked` є
   explicit opt-in;

--- a/docs/windows-11-installation.md
+++ b/docs/windows-11-installation.md
@@ -16,7 +16,7 @@ PowerShell syntax throughout.
 
 ## Support and evidence boundary
 
-- P.O.W.E.R. requires Python 3.11 or newer.
+- P.O.W.E.R. requires Python 3.13 or 3.14.
 - Windows 11 25H2 is an official Windows 11 release (OS build family `26200`).
 - ONNX Runtime supports Windows 11, and its Windows builds require the current
   Microsoft Visual C++ runtime.
@@ -281,7 +281,7 @@ runtime. Back it up before deleting either directory.
 ## Acceptance checklist
 
 - Windows reports version 25H2 / build family `26200`.
-- The selected Python is 3.11 or newer and the venv check prints `True`.
+- The selected Python is 3.13 or 3.14 and the venv check prints `True`.
 - `power --version` and distribution metadata both report `3.7.8`.
 - `power_framework` imports successfully and the official agent-server install
   includes the `[mcp]` extra.

--- a/docs/windows-11-installation.ua.md
+++ b/docs/windows-11-installation.ua.md
@@ -16,7 +16,7 @@
 
 ## Межа підтримки та доказів
 
-- P.O.W.E.R. потребує Python 3.11 або новішого.
+- P.O.W.E.R. потребує Python 3.13 або 3.14.
 - Windows 11 25H2 є офіційним релізом Windows 11 (сімейство OS build `26200`).
 - ONNX Runtime підтримує Windows 11, а його Windows-збірки потребують
   актуального Microsoft Visual C++ Runtime.
@@ -284,7 +284,7 @@ runtime. Зробіть backup перед видаленням будь-яког
 ## Acceptance checklist
 
 - Windows повідомляє version 25H2 / build family `26200`.
-- Обраний Python має версію 3.11+; venv-перевірка повертає `True`.
+- Обраний Python має версію 3.13 або 3.14; venv-перевірка повертає `True`.
 - `power --version` і distribution metadata повертають `3.7.8`.
 - `power_framework` імпортується, а офіційний agent-server install містить extra
   `[mcp]`.

--- a/tests/web/contract/test_read_only_and_e2e.py
+++ b/tests/web/contract/test_read_only_and_e2e.py
@@ -262,7 +262,7 @@ def test_task_completion_evidence_creates_canonical_tcr_receipt(hermetic_vault: 
 
 
 def test_task_sse_resume_cursor_starts_after_requested_sequence(
-    hermetic_vault: Path,
+    hermetic_vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """SSE resumes from the caller cursor instead of replaying the full journal."""
     svc = ApplicationService(hermetic_vault)
@@ -277,6 +277,15 @@ def test_task_sse_resume_cursor_starts_after_requested_sequence(
         expected_revision=1,
         context=RequestContext(actor="seed", authority="apply"),
     )
+
+    async def _run_power_call(request, settings, function, *args, **kwargs):
+        del request, settings
+        kwargs.pop("timeout_seconds", None)
+        return function(*args, **kwargs)
+
+    from power_framework.web.routes import tasks as task_routes
+
+    monkeypatch.setattr(task_routes, "run_power_call", _run_power_call)
 
     settings = Settings(
         vault_path=hermetic_vault,


### PR DESCRIPTION
## Summary
- Align v3.7.8 public documentation with the executable CLI/MCP/runtime contracts.
- Fix the hermetic SSE resume contract test by replacing the timing-sensitive offload boundary with a local test double.
- Apply the AGY Gemini 3.7 Flash (High) read-only documentation audit findings plus a lazy-license-init wording correction.

## Validation
- `scripts/check_doc_drift.py` — passed.
- `mkdocs build --strict` — built successfully; only existing nav/deprecation warnings.
- `pytest tests/ -q` — 1195 passed, 14 skipped, coverage 81.19%.
- `ruff check`, `ruff format --check`, `mypy` — passed.
- Workspace `./verify.sh` — passed.

No production source code was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated reranker guidance, including the default backend, fallback behavior, and requirements for optional non-commercial adapters.
  - Expanded CLI documentation for provider probing, read-only diagnostics, JSON reports, and maintenance actions.
  - Corrected version, command-count, and MCP tool-count references.
  - Updated Windows 11 installation guidance to require Python 3.13 or 3.14.
  - Clarified standard operating mode and explicit reranking in Ukrainian documentation.

- **Tests**
  - Improved end-to-end coverage for resuming server-sent event streams under short test lifetimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->