### PR TITLE
feat: add PRXMX POWER runtime audit

### DIFF
--- a/scripts/prxmx_power_runtime_audit.py
+++ b/scripts/prxmx_power_runtime_audit.py
@@ -1,0 +1,2418 @@
+#!/usr/bin/env python3
+"""Host-side P.O.W.E.R runtime version audit and update CLI.
+
+Audits and updates P.O.W.E.R runtime virtual environments, MCP client configurations,
+and Skill targets against the latest or specified public release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import dataclasses
+import fcntl
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import tomllib
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# System Python paths that must NEVER be mutated or treated as project venvs
+SYSTEM_PREFIXES = (
+    "/",
+    "/var",
+    "/run",
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib64",
+    "/opt/local",
+    "/etc",
+    "/sys",
+    "/proc",
+    "/dev",
+)
+
+DEFAULT_REPO = "weby-homelab/power-framework"
+DEFAULT_REF = "latest"
+DEFAULT_VAULT = Path("/root/geminicli/brain")
+DEFAULT_STATE_DIR = Path.home() / ".local" / "share" / "power" / "audit"
+
+DEFAULT_VENV_ROOTS = [
+    "/root/.config/opencode",
+    "/root/.local/share/power",
+    "/root/geminicli/projects",
+]
+
+DEFAULT_SKILL_TARGETS = [
+    "/root/geminicli/.agents/skills/power",
+    "/root/.opencode/skills/power",
+    "/root/.config/opencode/skills/power",
+    "/root/.gemini/config/skills/power",
+    "/root/.codex/skills/power",
+]
+
+ALLOWED_SKILL_TARGET_ROOTS = [
+    Path("/root/geminicli/.agents/skills"),
+    Path("/root/.opencode/skills"),
+    Path("/root/.config/opencode/skills"),
+    Path("/root/.gemini/config/skills"),
+    Path("/root/.gemini/skills"),
+    Path("/root/.codex/skills"),
+    Path("/root/.local/share/power/skills"),
+    Path.home() / ".agents" / "skills",
+    Path.home() / ".opencode" / "skills",
+    Path.home() / ".config" / "opencode" / "skills",
+    Path.home() / ".gemini" / "config" / "skills",
+    Path.home() / ".gemini" / "skills",
+    Path.home() / ".codex" / "skills",
+    Path.home() / ".local" / "share" / "power" / "skills",
+]
+
+DEFAULT_MCP_CONFIGS = [
+    "/root/.config/opencode/opencode.jsonc",
+    "/root/.gemini/config/mcp_config.json",
+    "/root/.codex/config.toml",
+    "/root/.codex/mcp.json",
+]
+
+ALLOWED_SKILL_TOP_LEVEL_FILES = frozenset({"SKILL.md", "README.md"})
+ALLOWED_SKILL_DIRECTORIES = frozenset({"references", "scripts", "templates", "assets"})
+ALLOWED_SKILL_EXTENSIONS = frozenset(
+    {
+        ".md",
+        ".txt",
+        ".json",
+        ".jsonc",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".py",
+        ".sh",
+        ".bash",
+        ".svg",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".template",
+        ".jinja",
+        ".j2",
+        ".csv",
+    }
+)
+
+_SECRET_PATTERNS = [
+    re.compile(r"(?i)(password|secret|token|apikey|api_key|auth|bearer)\s*[:=]\s*([^\s,;]+)"),
+    re.compile(r"ghp_[a-zA-Z0-9]{36}"),
+    re.compile(r"github_pat_[a-zA-Z0-9_]{82}"),
+]
+
+
+def redact_secrets(text: str) -> str:
+    """Sanitize error messages and logs to prevent secret leakage."""
+    if not text:
+        return text
+    sanitized = text
+    for pat in _SECRET_PATTERNS:
+        sanitized = pat.sub("[REDACTED]", sanitized)
+    return sanitized
+
+
+def is_safe_skill_relative_path(relative: str) -> bool:
+    """Validate relative skill path against allowlist and safety rules."""
+    if not relative or relative.startswith(("/", "\\")):
+        return False
+    rel_p = Path(relative)
+    if rel_p.is_absolute() or ".." in rel_p.parts:
+        return False
+
+    for part in rel_p.parts:
+        if part.startswith(".") or part == "__pycache__":
+            return False
+        if ":" in part or "\0" in part:
+            return False
+
+    parts = rel_p.parts
+    if len(parts) == 1:
+        return parts[0] in ALLOWED_SKILL_TOP_LEVEL_FILES
+
+    top_dir = parts[0]
+    if top_dir not in ALLOWED_SKILL_DIRECTORIES:
+        return False
+
+    suffix = rel_p.suffix.lower()
+    return suffix in ALLOWED_SKILL_EXTENSIONS
+
+
+class ReleaseValidationError(ValueError):
+    """Raised when release payload or artifacts violate integrity contracts."""
+
+
+class ProcessLock:
+    """Acquires a non-blocking exclusive file lock to prevent concurrent runs."""
+
+    def __init__(self, lock_path: Path) -> None:
+        self.lock_path = lock_path
+        self._fd: int | None = None
+
+    def __enter__(self) -> ProcessLock:
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._fd = os.open(self.lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (BlockingIOError, OSError) as exc:
+            os.close(self._fd)
+            self._fd = None
+            raise RuntimeError("Another audit/update process is currently running") from exc
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        if self._fd is not None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+            os.close(self._fd)
+            self._fd = None
+
+
+@dataclass(frozen=True)
+class ReleasePayload:
+    """Validated immutable release contract and artifacts."""
+
+    tag: str
+    version: str
+    pyproject_version: str
+    commit: str | None = None
+    wheel_filename: str | None = None
+    wheel_sha256: str | None = None
+    wheel_path: Path | None = None
+    wheel_url: str | None = None
+    skill_tree_sha256: str | None = None
+    skill_files: dict[str, bytes] = field(default_factory=dict)
+    manifest: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "tag": self.tag,
+            "version": self.version,
+            "pyproject_version": self.pyproject_version,
+            "commit": self.commit,
+            "wheel_filename": self.wheel_filename,
+            "wheel_sha256": self.wheel_sha256,
+            "wheel_path": str(self.wheel_path) if self.wheel_path else None,
+            "wheel_url": self.wheel_url,
+            "skill_tree_sha256": self.skill_tree_sha256,
+            "skill_files_count": len(self.skill_files),
+        }
+
+
+@dataclass
+class VenvAuditResult:
+    """Audit result for a single bounded virtual environment."""
+
+    path: str
+    python_path: str
+    installed_version: str | None
+    is_writable: bool
+    status: str  # "up_to_date", "outdated", "not_installed", "newer", "unwritable", "broken_venv"
+    action_taken: str | None = None
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class MCPAuditResult:
+    """Audit result for an MCP client configuration."""
+
+    client: str
+    config_path: str
+    config_format: str  # "json", "jsonc", "toml"
+    status: str  # "canonical", "outdated", "missing_runtime", "mismatch", "missing_entry", "manual_review", "missing_file"
+    entry_present: bool = False
+    executable: str | None = None
+    resolved_executable: str | None = None
+    runtime_python: str | None = None
+    installed_version: str | None = None
+    env_keys: list[str] = field(default_factory=list)  # NEVER store secret values
+    has_comments: bool = False
+    action_taken: str | None = None
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class SkillAuditResult:
+    """Audit result for a managed Skill target."""
+
+    target_path: str
+    installed_version: str | None
+    tree_sha256: str | None
+    status: str  # "up_to_date", "upgrade_ready", "ready", "manual_review", "missing"
+    file_count: int = 0
+    action_taken: str | None = None
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class AuditReport:
+    """Complete host-side runtime audit report."""
+
+    timestamp: str
+    release: dict[str, Any]
+    venvs: list[VenvAuditResult]
+    mcp_configs: list[MCPAuditResult]
+    skills: list[SkillAuditResult]
+    applied: bool
+    recorded: bool
+    has_drift: bool
+    errors: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "release": self.release,
+            "has_drift": self.has_drift,
+            "applied": self.applied,
+            "recorded": self.recorded,
+            "errors": self.errors,
+            "venvs": [v.as_dict() for v in self.venvs],
+            "mcp_configs": [m.as_dict() for m in self.mcp_configs],
+            "skills": [s.as_dict() for s in self.skills],
+        }
+
+
+# ============================================================================
+# Version Parsing and Lexical Tree Hashing
+# ============================================================================
+
+_VERSION_RE = re.compile(
+    r"""
+    ^\s*[vV]?
+    (?P<release>\d+(?:\.\d+)*)
+    (?:
+        (?:[-._]?)(?P<pre_type>a|alpha|b|beta|rc|c|pre|preview|dev)(?:[-._]?(?P<pre_num>\d+))?
+    )?
+    (?:
+        (?:[-._]?)(?P<post_type>post|r|rev)(?:[-._]?(?P<post_num>\d+))?
+    )?
+    (?:\+[a-zA-Z0-9._-]+)?
+    \s*$
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+PRE_MAP = {
+    "dev": -4,
+    "a": -3,
+    "alpha": -3,
+    "b": -2,
+    "beta": -2,
+    "c": -1,
+    "rc": -1,
+    "pre": -1,
+    "preview": -1,
+}
+
+
+def parse_version(version_str: str) -> tuple[tuple[int, ...], int, int, int]:
+    """Parse a semantic or PEP 440 version string into a comparable tuple.
+
+    Returns ((major, minor, patch, ...), pre_phase, pre_num, post_num)
+    where pre_phase is:
+      -4: dev
+      -3: alpha (a)
+      -2: beta (b)
+      -1: rc / c / pre / preview
+       0: stable
+       1: post / r / rev
+    """
+    m = _VERSION_RE.match(version_str.strip())
+    if not m:
+        nums = re.findall(r"\d+", version_str)
+        if nums:
+            return (tuple(int(n) for n in nums), 0, 0, 0)
+        return ((0,), 0, 0, 0)
+
+    release_str = m.group("release")
+    release_tuple = tuple(int(n) for n in release_str.split("."))
+
+    pre_type = m.group("pre_type")
+    post_type = m.group("post_type")
+
+    pre_phase = 0
+    pre_num = 0
+    post_num = 0
+
+    if pre_type:
+        pre_phase = PRE_MAP.get(pre_type.lower(), -1)
+        pre_num = int(m.group("pre_num") or 0)
+
+    if post_type:
+        pre_phase = 1
+        post_num = int(m.group("post_num") or 0)
+
+    return (release_tuple, pre_phase, pre_num, post_num)
+
+
+def compare_versions(v1: str, v2: str) -> int:
+    """Compare two version strings. Returns -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2."""
+    base1, phase1, pre1, post1 = parse_version(v1)
+    base2, phase2, pre2, post2 = parse_version(v2)
+    max_len = max(len(base1), len(base2))
+    base1_padded = base1 + (0,) * (max_len - len(base1))
+    base2_padded = base2 + (0,) * (max_len - len(base2))
+
+    k1 = (base1_padded, phase1, pre1, post1)
+    k2 = (base2_padded, phase2, pre2, post2)
+    if k1 < k2:
+        return -1
+    if k1 > k2:
+        return 1
+    return 0
+
+
+def aggregate_tree_hash(files: dict[str, bytes]) -> str:
+    """Hash paths and bytes in deterministic lexical order matching POWER contract."""
+    digest = hashlib.sha256()
+    for relative in sorted(files):
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(files[relative]).digest())
+    return digest.hexdigest()
+
+
+def tree_from_directory(root: Path) -> dict[str, bytes]:
+    """Read a target directory using relative POSIX paths without bytecode/symlinks."""
+    if not root.is_dir() or root.is_symlink():
+        return {}
+    files: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*")):
+        if (
+            path.is_file()
+            and not path.is_symlink()
+            and "__pycache__" not in path.parts
+            and path.suffix != ".pyc"
+        ):
+            try:
+                rel = path.relative_to(root).as_posix()
+                if is_safe_skill_relative_path(rel):
+                    files[rel] = path.read_bytes()
+            except (OSError, ValueError):
+                continue
+    return files
+
+
+def sha256_file(path: Path) -> str:
+    """Compute SHA-256 digest of a regular file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+# ============================================================================
+# Release Payload Fetching and Validation
+# ============================================================================
+
+
+def _extract_wheel_skill_tree(wheel_path: Path) -> dict[str, bytes]:
+    """Extract packaged skill tree from a unified wheel with allowlist & traversal protection."""
+    prefix = "power_framework/data/skills/power/"
+    files: dict[str, bytes] = {}
+    with zipfile.ZipFile(wheel_path) as archive:
+        for name in archive.namelist():
+            if not name.startswith(prefix) or name.endswith("/"):
+                continue
+            relative = name[len(prefix) :]
+            if not relative or "__pycache__" in relative or relative.endswith(".pyc"):
+                continue
+            if not is_safe_skill_relative_path(relative):
+                raise ReleaseValidationError(f"Unsafe or disallowed path in wheel archive: {name}")
+            files[relative] = archive.read(name)
+    return files
+
+
+def _read_pyproject_version_from_text(content: str) -> str:
+    """Extract project.version from pyproject.toml text using tomllib."""
+    try:
+        data = tomllib.loads(content)
+    except Exception as exc:
+        raise ReleaseValidationError(f"Invalid pyproject.toml TOML: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ReleaseValidationError("pyproject.toml root is not a table")
+
+    project = data.get("project")
+    if isinstance(project, dict) and "version" in project:
+        ver = str(project["version"]).strip()
+        if ver:
+            return ver
+
+    tool = data.get("tool", {})
+    if isinstance(tool, dict):
+        poetry = tool.get("poetry", {})
+        if isinstance(poetry, dict) and "version" in poetry:
+            ver = str(poetry["version"]).strip()
+            if ver:
+                return ver
+
+    raise ReleaseValidationError("pyproject.toml is missing project.version")
+
+
+def download_and_verify_wheel(
+    wheel_url: str,
+    expected_sha256: str,
+    dest_dir: Path,
+) -> Path:
+    """Download wheel from URL and verify its SHA-256 digest."""
+    if not expected_sha256:
+        raise ReleaseValidationError("Cannot download wheel without verified expected SHA-256")
+
+    headers = {"User-Agent": "power-runtime-audit/1.0"}
+    req = urllib.request.Request(wheel_url, headers=headers)
+    fd, tmp_file = tempfile.mkstemp(prefix="power_wheel_", suffix=".whl", dir=dest_dir)
+    try:
+        with os.fdopen(fd, "wb") as handle, urllib.request.urlopen(req, timeout=60) as resp:
+            shutil.copyfileobj(resp, handle)
+        actual_sha256 = sha256_file(Path(tmp_file))
+        if actual_sha256.lower() != expected_sha256.lower():
+            raise ReleaseValidationError(
+                f"Downloaded wheel SHA-256 mismatch: expected {expected_sha256}, got {actual_sha256}"
+            )
+        return Path(tmp_file)
+    except Exception:
+        if os.path.exists(tmp_file):
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_file)
+        raise
+
+
+def fetch_release_payload(
+    repo: str = DEFAULT_REPO,
+    ref: str = DEFAULT_REF,
+    source_dir: Path | None = None,
+) -> ReleasePayload:
+    """Fetch and validate release metadata and artifacts, failing closed on mismatch."""
+    if source_dir is not None:
+        return _fetch_from_local_source(source_dir, ref)
+
+    return _fetch_from_github(repo, ref)
+
+
+def _fetch_from_local_source(source_dir: Path, ref: str) -> ReleasePayload:
+    """Load release metadata and artifacts from a local directory or repository checkout."""
+    source_root = Path(source_dir).expanduser().resolve()
+    pyproject_file = source_root / "pyproject.toml"
+    if not pyproject_file.is_file():
+        raise ReleaseValidationError(f"pyproject.toml not found in {source_root}")
+
+    pyproject_ver = _read_pyproject_version_from_text(pyproject_file.read_text(encoding="utf-8"))
+    tag = ref if ref != "latest" else f"v{pyproject_ver}"
+    expected_ver = tag.lstrip("v")
+
+    if ref == "latest":
+        _, pre_phase, _, _ = parse_version(pyproject_ver)
+        if pre_phase < 0:
+            raise ReleaseValidationError(
+                f"Local source version '{pyproject_ver}' is not a stable release (prerelease)"
+            )
+
+    if pyproject_ver != expected_ver:
+        raise ReleaseValidationError(
+            f"Release tag {tag} version ({expected_ver}) mismatch with "
+            f"pyproject version ({pyproject_ver})"
+        )
+
+    # Check for release manifest
+    manifest_file = source_root / "release" / "power-release-manifest.json"
+    manifest: dict[str, Any] = {}
+    if manifest_file.is_file():
+        try:
+            manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ReleaseValidationError(f"Invalid release manifest JSON: {exc}") from exc
+        if not isinstance(manifest, dict):
+            raise ReleaseValidationError("Release manifest root is not an object")
+        if manifest.get("schema") != "power.release.manifest.v1":
+            raise ReleaseValidationError(
+                f"Unsupported release manifest schema: {manifest.get('schema')}"
+            )
+        if manifest.get("version") != expected_ver:
+            raise ReleaseValidationError(
+                f"Manifest version {manifest.get('version')} does not match {expected_ver}"
+            )
+
+    # Locate wheel
+    manifest_wheel_filename: str | None = None
+    manifest_wheel_sha256: str | None = None
+
+    if manifest and "artifacts" in manifest and isinstance(manifest["artifacts"], dict):
+        wheel_meta = manifest["artifacts"].get("power_wheel")
+        if isinstance(wheel_meta, dict):
+            manifest_wheel_filename = wheel_meta.get("filename")
+            manifest_wheel_sha256 = wheel_meta.get("sha256")
+            if manifest_wheel_sha256 and (
+                len(manifest_wheel_sha256) != 64
+                or not re.fullmatch(r"[0-9a-fA-F]{64}", manifest_wheel_sha256)
+            ):
+                raise ReleaseValidationError(
+                    f"Invalid wheel SHA-256 in manifest: {manifest_wheel_sha256}"
+                )
+
+    expected_wheel_prefix = f"power_framework-{expected_ver}"
+    if manifest_wheel_filename and not manifest_wheel_filename.startswith(expected_wheel_prefix):
+        raise ReleaseValidationError(
+            f"Manifest wheel filename '{manifest_wheel_filename}' does not match version '{expected_ver}'"
+        )
+
+    # Search for wheel in dist or source_root
+    dist_dir = source_root / "dist"
+    candidates: list[Path] = []
+    if dist_dir.is_dir():
+        candidates.extend(sorted(dist_dir.glob(f"power_framework-{expected_ver}*.whl")))
+    candidates.extend(sorted(source_root.glob(f"power_framework-{expected_ver}*.whl")))
+
+    wheel_filename: str | None = manifest_wheel_filename
+    wheel_sha256: str | None = manifest_wheel_sha256
+    wheel_path: Path | None = None
+
+    if candidates:
+        wheel_path = candidates[0]
+        if manifest_wheel_filename and wheel_path.name != manifest_wheel_filename:
+            raise ReleaseValidationError(
+                f"Local wheel filename '{wheel_path.name}' does not match manifest '{manifest_wheel_filename}'"
+            )
+        actual_sha256 = sha256_file(wheel_path)
+        if wheel_sha256 and actual_sha256.lower() != wheel_sha256.lower():
+            raise ReleaseValidationError(
+                f"Wheel digest mismatch for {wheel_path.name}: "
+                f"expected {wheel_sha256}, got {actual_sha256}"
+            )
+        wheel_sha256 = actual_sha256
+        wheel_filename = wheel_path.name
+
+    # Extract or locate skill tree: check .agents/skills/power first, then skills/power, then wheel
+    skill_files: dict[str, bytes] = {}
+    agents_skill_dir = source_root / ".agents" / "skills" / "power"
+    standard_skill_dir = source_root / "skills" / "power"
+
+    if agents_skill_dir.is_dir():
+        skill_files = tree_from_directory(agents_skill_dir)
+    elif standard_skill_dir.is_dir():
+        skill_files = tree_from_directory(standard_skill_dir)
+    elif wheel_path is not None:
+        skill_files = _extract_wheel_skill_tree(wheel_path)
+
+    computed_skill_hash = aggregate_tree_hash(skill_files) if skill_files else None
+    expected_skill_hash = manifest.get("skill_tree_sha256") if manifest else None
+
+    # If wheel is present, validate wheel skill contents against manifest or computed
+    if wheel_path is not None and expected_skill_hash:
+        wheel_skills = _extract_wheel_skill_tree(wheel_path)
+        if wheel_skills:
+            w_hash = aggregate_tree_hash(wheel_skills)
+            if w_hash != expected_skill_hash:
+                raise ReleaseValidationError(
+                    f"Wheel Skill tree hash mismatch: expected {expected_skill_hash}, got {w_hash}"
+                )
+
+    effective_skill_hash = computed_skill_hash or expected_skill_hash
+
+    return ReleasePayload(
+        tag=tag,
+        version=expected_ver,
+        pyproject_version=pyproject_ver,
+        commit=manifest.get("commit"),
+        wheel_filename=wheel_filename,
+        wheel_sha256=wheel_sha256,
+        wheel_path=wheel_path,
+        skill_tree_sha256=effective_skill_hash,
+        skill_files=skill_files,
+        manifest=manifest,
+    )
+
+
+def _fetch_from_github(repo: str, ref: str) -> ReleasePayload:
+    """Fetch release information from public GitHub repository, failing closed if unresolved."""
+    headers = {"User-Agent": "power-runtime-audit/1.0", "Accept": "application/json"}
+
+    api_url = (
+        f"https://api.github.com/repos/{repo}/releases/latest"
+        if ref == "latest"
+        else f"https://api.github.com/repos/{repo}/releases/tags/{ref}"
+    )
+
+    release_data: dict[str, Any] = {}
+    try:
+        req = urllib.request.Request(api_url, headers=headers)
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            release_data = json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:
+        raise ReleaseValidationError(
+            f"Could not resolve release '{ref}' from GitHub API for {repo}: {exc}"
+        ) from exc
+
+    if not isinstance(release_data, dict) or not release_data.get("tag_name"):
+        raise ReleaseValidationError(
+            f"GitHub API for {repo}@{ref} did not return a valid release with tag_name"
+        )
+
+    tag_name = str(release_data["tag_name"]).strip()
+    expected_ver = tag_name.lstrip("v")
+    if not expected_ver or tag_name != f"v{expected_ver}":
+        raise ReleaseValidationError(
+            f"Release tag '{tag_name}' does not match expected format 'v<version>'"
+        )
+
+    if ref == "latest":
+        if release_data.get("draft") is True:
+            raise ReleaseValidationError(f"Latest release '{tag_name}' is a draft release")
+        if release_data.get("prerelease") is True:
+            raise ReleaseValidationError(f"Latest release '{tag_name}' is a prerelease")
+        _, pre_phase, _, _ = parse_version(expected_ver)
+        if pre_phase < 0:
+            raise ReleaseValidationError(
+                f"Latest release '{tag_name}' is not a stable release ({expected_ver})"
+            )
+
+    # 2. Fetch raw pyproject.toml to validate version
+    raw_pyproject_url = f"https://raw.githubusercontent.com/{repo}/{tag_name}/pyproject.toml"
+    try:
+        req = urllib.request.Request(raw_pyproject_url, headers=headers)
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            pyproject_content = resp.read().decode("utf-8")
+    except Exception as exc:
+        raise ReleaseValidationError(
+            f"Failed to fetch pyproject.toml for {repo}@{tag_name}: {exc}"
+        ) from exc
+
+    pyproject_ver = _read_pyproject_version_from_text(pyproject_content)
+    if pyproject_ver != expected_ver:
+        raise ReleaseValidationError(
+            f"Release tag {tag_name} does not match pyproject.toml version {pyproject_ver}"
+        )
+
+    # 3. Fetch release manifest if present
+    raw_manifest_url = (
+        f"https://raw.githubusercontent.com/{repo}/{tag_name}/release/power-release-manifest.json"
+    )
+    manifest: dict[str, Any] = {}
+    try:
+        req = urllib.request.Request(raw_manifest_url, headers=headers)
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            manifest_text = resp.read().decode("utf-8")
+            manifest = json.loads(manifest_text)
+    except Exception:
+        manifest = {}
+
+    if manifest:
+        if not isinstance(manifest, dict):
+            raise ReleaseValidationError("Release manifest root is not an object")
+        if manifest.get("schema") != "power.release.manifest.v1":
+            raise ReleaseValidationError(
+                f"Unsupported release manifest schema: {manifest.get('schema')}"
+            )
+        if manifest.get("version") != expected_ver:
+            raise ReleaseValidationError(
+                f"Manifest version {manifest.get('version')} does not match {expected_ver}"
+            )
+
+    manifest_wheel_filename: str | None = None
+    manifest_wheel_sha256: str | None = None
+
+    if manifest and "artifacts" in manifest and isinstance(manifest["artifacts"], dict):
+        wheel_meta = manifest["artifacts"].get("power_wheel")
+        if isinstance(wheel_meta, dict):
+            manifest_wheel_filename = wheel_meta.get("filename")
+            manifest_wheel_sha256 = wheel_meta.get("sha256")
+            if manifest_wheel_sha256:
+                manifest_wheel_sha256 = str(manifest_wheel_sha256).strip()
+                if len(manifest_wheel_sha256) != 64 or not re.fullmatch(
+                    r"[0-9a-fA-F]{64}", manifest_wheel_sha256
+                ):
+                    raise ReleaseValidationError(
+                        f"Invalid wheel SHA-256 in manifest: {manifest_wheel_sha256}"
+                    )
+                manifest_wheel_sha256 = manifest_wheel_sha256.lower()
+
+    expected_wheel_prefix = f"power_framework-{expected_ver}"
+    if manifest_wheel_filename and not manifest_wheel_filename.startswith(expected_wheel_prefix):
+        raise ReleaseValidationError(
+            f"Manifest wheel filename '{manifest_wheel_filename}' does not match version '{expected_ver}'"
+        )
+
+    # Check assets in release_data
+    asset_wheel_name: str | None = None
+    asset_wheel_url: str | None = None
+    asset_wheel_digest: str | None = None
+    for asset in release_data.get("assets", []):
+        name = asset.get("name", "")
+        if name.endswith(".whl"):
+            asset_wheel_name = name
+            asset_wheel_url = asset.get("browser_download_url")
+            raw_digest = asset.get("digest")
+            if raw_digest is not None:
+                norm_digest = str(raw_digest).strip()
+                if norm_digest.lower().startswith("sha256:"):
+                    norm_digest = norm_digest[7:].strip()
+                if norm_digest:
+                    if len(norm_digest) != 64 or not re.fullmatch(r"[0-9a-fA-F]{64}", norm_digest):
+                        raise ReleaseValidationError(
+                            f"Invalid wheel SHA-256 digest in asset: {raw_digest}"
+                        )
+                    asset_wheel_digest = norm_digest.lower()
+            break
+
+    if asset_wheel_name and not asset_wheel_name.startswith(expected_wheel_prefix):
+        raise ReleaseValidationError(
+            f"Wheel asset name '{asset_wheel_name}' does not match expected version '{expected_ver}'"
+        )
+
+    if manifest_wheel_filename and asset_wheel_name and manifest_wheel_filename != asset_wheel_name:
+        raise ReleaseValidationError(
+            f"Release asset wheel '{asset_wheel_name}' does not match manifest wheel '{manifest_wheel_filename}'"
+        )
+
+    if manifest_wheel_sha256 and asset_wheel_digest and manifest_wheel_sha256 != asset_wheel_digest:
+        raise ReleaseValidationError(
+            f"Release asset wheel digest '{asset_wheel_digest}' does not match manifest wheel SHA-256 '{manifest_wheel_sha256}'"
+        )
+
+    wheel_filename = asset_wheel_name or manifest_wheel_filename
+    wheel_sha256 = manifest_wheel_sha256 or asset_wheel_digest
+    wheel_url = asset_wheel_url
+
+    expected_skill_hash = manifest.get("skill_tree_sha256") if manifest else None
+
+    return ReleasePayload(
+        tag=tag_name,
+        version=pyproject_ver,
+        pyproject_version=pyproject_ver,
+        commit=manifest.get("commit") or release_data.get("target_commitish"),
+        wheel_filename=wheel_filename,
+        wheel_sha256=wheel_sha256,
+        wheel_url=wheel_url,
+        skill_tree_sha256=expected_skill_hash,
+        manifest=manifest,
+    )
+
+
+# ============================================================================
+# Bounded Python Virtual Environments Discovery and Audit
+# ============================================================================
+
+
+def is_system_prefix(path: Path) -> bool:
+    """Return True if path resolves inside system python / root library locations."""
+    try:
+        resolved_str = str(path.resolve())
+    except OSError:
+        resolved_str = str(path)
+    return any(
+        resolved_str == prefix or (prefix != "/" and resolved_str.startswith(f"{prefix}/"))
+        for prefix in SYSTEM_PREFIXES
+    )
+
+
+def is_python_interpreter(path: Path | str) -> bool:
+    """Return True if path/name represents a valid Python interpreter binary."""
+    p = Path(path)
+    name = p.name.lower()
+    if not name:
+        return False
+    if name in {
+        "sh",
+        "bash",
+        "dash",
+        "zsh",
+        "ksh",
+        "csh",
+        "tcsh",
+        "fish",
+        "busybox",
+        "env",
+        "node",
+        "perl",
+        "ruby",
+    }:
+        return False
+    return bool(
+        re.match(r"^(?:python|pypy)(?:\d+(?:\.\d+)*)?(?:t)?(?:\.exe)?$", name, re.IGNORECASE)
+    )
+
+
+def find_venv_python(venv_dir: Path) -> Path | None:
+    """Find python executable in virtualenv (bin/python, bin/python3, Scripts/python.exe)."""
+    if is_system_prefix(venv_dir):
+        return None
+    for candidate_rel in (
+        "bin/python",
+        "bin/python3",
+        "Scripts/python.exe",
+        "Scripts/python",
+    ):
+        candidate = venv_dir / candidate_rel
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def find_venv_pip(venv_dir: Path) -> list[str] | None:
+    """Find pip invocation for virtualenv (bin/pip, bin/pip3, or python -m pip)."""
+    if is_system_prefix(venv_dir):
+        return None
+    for candidate_rel in (
+        "bin/pip",
+        "bin/pip3",
+        "Scripts/pip.exe",
+        "Scripts/pip",
+    ):
+        candidate = venv_dir / candidate_rel
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return [str(candidate)]
+        if candidate.is_file():
+            return [str(candidate)]
+
+    py = find_venv_python(venv_dir)
+    if py is not None:
+        return [str(py), "-m", "pip"]
+    return None
+
+
+def discover_bounded_venvs(roots: list[str | Path]) -> list[Path]:
+    """Discover real Python virtual environments within explicitly bounded search roots."""
+    discovered: set[Path] = set()
+
+    for root_item in roots:
+        root_path = Path(root_item).expanduser()
+        if not root_path.exists():
+            continue
+
+        # Reject scanning filesystem root or system prefixes directly
+        if is_system_prefix(root_path):
+            continue
+
+        # Check if root_path itself is a venv
+        if (
+            (root_path / "pyvenv.cfg").is_file()
+            and not is_system_prefix(root_path)
+            and find_venv_python(root_path) is not None
+        ):
+            discovered.add(root_path.resolve())
+
+        # Check current symlink if under managed path
+        current_link = root_path / "current" / "venv"
+        if current_link.is_dir():
+            target_venv = current_link.resolve()
+            if not is_system_prefix(target_venv) and find_venv_python(target_venv) is not None:
+                discovered.add(target_venv)
+
+        # Recursively search for pyvenv.cfg (bounded)
+        try:
+            for cfg in root_path.glob("**/pyvenv.cfg"):
+                venv_dir = cfg.parent
+                if is_system_prefix(venv_dir):
+                    continue
+                if find_venv_python(venv_dir) is not None:
+                    discovered.add(venv_dir.resolve())
+        except (PermissionError, OSError):
+            continue
+
+    return sorted(discovered)
+
+
+def get_venv_power_framework_version(venv_dir: Path) -> str | None:
+    """Determine installed power-framework version from dist-info metadata or interpreter."""
+    if is_system_prefix(venv_dir):
+        return None
+    if not venv_dir.exists():
+        return None
+
+    lib_dir = venv_dir / "lib"
+    if lib_dir.is_dir():
+        for dist_info in lib_dir.glob("python*/site-packages/power_framework-*.dist-info"):
+            metadata_file = dist_info / "METADATA"
+            if metadata_file.is_file():
+                try:
+                    text = metadata_file.read_text(encoding="utf-8", errors="ignore")
+                    match = re.search(r"(?m)^Version:\s*([^\s]+)", text)
+                    if match:
+                        return match.group(1).strip()
+                except OSError:
+                    pass
+
+    # Check all site-packages under venv
+    for dist_info in venv_dir.glob("**/power_framework-*.dist-info"):
+        metadata_file = dist_info / "METADATA"
+        if metadata_file.is_file():
+            try:
+                text = metadata_file.read_text(encoding="utf-8", errors="ignore")
+                match = re.search(r"(?m)^Version:\s*([^\s]+)", text)
+                if match:
+                    return match.group(1).strip()
+            except OSError:
+                pass
+
+    # Fallback to executing python in venv with short timeout
+    python_bin = find_venv_python(venv_dir)
+    if python_bin is not None and python_bin.is_file():
+        try:
+            res = subprocess.run(  # noqa: S603
+                [
+                    str(python_bin),
+                    "-c",
+                    "import importlib.metadata as m; print(m.version('power-framework'))",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            if res.returncode == 0 and res.stdout.strip():
+                return res.stdout.strip()
+        except (subprocess.SubprocessError, OSError):
+            pass
+
+    return None
+
+
+def audit_venv(venv_dir: Path, target_version: str) -> VenvAuditResult:
+    """Audit one virtual environment for power-framework presence, version, and writability."""
+    python_bin = find_venv_python(venv_dir)
+    python_path = str(python_bin) if python_bin else str(venv_dir / "bin" / "python")
+
+    if is_system_prefix(venv_dir):
+        return VenvAuditResult(
+            path=str(venv_dir),
+            python_path=python_path,
+            installed_version=None,
+            is_writable=False,
+            status="unwritable",
+            error="System Python installations cannot be audited or mutated as virtualenvs",
+        )
+
+    if python_bin is None:
+        return VenvAuditResult(
+            path=str(venv_dir),
+            python_path=python_path,
+            installed_version=None,
+            is_writable=False,
+            status="broken_venv",
+            error="Virtual environment lacks valid python binary",
+        )
+
+    installed_ver = get_venv_power_framework_version(venv_dir)
+    is_writable = os.access(venv_dir, os.W_OK) and (
+        not (venv_dir / "bin").exists() or os.access(venv_dir / "bin", os.W_OK)
+    )
+
+    if installed_ver is None:
+        status = "not_installed"
+    else:
+        cmp = compare_versions(installed_ver, target_version)
+        if cmp == 0:
+            status = "up_to_date"
+        elif cmp < 0:
+            status = "outdated" if is_writable else "unwritable"
+        else:
+            status = "newer"
+
+    return VenvAuditResult(
+        path=str(venv_dir),
+        python_path=python_path,
+        installed_version=installed_ver,
+        is_writable=is_writable,
+        status=status,
+    )
+
+
+def apply_venv_update(
+    audit: VenvAuditResult,
+    release: ReleasePayload,
+    dry_run: bool = True,
+) -> tuple[str, str | None]:
+    """Update an outdated virtual environment to the target release using a verified wheel."""
+    if audit.status != "outdated":
+        return "skipped", None
+
+    if not audit.is_writable:
+        return "unwritable", "Virtual environment is not writable"
+
+    venv_dir = Path(audit.path)
+    if is_system_prefix(venv_dir):
+        return "unwritable", "Refusing to mutate system Python prefix"
+
+    pip_cmd = find_venv_pip(venv_dir)
+    if pip_cmd is None:
+        return "failed", "No pip or python binary found in virtual environment"
+
+    if dry_run:
+        return "planned_update", None
+
+    # Prohibit installation without a verified wheel
+    wheel_path = release.wheel_path
+    if wheel_path is None or not wheel_path.is_file():
+        return (
+            "failed",
+            "No verified local release wheel available; installation from unverified PyPI is prohibited",
+        )
+
+    if release.wheel_sha256:
+        actual_sha = sha256_file(wheel_path)
+        if actual_sha.lower() != release.wheel_sha256.lower():
+            return (
+                "failed",
+                f"Wheel digest mismatch: expected {release.wheel_sha256}, got {actual_sha}",
+            )
+
+    cmd = [*pip_cmd, "install", "--upgrade", "--no-deps", "--no-input", str(wheel_path)]
+
+    try:
+        res = subprocess.run(  # noqa: S603
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        if res.returncode != 0:
+            return "failed", redact_secrets(f"pip install failed: {res.stderr.strip()}")
+
+        new_ver = get_venv_power_framework_version(venv_dir)
+        if new_ver != release.version:
+            return (
+                "failed",
+                f"Post-install version check failed: got {new_ver}, expected {release.version}",
+            )
+
+        return "updated", None
+    except Exception as exc:
+        return "failed", redact_secrets(str(exc))
+
+
+# ============================================================================
+# POWER MCP Client Config Inspection and Audit
+# ============================================================================
+
+
+def has_jsonc_comments(content: str) -> bool:
+    """Check if JSON/JSONC text contains comments outside of string literals using a tokenizer."""
+    in_string = False
+    escape = False
+    i = 0
+    n = len(content)
+    while i < n:
+        char = content[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            i += 1
+            continue
+
+        if char == '"':
+            in_string = True
+            i += 1
+            continue
+
+        if char == "/" and i + 1 < n:
+            next_char = content[i + 1]
+            if next_char in ("/", "*"):
+                return True
+
+        i += 1
+
+    return False
+
+
+def strip_jsonc_comments(content: str) -> str:
+    """Strip single-line and multi-line comments from JSONC text for in-memory parsing.
+
+    Preserves string literals, escapes, and structure without mutating files on disk.
+    """
+    result: list[str] = []
+    in_string = False
+    escape = False
+    i = 0
+    n = len(content)
+    while i < n:
+        char = content[i]
+        if in_string:
+            result.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            i += 1
+            continue
+
+        if char == '"':
+            in_string = True
+            result.append(char)
+            i += 1
+            continue
+
+        if char == "/" and i + 1 < n:
+            next_char = content[i + 1]
+            if next_char == "/":
+                i += 2
+                while i < n and content[i] not in ("\r", "\n"):
+                    i += 1
+                continue
+            if next_char == "*":
+                i += 2
+                while i + 1 < n and not (content[i] == "*" and content[i + 1] == "/"):
+                    i += 1
+                i += 2
+                continue
+
+        result.append(char)
+        i += 1
+
+    return "".join(result)
+
+
+MAX_WRAPPER_DEPTH = 5
+
+
+def _extract_shebang_python(first_line: str) -> Path | None:
+    """Extract and validate Python interpreter from a #! shebang line."""
+    if not first_line.startswith("#!"):
+        return None
+    shebang = first_line[2:].strip()
+    parts = shebang.split()
+    if not parts:
+        return None
+
+    if parts[0] == "/usr/bin/env" or parts[0].endswith("/env"):
+        args = parts[1:]
+        target_cmd: str | None = None
+        i = 0
+        while i < len(args):
+            arg = args[i]
+            if arg == "-S":
+                i += 1
+                continue
+            if arg.startswith("-S"):
+                target_cmd = arg[2:]
+                break
+            if arg.startswith("-"):
+                i += 1
+                continue
+            target_cmd = arg
+            break
+
+        if target_cmd and is_python_interpreter(target_cmd):
+            which_py = shutil.which(target_cmd)
+            if which_py:
+                return Path(which_py)
+            p = Path(target_cmd)
+            if p.is_file():
+                return p
+    else:
+        if is_python_interpreter(parts[0]):
+            direct_p = Path(parts[0])
+            if direct_p.is_file():
+                return direct_p
+            which_direct = shutil.which(parts[0])
+            if which_direct:
+                return Path(which_direct)
+
+    return None
+
+
+def _extract_exec_target_from_wrapper(content: str, base_dir: Path | None = None) -> Path | None:
+    """Inspect trusted local wrapper script text for an absolute or wrapper-relative exec target."""
+    for line in content.splitlines():
+        line_str = line.strip()
+        if not line_str or line_str.startswith("#"):
+            continue
+
+        sub_commands = re.split(r";|&&|\|\|", line_str)
+        for sub_cmd in sub_commands:
+            sub = sub_cmd.strip()
+            if not sub:
+                continue
+
+            target_token: str | None = None
+            if sub.startswith("exec ") or sub.startswith("exec\t") or sub == "exec":
+                try:
+                    tokens = shlex.split(sub, comments=True)
+                except ValueError:
+                    tokens = sub.split()
+                if len(tokens) >= 2 and tokens[0] == "exec":
+                    target_token = tokens[1]
+
+            if not target_token:
+                quoted_match = re.search(r"""(?:^|[\t ])exec[\t ]+(["'])(.+?)\1""", sub)
+                if quoted_match:
+                    target_token = quoted_match.group(2)
+                else:
+                    unquoted_match = re.search(r"""(?:^|[\t ])exec[\t ]+([^\s"';#]+)""", sub)
+                    if unquoted_match:
+                        target_token = unquoted_match.group(1)
+
+            if not target_token:
+                continue
+
+            target_token = target_token.strip("\"'")
+            if not target_token:
+                continue
+
+            if target_token.startswith("/"):
+                return Path(target_token)
+
+            if target_token.startswith(("./", "../")):
+                if base_dir is not None:
+                    return (base_dir / target_token).resolve()
+                return Path(target_token)
+
+            if base_dir is not None:
+                rel_p = base_dir / target_token
+                if rel_p.exists():
+                    return rel_p.resolve()
+
+    return None
+
+
+def _extract_exec_python_from_wrapper(content: str) -> Path | None:
+    """Inspect trusted local wrapper script text for an absolute Python interpreter used by exec."""
+    target = _extract_exec_target_from_wrapper(content)
+    if target is not None and is_python_interpreter(target) and target.is_file():
+        return target
+    return None
+
+
+def resolve_mcp_runtime(
+    executable_cmd: str,
+) -> tuple[str | None, str | None, str | None, str | None]:
+    """Inspect MCP executable, resolving shebang/interpreter and installed package version.
+
+    Follows absolute or wrapper-relative local exec targets recursively with depth limit
+    and cycle protection. Never treats /bin/sh as Python, never executes wrapper contents,
+    and redacts error messages.
+
+    Returns:
+        (resolved_executable, runtime_python, installed_version, error_message)
+    """
+    if not executable_cmd:
+        return None, None, None, "No executable specified in MCP config"
+
+    initial_path: Path | None = None
+    if "/" in executable_cmd or "\\" in executable_cmd:
+        initial_path = Path(executable_cmd).expanduser()
+    else:
+        which_p = shutil.which(executable_cmd)
+        if which_p:
+            initial_path = Path(which_p)
+
+    if initial_path is None or not initial_path.exists():
+        return executable_cmd, None, None, f"MCP executable '{executable_cmd}' not found"
+
+    resolved_top_exe = str(initial_path)
+    current_path = initial_path
+    if current_path.is_symlink():
+        with contextlib.suppress(OSError):
+            current_path = current_path.resolve()
+
+    visited_paths: set[Path] = set()
+    depth = 0
+    max_depth = MAX_WRAPPER_DEPTH
+
+    runtime_python: Path | None = None
+
+    while current_path is not None and depth <= max_depth:
+        # Cycle detection: resolve real path for canonical identity
+        try:
+            canonical_path = current_path.resolve()
+        except OSError:
+            canonical_path = current_path
+
+        if canonical_path in visited_paths or current_path in visited_paths:
+            return (
+                resolved_top_exe,
+                None,
+                None,
+                redact_secrets(f"Cyclic exec wrapper reference detected: {current_path}"),
+            )
+
+        visited_paths.add(canonical_path)
+        visited_paths.add(current_path)
+
+        # 1. Check if current_path itself is a Python interpreter
+        if is_python_interpreter(current_path):
+            runtime_python = current_path
+            break
+
+        # If it is a system prefix path and not a Python interpreter (e.g. /bin/sh), do not parse
+        if is_system_prefix(current_path):
+            break
+
+        # 2. Check if file exists and is regular file
+        if not current_path.is_file():
+            return (
+                resolved_top_exe,
+                None,
+                None,
+                redact_secrets(f"Exec target '{current_path}' is not a regular file"),
+            )
+
+        # 3. Read content safely without executing
+        try:
+            content = current_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError as exc:
+            return (
+                resolved_top_exe,
+                None,
+                None,
+                redact_secrets(f"Cannot read executable script: {exc}"),
+            )
+
+        # 4. Check shebang
+        first_line = content.splitlines()[0] if content.splitlines() else ""
+        shebang_py = _extract_shebang_python(first_line)
+        if shebang_py is not None and is_python_interpreter(shebang_py):
+            runtime_python = shebang_py
+            break
+
+        # 5. Extract next exec target (absolute or wrapper-relative)
+        next_target = _extract_exec_target_from_wrapper(content, base_dir=current_path.parent)
+        if next_target is None:
+            # Fallback to checking sibling/parent venv structure (only if not a system prefix)
+            if not is_system_prefix(current_path.parent.parent):
+                sibling_py = find_venv_python(current_path.parent.parent)
+                if sibling_py is not None and is_python_interpreter(sibling_py):
+                    runtime_python = sibling_py
+            break
+
+        # Check if next target exists
+        if not next_target.exists():
+            return (
+                resolved_top_exe,
+                None,
+                None,
+                redact_secrets(f"Exec target '{next_target}' not found"),
+            )
+
+        if next_target.is_symlink():
+            with contextlib.suppress(OSError):
+                next_target = next_target.resolve()
+
+        current_path = next_target
+        depth += 1
+
+    if depth > max_depth and runtime_python is None:
+        return (
+            resolved_top_exe,
+            None,
+            None,
+            redact_secrets(
+                f"Exec wrapper depth limit ({max_depth}) exceeded resolving MCP runtime: {resolved_top_exe}"
+            ),
+        )
+
+    # If runtime_python was found, extract installed version from its venv
+    installed_ver: str | None = None
+    if runtime_python is not None:
+        venv_dir = runtime_python.parent.parent
+        installed_ver = get_venv_power_framework_version(venv_dir)
+        if installed_ver is None:
+            with contextlib.suppress(OSError):
+                installed_ver = get_venv_power_framework_version(
+                    runtime_python.resolve().parent.parent
+                )
+
+    return (
+        resolved_top_exe,
+        str(runtime_python) if runtime_python else None,
+        installed_ver,
+        None,
+    )
+
+
+def audit_mcp_config(
+    config_path: Path,
+    target_version: str | None = None,
+) -> MCPAuditResult:
+    """Inspect MCP configuration file without exposing credentials."""
+    client_name = config_path.stem
+    if "opencode" in str(config_path):
+        client_name = "opencode"
+    elif "gemini" in str(config_path):
+        client_name = "gemini"
+    elif "codex" in str(config_path):
+        client_name = "codex"
+
+    suffix = config_path.suffix.lower()
+    config_format = "toml" if suffix == ".toml" else ("jsonc" if suffix == ".jsonc" else "json")
+
+    if not config_path.exists():
+        return MCPAuditResult(
+            client=client_name,
+            config_path=str(config_path),
+            config_format=config_format,
+            status="missing_file",
+        )
+
+    if config_path.is_symlink():
+        return MCPAuditResult(
+            client=client_name,
+            config_path=str(config_path),
+            config_format=config_format,
+            status="manual_review",
+            error="Symlink client configuration files are not followed",
+        )
+
+    try:
+        content = config_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return MCPAuditResult(
+            client=client_name,
+            config_path=str(config_path),
+            config_format=config_format,
+            status="manual_review",
+            error=redact_secrets(f"Cannot read config: {exc}"),
+        )
+
+    has_comments = config_format in {"json", "jsonc"} and has_jsonc_comments(content)
+
+    power_entry: Any = None
+    if config_format == "toml":
+        try:
+            payload = tomllib.loads(content) if content.strip() else {}
+        except tomllib.TOMLDecodeError as exc:
+            return MCPAuditResult(
+                client=client_name,
+                config_path=str(config_path),
+                config_format=config_format,
+                status="manual_review",
+                error=redact_secrets(f"TOML decode error: {exc}"),
+            )
+        if not isinstance(payload, dict):
+            return MCPAuditResult(
+                client=client_name,
+                config_path=str(config_path),
+                config_format=config_format,
+                status="manual_review",
+                error="Root TOML element is not a table",
+            )
+        servers = payload.get("mcp_servers") or payload.get("mcpServers") or payload.get("mcp")
+        if servers is None or not isinstance(servers, dict):
+            return MCPAuditResult(
+                client=client_name,
+                config_path=str(config_path),
+                config_format=config_format,
+                status="missing_entry",
+            )
+        power_entry = servers.get("power")
+    else:
+        parseable_content = strip_jsonc_comments(content) if has_comments else content
+        try:
+            payload = json.loads(parseable_content) if parseable_content.strip() else {}
+        except json.JSONDecodeError as exc:
+            return MCPAuditResult(
+                client=client_name,
+                config_path=str(config_path),
+                config_format=config_format,
+                status="manual_review",
+                has_comments=has_comments,
+                error=redact_secrets(f"JSON decode error: {exc}"),
+            )
+        if not isinstance(payload, dict):
+            return MCPAuditResult(
+                client=client_name,
+                config_path=str(config_path),
+                config_format=config_format,
+                status="manual_review",
+                has_comments=has_comments,
+                error="Root JSON element is not an object",
+            )
+        root_key = "mcp" if client_name == "opencode" else "mcpServers"
+        servers = payload.get(root_key)
+        if servers is None and "mcp_servers" in payload:
+            servers = payload.get("mcp_servers")
+        if servers is None and "mcpServers" in payload:
+            servers = payload.get("mcpServers")
+        if servers is None and "mcp" in payload:
+            servers = payload.get("mcp")
+        if servers is None or not isinstance(servers, dict):
+            return MCPAuditResult(
+                client=client_name,
+                config_path=str(config_path),
+                config_format=config_format,
+                status="manual_review" if has_comments else "missing_entry",
+                has_comments=has_comments,
+                error="JSONC contains user comments; manual review required to preserve structure"
+                if has_comments
+                else None,
+            )
+        power_entry = servers.get("power")
+
+    if power_entry is None:
+        return MCPAuditResult(
+            client=client_name,
+            config_path=str(config_path),
+            config_format=config_format,
+            status="manual_review" if has_comments else "missing_entry",
+            has_comments=has_comments,
+            error="JSONC contains user comments; manual review required to preserve structure"
+            if has_comments
+            else None,
+        )
+
+    if not isinstance(power_entry, dict):
+        return MCPAuditResult(
+            client=client_name,
+            config_path=str(config_path),
+            config_format=config_format,
+            status="manual_review",
+            has_comments=has_comments,
+            error="power entry is not a table/object",
+        )
+
+    cmd_val = power_entry.get("command")
+    env_obj = power_entry.get("env") or power_entry.get("environment") or {}
+    env_keys = sorted(env_obj.keys()) if isinstance(env_obj, dict) else []
+
+    executable_name = ""
+    if isinstance(cmd_val, list) and cmd_val:
+        executable_name = str(cmd_val[0])
+    elif isinstance(cmd_val, str):
+        executable_name = cmd_val
+
+    is_canonical_name = (
+        executable_name.endswith("/power-mcp")
+        or executable_name == "power-mcp"
+        or "power_framework.mcp" in str(cmd_val)
+    )
+
+    if not is_canonical_name:
+        return MCPAuditResult(
+            client=client_name,
+            config_path=str(config_path),
+            config_format=config_format,
+            status="manual_review" if has_comments else "mismatch",
+            entry_present=True,
+            executable=executable_name,
+            env_keys=env_keys,
+            has_comments=has_comments,
+            error=redact_secrets(
+                "JSONC contains user comments; manual review required to preserve structure"
+                if has_comments
+                else "Command does not match canonical power-mcp executable"
+            ),
+        )
+
+    resolved_exe, runtime_py, inst_ver, run_err = resolve_mcp_runtime(executable_name)
+
+    if run_err or not runtime_py or inst_ver is None:
+        raw_status = "missing_runtime"
+    elif target_version is not None:
+        cmp = compare_versions(inst_ver, target_version)
+        raw_status = "outdated" if cmp < 0 else "canonical"
+    else:
+        raw_status = "canonical"
+
+    final_status = "manual_review" if has_comments else raw_status
+    if has_comments:
+        error_msg = (
+            redact_secrets(run_err)
+            if run_err
+            else "JSONC contains user comments; manual review required to preserve structure"
+        )
+    else:
+        error_msg = redact_secrets(run_err) if run_err else None
+
+    return MCPAuditResult(
+        client=client_name,
+        config_path=str(config_path),
+        config_format=config_format,
+        status=final_status,
+        entry_present=True,
+        executable=executable_name,
+        resolved_executable=resolved_exe,
+        runtime_python=runtime_py,
+        installed_version=inst_ver,
+        env_keys=env_keys,
+        has_comments=has_comments,
+        error=error_msg,
+    )
+
+
+# ============================================================================
+# POWER Skill Targets Inspection and Atomic Update
+# ============================================================================
+
+
+def extract_skill_version(skill_md_content: str) -> str | None:
+    """Extract version from SKILL.md YAML frontmatter, stripping quotes."""
+    match = re.search(r"(?ms)^---\s*\n(.*?)\n---", skill_md_content)
+    if not match:
+        return None
+    ver_match = re.search(r"(?m)^version:\s*(?:['\"]([^'\"]+)['\"]|([^\s#]+))", match.group(1))
+    if not ver_match:
+        return None
+    ver = (ver_match.group(1) or ver_match.group(2) or "").strip().strip("\"'")
+    return ver if ver else None
+
+
+def is_managed_skill_tree(files: dict[str, bytes]) -> bool:
+    """Check if target contains valid managed POWER SKILL.md."""
+    if "SKILL.md" not in files:
+        return False
+    header = files["SKILL.md"].decode("utf-8", errors="ignore")
+    return header.startswith("---\n") and "\nname: power\n" in header
+
+
+def is_allowed_skill_target(
+    target_path: Path,
+    allowed_roots: list[Path] | None = None,
+) -> bool:
+    """Verify target path is under an allowed non-system root and not a symlink."""
+    if is_system_prefix(target_path):
+        return False
+
+    try:
+        resolved = target_path.resolve()
+    except OSError:
+        return False
+
+    if is_system_prefix(resolved):
+        return False
+
+    # Disallow root or /root directly
+    if resolved in (Path("/"), Path.home(), Path("/root")):
+        return False
+
+    # Check symlinks in ancestors
+    cur = target_path
+    while cur != cur.parent:
+        if cur.is_symlink():
+            return False
+        cur = cur.parent
+
+    roots = allowed_roots if allowed_roots is not None else ALLOWED_SKILL_TARGET_ROOTS
+    for allowed in roots:
+        try:
+            if resolved.is_relative_to(allowed.resolve()):
+                return True
+        except ValueError:
+            continue
+
+    return False
+
+
+def audit_skill(
+    target_path: Path,
+    release: ReleasePayload,
+    allowed_roots: list[Path] | None = None,
+) -> SkillAuditResult:
+    """Audit one Skill directory against the release skill payload."""
+    if not is_allowed_skill_target(target_path, allowed_roots):
+        return SkillAuditResult(
+            target_path=str(target_path),
+            installed_version=None,
+            tree_sha256=None,
+            status="manual_review",
+            error="Target is outside allowed roots or is a symlink",
+        )
+
+    if not target_path.exists():
+        return SkillAuditResult(
+            target_path=str(target_path),
+            installed_version=None,
+            tree_sha256=None,
+            status="ready",
+            file_count=0,
+        )
+
+    if not target_path.is_dir() or target_path.is_symlink():
+        return SkillAuditResult(
+            target_path=str(target_path),
+            installed_version=None,
+            tree_sha256=None,
+            status="manual_review",
+            error="Target exists but is a symlink or non-directory",
+        )
+
+    target_files = tree_from_directory(target_path)
+    if not target_files:
+        return SkillAuditResult(
+            target_path=str(target_path),
+            installed_version=None,
+            tree_sha256=None,
+            status="ready",
+            file_count=0,
+        )
+
+    target_hash = aggregate_tree_hash(target_files)
+    skill_md = target_files.get("SKILL.md", b"").decode("utf-8", errors="ignore")
+    installed_ver = extract_skill_version(skill_md)
+
+    if release.skill_tree_sha256 and target_hash == release.skill_tree_sha256:
+        status = "up_to_date"
+    elif is_managed_skill_tree(target_files):
+        status = "upgrade_ready"
+    else:
+        status = "manual_review"
+
+    return SkillAuditResult(
+        target_path=str(target_path),
+        installed_version=installed_ver,
+        tree_sha256=target_hash,
+        status=status,
+        file_count=len(target_files),
+    )
+
+
+def apply_skill_update(
+    audit: SkillAuditResult,
+    release: ReleasePayload,
+    dry_run: bool = True,
+    allowed_roots: list[Path] | None = None,
+) -> tuple[str, str | None]:
+    """Atomically install or upgrade a managed Skill target with path safety checks."""
+    if audit.status not in {"ready", "upgrade_ready"}:
+        return "skipped", None
+
+    if not release.skill_files:
+        return "failed", "Release payload contains no skill files"
+
+    target = Path(audit.target_path).expanduser()
+    if not is_allowed_skill_target(target, allowed_roots):
+        return "failed", f"Skill target {target} is outside allowed roots or is a symlink"
+
+    # Verify skill tree hash if expected hash is present
+    actual_tree_hash = aggregate_tree_hash(release.skill_files)
+    if release.skill_tree_sha256 and actual_tree_hash != release.skill_tree_sha256:
+        return (
+            "failed",
+            f"Skill tree hash mismatch: expected {release.skill_tree_sha256}, got {actual_tree_hash}",
+        )
+
+    # Check every relative path for allowlist / safety
+    for relative in release.skill_files:
+        if not is_safe_skill_relative_path(relative):
+            return "failed", f"Unsafe or disallowed skill relative path: {relative}"
+
+    if dry_run:
+        return "planned_update", None
+
+    target = target.resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    staging = Path(tempfile.mkdtemp(prefix=f".{target.name}.staging-", dir=target.parent))
+    previous: Path | None = None
+    try:
+        for relative, content in release.skill_files.items():
+            dest = staging / relative
+            if not dest.resolve().is_relative_to(staging.resolve()):
+                raise ValueError(f"Path traversal detected in skill file: {relative}")
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(content)
+            mode = 0o755 if relative.startswith("scripts/") else 0o644
+            dest.chmod(mode)
+
+        if target.exists():
+            previous = target.parent / f".{target.name}.prev-{os.getpid()}"
+            if previous.exists():
+                shutil.rmtree(previous, ignore_errors=True)
+            os.replace(target, previous)
+
+        os.replace(staging, target)
+
+        # Validate the final installed tree hash before deleting previous
+        installed_files = tree_from_directory(target)
+        installed_hash = aggregate_tree_hash(installed_files)
+        expected_hash = release.skill_tree_sha256 or actual_tree_hash
+        if installed_hash != expected_hash:
+            raise ValueError(
+                f"Installed skill tree hash mismatch: expected {expected_hash}, got {installed_hash}"
+            )
+
+        if previous is not None and previous.exists():
+            shutil.rmtree(previous, ignore_errors=True)
+        return "updated", None
+    except Exception as exc:
+        if staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)
+        if previous is not None and previous.exists():
+            if target.exists():
+                shutil.rmtree(target, ignore_errors=True)
+            with contextlib.suppress(OSError):
+                os.replace(previous, target)
+        elif target.exists() and previous is None:
+            shutil.rmtree(target, ignore_errors=True)
+        return "failed", redact_secrets(str(exc))
+
+
+# ============================================================================
+# State Report Persistence and Canonical Brain Log
+# ============================================================================
+
+
+def persist_state_report(report: AuditReport, state_dir: Path) -> Path:
+    """Atomically persist a redacted JSON audit report under the state directory."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    ts_sec = int(time.time())
+    ts_ns = time.time_ns()
+    pid = os.getpid()
+    report_file = state_dir / f"audit-{ts_sec}-{ts_ns % 1_000_000_000:09d}-{pid}.json"
+    latest_file = state_dir / "latest.json"
+
+    data = json.dumps(report.as_dict(), indent=2, ensure_ascii=False) + "\n"
+
+    # Atomic write report_file
+    fd, tmp = tempfile.mkstemp(prefix=f".{report_file.name}.", dir=state_dir)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(data)
+    os.replace(tmp, report_file)
+
+    # Atomic write latest_file
+    fd_lat, tmp_lat = tempfile.mkstemp(prefix=".latest.", dir=state_dir)
+    with os.fdopen(fd_lat, "w", encoding="utf-8") as handle:
+        handle.write(data)
+    os.replace(tmp_lat, latest_file)
+
+    return report_file
+
+
+def record_brain_log(vault_path: Path, report: AuditReport) -> bool:
+    """Record a deduplicated Action/Result entry in the canonical brain log with file locking."""
+    vault = Path(vault_path).expanduser().resolve()
+    if not vault.is_dir():
+        return False
+
+    log_file = vault / "log.md"
+    if not log_file.is_file():
+        daily_log = vault / "06_Daily_Logs" / "log.md"
+        if daily_log.is_file():
+            log_file = daily_log
+        else:
+            return False
+
+    lock_dir = vault / ".power"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_file = lock_dir / "mutation.lock"
+
+    mode_str = "Apply" if report.applied else "Audit"
+    action_desc = "applied updates" if report.applied else "read-only audit"
+    rel_ver = report.release.get("version", "unknown")
+    if "error" in report.release and rel_ver == "unknown":
+        rel_ver = "failed"
+    drift_desc = "Drift detected" if report.has_drift else "No drift"
+
+    sig = f"Runtime {mode_str} (v{rel_ver})"
+    date_str = datetime.now(UTC).strftime("%Y-%m-%d %H:%M")
+
+    if "error" in report.release:
+        result_desc = f"Release validation failed: {report.release['error']}."
+    else:
+        result_desc = (
+            f"Checked {len(report.venvs)} venvs, {len(report.mcp_configs)} MCP configs, "
+            f"{len(report.skills)} skills. Status: {drift_desc}."
+        )
+
+    entry_text = (
+        f"\n### {date_str} UTC — {sig}\n"
+        f"- **Action**: P.O.W.E.R runtime {action_desc} (target release v{rel_ver}).\n"
+        f"- **Result**: {result_desc}\n"
+    )
+
+    try:
+        with lock_file.open("a+") as lock_handle:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+            try:
+                content = log_file.read_text(encoding="utf-8")
+                last_entries = "\n".join(content.splitlines()[-20:])
+                if sig in last_entries and drift_desc in last_entries:
+                    return False  # Deduplicated
+
+                fd, tmp = tempfile.mkstemp(prefix=".log.", dir=log_file.parent)
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(content + entry_text)
+                os.replace(tmp, log_file)
+                return True
+            finally:
+                fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+    except Exception:
+        return False
+
+
+# ============================================================================
+# Human Readable & JSON Report Formatters
+# ============================================================================
+
+
+def format_human_report(report: AuditReport) -> str:
+    """Format audit report into structured human-readable tables."""
+    lines: list[str] = [
+        "=" * 80,
+        f" P.O.W.E.R Host-side Runtime Audit Report ({report.timestamp} UTC)",
+        "=" * 80,
+        f"Release: v{report.release.get('version')} (Tag: {report.release.get('tag')})",
+        f"Mode:    {'APPLY (Mutations Active)' if report.applied else 'AUDIT (Read-Only)'}",
+        f"Status:  {'DRIFT DETECTED' if report.has_drift else 'ALL UP TO DATE'}",
+        "",
+        "--- Virtual Environments ---",
+        f"{'Venv Path':<50} {'Installed':<12} {'Status':<15}",
+        "-" * 80,
+    ]
+
+    for v in report.venvs:
+        ver = v.installed_version or "(none)"
+        st = v.status.upper()
+        if v.action_taken:
+            st = f"{st} -> {v.action_taken.upper()}"
+        lines.append(f"{v.path:<50} {ver:<12} {st:<15}")
+
+    lines.extend(
+        [
+            "",
+            "--- MCP Client Configurations ---",
+            f"{'Client / Path':<50} {'Format':<8} {'Status':<18}",
+            "-" * 80,
+        ]
+    )
+
+    for m in report.mcp_configs:
+        path_abbr = m.config_path
+        if len(path_abbr) > 48:
+            path_abbr = "..." + path_abbr[-45:]
+        lines.append(f"{path_abbr:<50} {m.config_format:<8} {m.status.upper():<18}")
+
+    lines.extend(
+        [
+            "",
+            "--- Skill Targets ---",
+            f"{'Skill Target Path':<50} {'Files':<8} {'Status':<18}",
+            "-" * 80,
+        ]
+    )
+
+    for s in report.skills:
+        path_abbr = s.target_path
+        if len(path_abbr) > 48:
+            path_abbr = "..." + path_abbr[-45:]
+        st = s.status.upper()
+        if s.action_taken:
+            st = f"{st} -> {s.action_taken.upper()}"
+        lines.append(f"{path_abbr:<50} {s.file_count:<8} {st:<18}")
+
+    if report.errors:
+        lines.extend(["", "--- Errors ---"])
+        lines.extend(f"  * {err}" for err in report.errors)
+
+    lines.append("=" * 80)
+    return "\n".join(lines)
+
+
+# ============================================================================
+# Main Execution Pipeline
+# ============================================================================
+
+
+def run_audit(
+    repo: str = DEFAULT_REPO,
+    ref: str = DEFAULT_REF,
+    source_dir: Path | None = None,
+    vault_path: Path = DEFAULT_VAULT,
+    state_dir: Path = DEFAULT_STATE_DIR,
+    venv_roots: list[str | Path] | None = None,
+    skill_targets: list[str | Path] | None = None,
+    mcp_configs: list[str | Path] | None = None,
+    apply: bool = False,
+    record: bool = False,
+    fail_on_drift: bool = False,
+) -> tuple[AuditReport, int]:
+    """Execute complete runtime audit and optional updates under process lock."""
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+
+    state_dir_path = Path(state_dir).expanduser().resolve()
+    state_dir_path.mkdir(parents=True, exist_ok=True)
+    lock_file = state_dir_path / ".process.lock"
+
+    try:
+        with ProcessLock(lock_file):
+            return _run_audit_internal(
+                repo=repo,
+                ref=ref,
+                source_dir=source_dir,
+                vault_path=vault_path,
+                state_dir=state_dir_path,
+                venv_roots=venv_roots,
+                skill_targets=skill_targets,
+                mcp_configs=mcp_configs,
+                apply=apply,
+                record=record,
+                fail_on_drift=fail_on_drift,
+                timestamp=timestamp,
+            )
+    except RuntimeError as exc:
+        err_msg = redact_secrets(str(exc))
+        report = AuditReport(
+            timestamp=timestamp,
+            release={"error": err_msg},
+            venvs=[],
+            mcp_configs=[],
+            skills=[],
+            applied=apply,
+            recorded=False,
+            has_drift=True,
+            errors=[err_msg],
+        )
+        try:
+            persist_state_report(report, state_dir_path)
+        except Exception as p_exc:
+            report.errors.append(redact_secrets(f"Failed to persist state report: {p_exc}"))
+        return report, 1
+
+
+def _run_audit_internal(
+    repo: str,
+    ref: str,
+    source_dir: Path | None,
+    vault_path: Path,
+    state_dir: Path,
+    venv_roots: list[str | Path] | None,
+    skill_targets: list[str | Path] | None,
+    mcp_configs: list[str | Path] | None,
+    apply: bool,
+    record: bool,
+    fail_on_drift: bool,
+    timestamp: str,
+) -> tuple[AuditReport, int]:
+    errors: list[str] = []
+
+    # 1. Fetch release metadata
+    try:
+        release = fetch_release_payload(repo=repo, ref=ref, source_dir=source_dir)
+    except Exception as exc:
+        err_msg = redact_secrets(f"Release validation failed: {exc}")
+        report = AuditReport(
+            timestamp=timestamp,
+            release={"error": redact_secrets(str(exc))},
+            venvs=[],
+            mcp_configs=[],
+            skills=[],
+            applied=apply,
+            recorded=False,
+            has_drift=True,
+            errors=[err_msg],
+        )
+        try:
+            persist_state_report(report, state_dir)
+        except Exception as p_exc:
+            report.errors.append(redact_secrets(f"Failed to persist state report: {p_exc}"))
+
+        if record:
+            rec_ok = record_brain_log(vault_path, report)
+            report.recorded = rec_ok
+            try:
+                persist_state_report(report, state_dir)
+            except Exception as p_exc:
+                report.errors.append(
+                    redact_secrets(f"Failed to persist updated state report: {p_exc}")
+                )
+
+        return report, 1
+
+    downloaded_wheel_tmp: Path | None = None
+    try:
+        if apply:
+            if release.wheel_path is None and release.wheel_url and release.wheel_sha256:
+                try:
+                    downloaded_wheel_tmp = download_and_verify_wheel(
+                        wheel_url=release.wheel_url,
+                        expected_sha256=release.wheel_sha256,
+                        dest_dir=state_dir,
+                    )
+                    extracted_skills = _extract_wheel_skill_tree(downloaded_wheel_tmp)
+                    if release.skill_tree_sha256:
+                        actual_tree_hash = aggregate_tree_hash(extracted_skills)
+                        if actual_tree_hash != release.skill_tree_sha256:
+                            raise ReleaseValidationError(
+                                f"Extracted skill tree hash mismatch: expected {release.skill_tree_sha256}, got {actual_tree_hash}"
+                            )
+                    release = ReleasePayload(
+                        tag=release.tag,
+                        version=release.version,
+                        pyproject_version=release.pyproject_version,
+                        commit=release.commit,
+                        wheel_filename=release.wheel_filename,
+                        wheel_sha256=release.wheel_sha256,
+                        wheel_path=downloaded_wheel_tmp,
+                        wheel_url=release.wheel_url,
+                        skill_tree_sha256=release.skill_tree_sha256,
+                        skill_files=extracted_skills if extracted_skills else release.skill_files,
+                        manifest=release.manifest,
+                    )
+                except Exception as exc:
+                    err_msg = redact_secrets(f"Wheel download/verification failed: {exc}")
+                    errors.append(err_msg)
+            elif release.wheel_path is None and not release.skill_files:
+                errors.append(
+                    "Apply mode requires a verified release wheel; wheel asset or manifest SHA-256 is missing"
+                )
+
+        # 2. Discover and audit venvs
+        roots = venv_roots if venv_roots is not None else DEFAULT_VENV_ROOTS
+        venv_paths = discover_bounded_venvs(roots)
+        venv_results: list[VenvAuditResult] = []
+
+        for vp in venv_paths:
+            v_audit = audit_venv(vp, release.version)
+            if apply and v_audit.status == "outdated":
+                if release.wheel_path is None:
+                    v_audit.action_taken = "failed"
+                    v_audit.error = "No verified release wheel available for apply"
+                    errors.append(
+                        f"Venv update failed for {vp}: No verified release wheel available"
+                    )
+                else:
+                    action, err = apply_venv_update(v_audit, release, dry_run=False)
+                    v_audit.action_taken = action
+                    if err:
+                        v_audit.error = redact_secrets(err)
+                        errors.append(f"Venv update failed for {vp}: {redact_secrets(err)}")
+                    else:
+                        new_ver = get_venv_power_framework_version(vp)
+                        v_audit.installed_version = new_ver
+                        if new_ver == release.version:
+                            v_audit.status = "up_to_date"
+            venv_results.append(v_audit)
+
+        # 3. Audit MCP configs
+        mcp_paths = [
+            Path(p) for p in (mcp_configs if mcp_configs is not None else DEFAULT_MCP_CONFIGS)
+        ]
+        mcp_results: list[MCPAuditResult] = []
+        for mp in mcp_paths:
+            m_audit = audit_mcp_config(mp, target_version=release.version)
+            mcp_results.append(m_audit)
+
+        # 4. Audit Skills
+        allowed_roots: list[Path] = list(ALLOWED_SKILL_TARGET_ROOTS)
+        if skill_targets is not None:
+            for st in skill_targets:
+                st_p = Path(st).expanduser().resolve()
+                if not is_system_prefix(st_p.parent) and st_p.parent not in (
+                    Path("/"),
+                    Path("/root"),
+                ):
+                    allowed_roots.append(st_p.parent)
+
+        s_paths = [
+            Path(p) for p in (skill_targets if skill_targets is not None else DEFAULT_SKILL_TARGETS)
+        ]
+        skill_results: list[SkillAuditResult] = []
+        for sp in s_paths:
+            s_audit = audit_skill(sp, release, allowed_roots=allowed_roots)
+            if apply and s_audit.status in {"upgrade_ready", "ready"}:
+                if not release.skill_files:
+                    s_audit.action_taken = "failed"
+                    s_audit.error = "No verified skill files available for apply"
+                    errors.append(
+                        f"Skill update failed for {sp}: No verified skill files available"
+                    )
+                else:
+                    action, err = apply_skill_update(
+                        s_audit, release, dry_run=False, allowed_roots=allowed_roots
+                    )
+                    s_audit.action_taken = action
+                    if err:
+                        s_audit.error = redact_secrets(err)
+                        errors.append(f"Skill update failed for {sp}: {redact_secrets(err)}")
+                    else:
+                        re_audit = audit_skill(sp, release, allowed_roots=allowed_roots)
+                        s_audit.installed_version = re_audit.installed_version
+                        s_audit.tree_sha256 = re_audit.tree_sha256
+                        s_audit.file_count = re_audit.file_count
+                        s_audit.status = re_audit.status
+            skill_results.append(s_audit)
+
+        # Compute has_drift across all audit dimensions
+        has_drift = (
+            any(v.status in {"outdated", "unwritable", "broken_venv"} for v in venv_results)
+            or any(
+                m.status
+                in {
+                    "mismatch",
+                    "missing_entry",
+                    "missing_runtime",
+                    "outdated",
+                    "manual_review",
+                    "missing_file",
+                }
+                for m in mcp_results
+            )
+            or any(s.status in {"upgrade_ready", "ready", "manual_review"} for s in skill_results)
+        )
+
+        report = AuditReport(
+            timestamp=timestamp,
+            release=release.as_dict(),
+            venvs=venv_results,
+            mcp_configs=mcp_results,
+            skills=skill_results,
+            applied=apply,
+            recorded=False,
+            has_drift=has_drift,
+            errors=errors,
+        )
+
+        # Persist report
+        try:
+            persist_state_report(report, state_dir)
+        except Exception as exc:
+            errors.append(redact_secrets(f"Failed to persist state report: {exc}"))
+
+        # Record in canonical brain log if requested
+        if record:
+            rec_ok = record_brain_log(vault_path, report)
+            report.recorded = rec_ok
+            try:
+                persist_state_report(report, state_dir)
+            except Exception as exc:
+                errors.append(redact_secrets(f"Failed to persist updated state report: {exc}"))
+
+        exit_code = 0
+        if errors:
+            exit_code = 1
+        elif fail_on_drift and has_drift:
+            exit_code = 2
+
+        return report, exit_code
+    finally:
+        if downloaded_wheel_tmp is not None and downloaded_wheel_tmp.is_file():
+            with contextlib.suppress(OSError):
+                downloaded_wheel_tmp.unlink()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(
+        description="Host-side P.O.W.E.R version audit and update CLI.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output report as structured JSON",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply updates to outdated venvs and skills (default is read-only)",
+    )
+    parser.add_argument(
+        "--record",
+        action="store_true",
+        help="Record Action/Result entry in canonical brain log.md",
+    )
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help=f"GitHub repository (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--ref",
+        default=DEFAULT_REF,
+        help=f"Release tag or branch (default: {DEFAULT_REF})",
+    )
+    parser.add_argument(
+        "--vault",
+        type=Path,
+        default=DEFAULT_VAULT,
+        help=f"Obsidian brain vault directory (default: {DEFAULT_VAULT})",
+    )
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        default=DEFAULT_STATE_DIR,
+        help=f"Directory to persist audit reports (default: {DEFAULT_STATE_DIR})",
+    )
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        default=None,
+        help="Local repository or dist directory with release artifacts",
+    )
+    parser.add_argument(
+        "--venv-root",
+        action="append",
+        dest="venv_roots",
+        help="Virtual environment search root (can specify multiple times)",
+    )
+    parser.add_argument(
+        "--skill-target",
+        action="append",
+        dest="skill_targets",
+        help="Skill target directory (can specify multiple times)",
+    )
+    parser.add_argument(
+        "--mcp-config",
+        action="append",
+        dest="mcp_configs",
+        help="MCP configuration file path (can specify multiple times)",
+    )
+    parser.add_argument(
+        "--fail-on-drift",
+        action="store_true",
+        help="Return exit code 2 if version or configuration drift is detected",
+    )
+
+    args = parser.parse_args(argv)
+
+    report, code = run_audit(
+        repo=args.repo,
+        ref=args.ref,
+        source_dir=args.source_dir,
+        vault_path=args.vault,
+        state_dir=args.state_dir,
+        venv_roots=args.venv_roots,
+        skill_targets=args.skill_targets,
+        mcp_configs=args.mcp_configs,
+        apply=args.apply,
+        record=args.record,
+        fail_on_drift=args.fail_on_drift,
+    )
+
+    if args.json:
+        print(json.dumps(report.as_dict(), indent=2, ensure_ascii=False))
+    else:
+        print(format_human_report(report))
+
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_prxmx_power_runtime_audit.py
+++ b/tests/test_prxmx_power_runtime_audit.py
@@ -1242,15 +1242,36 @@ def test_audit_mcp_config_with_shell_wrapper(tmp_path: Path) -> None:
 
 
 def test_audit_mcp_extract_and_validate_structure(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    py_bin.chmod(0o755)
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    power_mcp = bin_dir / "power-mcp"
+    power_mcp.write_text(
+        f'#!/bin/sh\nexec {py_bin} -m power_framework.mcp "$@"\n',
+        encoding="utf-8",
+    )
+    power_mcp.chmod(0o755)
+
     config = tmp_path / "mcp_config.json"
     config.write_text(
         json.dumps(
             {
                 "mcpServers": {
                     "power": {
-                        "command": "/root/.local/bin/power-mcp",
+                        "command": str(power_mcp),
                         "args": [],
-                        "env": {"POWER_VAULT_DIR": "/root/geminicli/brain", "SECRET": "xyz"},
+                        "env": {"POWER_VAULT_DIR": "/custom/brain", "SECRET": "xyz"},
                     }
                 }
             }
@@ -1258,7 +1279,11 @@ def test_audit_mcp_extract_and_validate_structure(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     res = audit_mcp_config(config)
-    assert res.executable == "/root/.local/bin/power-mcp"
+    assert res.executable == str(power_mcp)
+    assert res.resolved_executable == str(power_mcp)
+    assert res.runtime_python == str(py_bin)
+    assert res.installed_version == "3.7.8"
+    assert res.status == "canonical"
     assert res.env_keys == ["POWER_VAULT_DIR", "SECRET"]
     assert "xyz" not in json.dumps(res.as_dict())
 
@@ -1297,16 +1322,31 @@ def test_is_safe_skill_relative_path_rules() -> None:
     assert is_safe_skill_relative_path(".hidden") is False
 
 
-def test_is_allowed_skill_target_protection() -> None:
+def test_is_allowed_skill_target_protection(tmp_path: Path) -> None:
     # Disallowed: system prefixes, root directory, user home root
     assert is_allowed_skill_target(Path("/usr/local/skills/power")) is False
     assert is_allowed_skill_target(Path("/etc/power")) is False
     assert is_allowed_skill_target(Path("/root")) is False
     assert is_allowed_skill_target(Path("/")) is False
 
-    # Allowed: standard default targets
-    assert is_allowed_skill_target(Path("/root/geminicli/.agents/skills/power")) is True
-    assert is_allowed_skill_target(Path("/root/.gemini/config/skills/power")) is True
+    # Allowed: valid non-system target under explicit allowed roots
+    allowed_root_1 = tmp_path / "agents_skills"
+    allowed_root_2 = tmp_path / "gemini_skills"
+    allowed_root_1.mkdir(parents=True)
+    allowed_root_2.mkdir(parents=True)
+
+    target_1 = allowed_root_1 / "power"
+    target_2 = allowed_root_2 / "power"
+    target_1.mkdir()
+    target_2.mkdir()
+
+    allowed_roots = [allowed_root_1, allowed_root_2]
+    assert is_allowed_skill_target(target_1, allowed_roots=allowed_roots) is True
+    assert is_allowed_skill_target(target_2, allowed_roots=allowed_roots) is True
+    assert (
+        is_allowed_skill_target(tmp_path / "disallowed" / "power", allowed_roots=allowed_roots)
+        is False
+    )
 
 
 def test_audit_skill_and_extract_metadata(tmp_path: Path) -> None:

--- a/tests/test_prxmx_power_runtime_audit.py
+++ b/tests/test_prxmx_power_runtime_audit.py
@@ -339,13 +339,7 @@ def test_fetch_local_release_wheel_hash_mismatch_fails_closed(tmp_path: Path) ->
 
 
 def test_fetch_from_github_api_failure_fails_closed() -> None:
-    http_err = urllib.error.HTTPError(
-        url="https://api.github.com/repos/test/releases/latest",
-        code=404,
-        msg="Not Found",
-        hdrs={},  # type: ignore[arg-type]
-        fp=None,
-    )
+    http_err = urllib.error.URLError("release endpoint unavailable")
     with (
         patch("urllib.request.urlopen", side_effect=http_err),
         pytest.raises(ReleaseValidationError, match="Could not resolve release"),
@@ -530,7 +524,7 @@ def test_fetch_from_github_wheel_asset_digest_without_manifest_succeeds() -> Non
         elif "pyproject.toml" in url:
             mock.read.return_value = pyproject_text.encode("utf-8")
         elif "power-release-manifest.json" in url:
-            raise urllib.error.HTTPError(url=url, code=404, msg="Not Found", hdrs={}, fp=None)  # type: ignore[arg-type]
+            raise urllib.error.URLError("manifest endpoint unavailable")
         return mock
 
     with patch("urllib.request.urlopen", side_effect=urlopen_side_effect):
@@ -1426,13 +1420,7 @@ def test_run_audit_release_failure_persists_state_and_log(tmp_path: Path) -> Non
 
     with patch(
         "urllib.request.urlopen",
-        side_effect=urllib.error.HTTPError(
-            url="https://api.github.com/repos/invalid/power/releases/latest",
-            code=404,
-            msg="Not Found",
-            hdrs={},  # type: ignore[arg-type]
-            fp=None,
-        ),
+        side_effect=urllib.error.URLError("release endpoint unavailable"),
     ):
         report, code = run_audit(
             repo="invalid/power",
@@ -1658,7 +1646,7 @@ def test_fetch_from_github_apply_requires_verified_wheel(tmp_path: Path) -> None
         elif "pyproject.toml" in url:
             mock.read.return_value = pyproject_text.encode("utf-8")
         elif "power-release-manifest.json" in url:
-            raise urllib.error.HTTPError(url=url, code=404, msg="Not Found", hdrs={}, fp=None)  # type: ignore[arg-type]
+            raise urllib.error.URLError("manifest endpoint unavailable")
         return mock
 
     state_dir = tmp_path / "state"
@@ -1721,7 +1709,7 @@ def test_fetch_from_github_apply_missing_wheel_digest_fails_closed(tmp_path: Pat
         elif "pyproject.toml" in url:
             mock.read.return_value = pyproject_text.encode("utf-8")
         elif "power-release-manifest.json" in url:
-            raise urllib.error.HTTPError(url=url, code=404, msg="Not Found", hdrs={}, fp=None)  # type: ignore[arg-type]
+            raise urllib.error.URLError("manifest endpoint unavailable")
         return mock
 
     state_dir = tmp_path / "state"

--- a/tests/test_prxmx_power_runtime_audit.py
+++ b/tests/test_prxmx_power_runtime_audit.py
@@ -1,0 +1,2258 @@
+"""Hermetic unit tests for host-side P.O.W.E.R runtime audit and update CLI."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+import zipfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.prxmx_power_runtime_audit import (
+    ALLOWED_SKILL_DIRECTORIES,
+    ALLOWED_SKILL_EXTENSIONS,
+    ALLOWED_SKILL_TOP_LEVEL_FILES,
+    DEFAULT_MCP_CONFIGS,
+    MAX_WRAPPER_DEPTH,
+    AuditReport,
+    ProcessLock,
+    ReleasePayload,
+    ReleaseValidationError,
+    SkillAuditResult,
+    VenvAuditResult,
+    _extract_exec_python_from_wrapper,
+    _extract_exec_target_from_wrapper,
+    _extract_wheel_skill_tree,
+    _read_pyproject_version_from_text,
+    aggregate_tree_hash,
+    apply_skill_update,
+    apply_venv_update,
+    audit_mcp_config,
+    audit_skill,
+    audit_venv,
+    compare_versions,
+    discover_bounded_venvs,
+    download_and_verify_wheel,
+    extract_skill_version,
+    fetch_release_payload,
+    find_venv_pip,
+    find_venv_python,
+    format_human_report,
+    get_venv_power_framework_version,
+    has_jsonc_comments,
+    is_allowed_skill_target,
+    is_managed_skill_tree,
+    is_python_interpreter,
+    is_safe_skill_relative_path,
+    is_system_prefix,
+    main,
+    parse_version,
+    persist_state_report,
+    record_brain_log,
+    redact_secrets,
+    resolve_mcp_runtime,
+    run_audit,
+    sha256_file,
+    strip_jsonc_comments,
+    tree_from_directory,
+)
+
+# ============================================================================
+# 1. Version Parsing and Prerelease Comparison Tests
+# ============================================================================
+
+
+def test_parse_version_semver_and_pep440() -> None:
+    assert parse_version("3.7.8")[0] == (3, 7, 8)
+    assert parse_version("v3.7.8")[0] == (3, 7, 8)
+    assert parse_version("3.7.8.post1")[1] == 1  # post release phase
+    assert parse_version("3.7.8.post1")[3] == 1  # post release number
+    assert parse_version("3.8.0a2")[1] == -3  # alpha phase
+    assert parse_version("3.8.0a2")[2] == 2  # alpha number
+    assert parse_version("  v1.0.0-beta.1  ")[1] == -2  # beta phase
+    assert parse_version("  v1.0.0-beta.1  ")[2] == 1  # beta number
+    assert parse_version("3.8.0.dev3")[1] == -4  # dev phase
+    assert parse_version("3.8.0.dev3")[2] == 3  # dev number
+    assert parse_version("3.8.0rc1")[1] == -1  # rc phase
+    assert parse_version("invalid")[0] == (0,)
+
+
+def test_compare_versions_prerelease_and_postrelease_ordering() -> None:
+    # PEP 440 order: dev < alpha < beta < rc < stable < post
+    assert compare_versions("3.8.0.dev1", "3.8.0a1") == -1
+    assert compare_versions("3.8.0a1", "3.8.0a2") == -1
+    assert compare_versions("3.8.0a2", "3.8.0b1") == -1
+    assert compare_versions("3.8.0b1", "3.8.0rc1") == -1
+    assert compare_versions("3.8.0rc1", "3.8.0") == -1
+    assert compare_versions("3.8.0", "3.8.0.post1") == -1
+    assert compare_versions("3.8.0.post1", "3.8.1") == -1
+
+    # Symmetry
+    assert compare_versions("3.8.0", "3.8.0rc1") == 1
+    assert compare_versions("3.8.0a2", "3.8.0.dev1") == 1
+    assert compare_versions("3.8.0.post1", "3.8.0") == 1
+
+    # Stable equivalence
+    assert compare_versions("3.7.8", "3.7.8") == 0
+    assert compare_versions("3.7.0", "3.7") == 0
+    assert compare_versions("3.7.7", "3.7.8") == -1
+    assert compare_versions("3.8.0", "3.7.8") == 1
+    assert compare_versions("3.10.0", "3.9.9") == 1
+
+
+# ============================================================================
+# 2. Tokenizer-Based JSONC Comment Detection Tests
+# ============================================================================
+
+
+def test_has_jsonc_comments_tokenizer() -> None:
+    # True positives: actual comments outside strings
+    assert has_jsonc_comments('{\n  // single line comment\n  "key": "val"\n}') is True
+    assert has_jsonc_comments('{\n  /* multi\n line */\n  "key": "val"\n}') is True
+    assert has_jsonc_comments('{"a": 1} // trailing comment') is True
+    assert has_jsonc_comments('{"a": 1} /* inline */') is True
+
+    # False positive guards: // or /* inside JSON strings
+    assert has_jsonc_comments('{\n  "url": "https://example.com/foo//bar"\n}') is False
+    assert has_jsonc_comments('{\n  "path": "/root//data/*"\n}') is False
+    assert has_jsonc_comments('{\n  "text": "This is // not a comment"\n}') is False
+    assert has_jsonc_comments('{\n  "text": "/* also not a comment */"\n}') is False
+    assert has_jsonc_comments('{\n  "escaped": "Quote \\" and // still in string"\n}') is False
+    assert has_jsonc_comments('{"clean": true}') is False
+
+
+def test_strip_jsonc_comments_tokenizer() -> None:
+    raw_jsonc = """{
+      // Header comment
+      "name": "power", /* inline block comment */
+      "endpoint": "https://example.com/api//v1",
+      "path": "/root//data/*",
+      "escaped_quote": "Quote \\" with // inside",
+      "escaped_backslash": "Path C:\\\\ // not a comment",
+      "block_in_string": "/* not a comment */",
+      /* Multi-line
+         block comment
+         with * and / symbols ***/
+      "mcp": {
+        "command": "power-mcp" // trailing comment
+      }
+      // EOF comment without trailing newline
+    }"""
+    stripped = strip_jsonc_comments(raw_jsonc)
+    data = json.loads(stripped)
+    assert data["name"] == "power"
+    assert data["endpoint"] == "https://example.com/api//v1"
+    assert data["path"] == "/root//data/*"
+    assert data["escaped_quote"] == 'Quote " with // inside'
+    assert data["escaped_backslash"] == "Path C:\\ // not a comment"
+    assert data["block_in_string"] == "/* not a comment */"
+    assert data["mcp"]["command"] == "power-mcp"
+
+
+# ============================================================================
+# 3. Default PRXMX MCP Configs Hardening Tests
+# ============================================================================
+
+
+def test_default_mcp_configs_matches_prxmx_canonical_paths() -> None:
+    expected = [
+        "/root/.config/opencode/opencode.jsonc",
+        "/root/.gemini/config/mcp_config.json",
+        "/root/.codex/config.toml",
+        "/root/.codex/mcp.json",
+    ]
+    assert expected == DEFAULT_MCP_CONFIGS
+    # Ensure stale nonexistent Gemini settings paths are not present
+    assert "/root/.gemini/settings.json" not in DEFAULT_MCP_CONFIGS
+    assert "/root/.gemini/antigravity-cli/settings.json" not in DEFAULT_MCP_CONFIGS
+
+
+# ============================================================================
+# 4. pyproject.toml Parsing with tomllib
+# ============================================================================
+
+
+def test_read_pyproject_version_from_text() -> None:
+    # Standard [project] table
+    content1 = '[project]\nname = "power-framework"\nversion = "3.7.8"\n'
+    assert _read_pyproject_version_from_text(content1) == "3.7.8"
+
+    # Poetry table fallback
+    content2 = '[tool.poetry]\nname = "power-framework"\nversion = "3.8.0a1"\n'
+    assert _read_pyproject_version_from_text(content2) == "3.8.0a1"
+
+    # Invalid TOML
+    with pytest.raises(ReleaseValidationError, match=r"Invalid pyproject\.toml TOML"):
+        _read_pyproject_version_from_text("[project\nversion = invalid")
+
+    # Missing version field
+    with pytest.raises(ReleaseValidationError, match=r"missing project\.version"):
+        _read_pyproject_version_from_text('[project]\nname = "power-framework"\n')
+
+
+# ============================================================================
+# 5. Tree Hashing, Directory Scanning, and Redaction Tests
+# ============================================================================
+
+
+def test_aggregate_tree_hash_is_deterministic() -> None:
+    files1 = {
+        "SKILL.md": b"---\nname: power\nversion: 3.7.8\n---\n",
+        "references/workflow.md": b"# Workflow\n",
+    }
+    files2 = {
+        "references/workflow.md": b"# Workflow\n",
+        "SKILL.md": b"---\nname: power\nversion: 3.7.8\n---\n",
+    }
+    assert aggregate_tree_hash(files1) == aggregate_tree_hash(files2)
+    assert len(aggregate_tree_hash(files1)) == 64
+
+
+def test_tree_from_directory_ignores_bytecode_and_symlinks(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Skill\n", encoding="utf-8")
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references" / "ref.md").write_text("# Ref\n", encoding="utf-8")
+
+    pycache = skill_dir / "__pycache__"
+    pycache.mkdir()
+    (pycache / "module.cpython-313.pyc").write_bytes(b"bytecode")
+    (skill_dir / "stray.pyc").write_bytes(b"bytecode")
+
+    # Symlink inside directory should be ignored
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text("secret", encoding="utf-8")
+    symlink_file = skill_dir / "link.txt"
+    symlink_file.symlink_to(secret_file)
+
+    tree = tree_from_directory(skill_dir)
+    assert "SKILL.md" in tree
+    assert "references/ref.md" in tree
+    assert "__pycache__/module.cpython-313.pyc" not in tree
+    assert "stray.pyc" not in tree
+    assert "link.txt" not in tree
+
+
+def test_sha256_file(tmp_path: Path) -> None:
+    f = tmp_path / "sample.txt"
+    f.write_text("Hello POWER\n", encoding="utf-8")
+    expected = "115f7a56f31fd80f08e658904b713c0372c8182a45aac1ace319ec5f2bdc9c4f"
+    assert sha256_file(f) == expected
+
+
+def test_redact_secrets() -> None:
+    raw1 = "Authorization: Bearer token=<set-via-env>"
+    assert "token=<set-via-env>" not in redact_secrets(raw1)
+    assert "[REDACTED]" in redact_secrets(raw1)
+
+    raw2 = "Error: password: <set-via-env> on host"
+    assert "<set-via-env>" not in redact_secrets(raw2)
+
+
+# ============================================================================
+# 6. Release Payload Fetching, Wheel Extraction & Fallback Protection
+# ============================================================================
+
+
+def test_fetch_local_release_supports_agents_skills_power(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "power-framework"\nversion = "3.7.8"\n',
+        encoding="utf-8",
+    )
+    # Source skill in .agents/skills/power
+    skill_dir = repo / ".agents" / "skills" / "power"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: power\nversion: 3.7.8\n---\n",
+        encoding="utf-8",
+    )
+
+    payload = fetch_release_payload(source_dir=repo)
+    assert payload.version == "3.7.8"
+    assert "SKILL.md" in payload.skill_files
+
+
+def test_fetch_local_release_prerelease_for_latest_fails_closed(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "power-framework"\nversion = "3.8.0rc1"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ReleaseValidationError, match="not a stable release"):
+        fetch_release_payload(source_dir=repo, ref="latest")
+
+
+def test_fetch_local_release_manifest_schema_mismatch_fails_closed(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "power-framework"\nversion = "3.7.8"\n',
+        encoding="utf-8",
+    )
+    rel_dir = repo / "release"
+    rel_dir.mkdir()
+    (rel_dir / "power-release-manifest.json").write_text(
+        json.dumps({"schema": "invalid.schema.v99", "version": "3.7.8"}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ReleaseValidationError, match="Unsupported release manifest schema"):
+        fetch_release_payload(source_dir=repo)
+
+
+def test_fetch_local_release_wheel_hash_mismatch_fails_closed(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "power-framework"\nversion = "3.7.8"\n',
+        encoding="utf-8",
+    )
+    rel_dir = repo / "release"
+    rel_dir.mkdir()
+    manifest_data = {
+        "schema": "power.release.manifest.v1",
+        "version": "3.7.8",
+        "artifacts": {
+            "power_wheel": {
+                "filename": "power_framework-3.7.8-py3-none-any.whl",
+                "sha256": "0" * 64,
+            }
+        },
+    }
+    (rel_dir / "power-release-manifest.json").write_text(
+        json.dumps(manifest_data),
+        encoding="utf-8",
+    )
+    dist_dir = repo / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "power_framework-3.7.8-py3-none-any.whl").write_bytes(b"corrupted content")
+
+    with pytest.raises(ReleaseValidationError, match="Wheel digest mismatch"):
+        fetch_release_payload(source_dir=repo)
+
+
+def test_fetch_from_github_api_failure_fails_closed() -> None:
+    http_err = urllib.error.HTTPError(
+        url="https://api.github.com/repos/test/releases/latest",
+        code=404,
+        msg="Not Found",
+        hdrs={},  # type: ignore[arg-type]
+        fp=None,
+    )
+    with (
+        patch("urllib.request.urlopen", side_effect=http_err),
+        pytest.raises(ReleaseValidationError, match="Could not resolve release"),
+    ):
+        fetch_release_payload(repo="weby-homelab/power-framework", ref="latest")
+
+
+def test_fetch_from_github_rejects_prerelease_on_latest() -> None:
+    release_resp = MagicMock()
+    release_resp.read.return_value = json.dumps(
+        {
+            "tag_name": "v3.8.0rc1",
+            "prerelease": True,
+            "draft": False,
+        }
+    ).encode("utf-8")
+    release_resp.__enter__.return_value = release_resp
+
+    with (
+        patch("urllib.request.urlopen", return_value=release_resp),
+        pytest.raises(ReleaseValidationError, match="prerelease"),
+    ):
+        fetch_release_payload(repo="weby-homelab/power-framework", ref="latest")
+
+
+def test_fetch_from_github_wheel_asset_mismatch_fails_closed() -> None:
+    release_json = {
+        "tag_name": "v3.7.8",
+        "prerelease": False,
+        "draft": False,
+        "assets": [
+            {
+                "name": "power_framework-3.7.8-py3-none-any.whl",
+                "browser_download_url": "https://example.com/power_framework-3.7.8-py3-none-any.whl",
+            }
+        ],
+    }
+    pyproject_text = '[project]\nname = "power-framework"\nversion = "3.7.8"\n'
+    manifest_json = {
+        "schema": "power.release.manifest.v1",
+        "version": "3.7.8",
+        "artifacts": {
+            "power_wheel": {
+                "filename": "power_framework-3.7.8-mismatched.whl",
+                "sha256": "a" * 64,
+            }
+        },
+    }
+
+    def urlopen_side_effect(req: urllib.request.Request, **kwargs: Any) -> MagicMock:
+        url = req.full_url
+        mock = MagicMock()
+        mock.__enter__.return_value = mock
+        if "releases" in url:
+            mock.read.return_value = json.dumps(release_json).encode("utf-8")
+        elif "pyproject.toml" in url:
+            mock.read.return_value = pyproject_text.encode("utf-8")
+        elif "power-release-manifest.json" in url:
+            mock.read.return_value = json.dumps(manifest_json).encode("utf-8")
+        return mock
+
+    with (
+        patch("urllib.request.urlopen", side_effect=urlopen_side_effect),
+        pytest.raises(ReleaseValidationError, match="does not match manifest wheel"),
+    ):
+        fetch_release_payload(repo="weby-homelab/power-framework", ref="latest")
+
+
+def test_fetch_from_github_wheel_asset_digest_manifest_mismatch_fails_closed() -> None:
+    manifest_sha = "a" * 64
+    asset_digest = "sha256:" + "b" * 64
+    release_json = {
+        "tag_name": "v3.7.8",
+        "prerelease": False,
+        "draft": False,
+        "assets": [
+            {
+                "name": "power_framework-3.7.8-py3-none-any.whl",
+                "browser_download_url": "https://example.com/power_framework-3.7.8-py3-none-any.whl",
+                "digest": asset_digest,
+            }
+        ],
+    }
+    pyproject_text = '[project]\nname = "power-framework"\nversion = "3.7.8"\n'
+    manifest_json = {
+        "schema": "power.release.manifest.v1",
+        "version": "3.7.8",
+        "artifacts": {
+            "power_wheel": {
+                "filename": "power_framework-3.7.8-py3-none-any.whl",
+                "sha256": manifest_sha,
+            }
+        },
+    }
+
+    def urlopen_side_effect(req: urllib.request.Request, **kwargs: Any) -> MagicMock:
+        url = req.full_url
+        mock = MagicMock()
+        mock.__enter__.return_value = mock
+        if "releases" in url:
+            mock.read.return_value = json.dumps(release_json).encode("utf-8")
+        elif "pyproject.toml" in url:
+            mock.read.return_value = pyproject_text.encode("utf-8")
+        elif "power-release-manifest.json" in url:
+            mock.read.return_value = json.dumps(manifest_json).encode("utf-8")
+        return mock
+
+    with (
+        patch("urllib.request.urlopen", side_effect=urlopen_side_effect),
+        pytest.raises(ReleaseValidationError, match="does not match manifest wheel SHA-256"),
+    ):
+        fetch_release_payload(repo="weby-homelab/power-framework", ref="latest")
+
+
+def test_fetch_from_github_wheel_asset_digest_matching_succeeds() -> None:
+    manifest_sha = "a" * 64
+    asset_digest = "SHA256:" + "a" * 64
+    release_json = {
+        "tag_name": "v3.7.8",
+        "prerelease": False,
+        "draft": False,
+        "assets": [
+            {
+                "name": "power_framework-3.7.8-py3-none-any.whl",
+                "browser_download_url": "https://example.com/power_framework-3.7.8-py3-none-any.whl",
+                "digest": asset_digest,
+            }
+        ],
+    }
+    pyproject_text = '[project]\nname = "power-framework"\nversion = "3.7.8"\n'
+    manifest_json = {
+        "schema": "power.release.manifest.v1",
+        "version": "3.7.8",
+        "artifacts": {
+            "power_wheel": {
+                "filename": "power_framework-3.7.8-py3-none-any.whl",
+                "sha256": manifest_sha,
+            }
+        },
+    }
+
+    def urlopen_side_effect(req: urllib.request.Request, **kwargs: Any) -> MagicMock:
+        url = req.full_url
+        mock = MagicMock()
+        mock.__enter__.return_value = mock
+        if "releases" in url:
+            mock.read.return_value = json.dumps(release_json).encode("utf-8")
+        elif "pyproject.toml" in url:
+            mock.read.return_value = pyproject_text.encode("utf-8")
+        elif "power-release-manifest.json" in url:
+            mock.read.return_value = json.dumps(manifest_json).encode("utf-8")
+        return mock
+
+    with patch("urllib.request.urlopen", side_effect=urlopen_side_effect):
+        payload = fetch_release_payload(repo="weby-homelab/power-framework", ref="latest")
+        assert payload.wheel_sha256 == "a" * 64
+        assert payload.wheel_filename == "power_framework-3.7.8-py3-none-any.whl"
+
+
+def test_fetch_from_github_wheel_asset_digest_without_manifest_succeeds() -> None:
+    asset_digest = "sha256:" + "c" * 64
+    release_json = {
+        "tag_name": "v3.7.8",
+        "prerelease": False,
+        "draft": False,
+        "assets": [
+            {
+                "name": "power_framework-3.7.8-py3-none-any.whl",
+                "browser_download_url": "https://example.com/power_framework-3.7.8-py3-none-any.whl",
+                "digest": asset_digest,
+            }
+        ],
+    }
+    pyproject_text = '[project]\nname = "power-framework"\nversion = "3.7.8"\n'
+
+    def urlopen_side_effect(req: urllib.request.Request, **kwargs: Any) -> MagicMock:
+        url = req.full_url
+        mock = MagicMock()
+        mock.__enter__.return_value = mock
+        if "releases" in url:
+            mock.read.return_value = json.dumps(release_json).encode("utf-8")
+        elif "pyproject.toml" in url:
+            mock.read.return_value = pyproject_text.encode("utf-8")
+        elif "power-release-manifest.json" in url:
+            raise urllib.error.HTTPError(url=url, code=404, msg="Not Found", hdrs={}, fp=None)  # type: ignore[arg-type]
+        return mock
+
+    with patch("urllib.request.urlopen", side_effect=urlopen_side_effect):
+        payload = fetch_release_payload(repo="weby-homelab/power-framework", ref="latest")
+        assert payload.wheel_sha256 == "c" * 64
+
+
+def test_extract_wheel_skill_tree_path_traversal_protection(tmp_path: Path) -> None:
+    wheel_file = tmp_path / "malicious.whl"
+
+    with zipfile.ZipFile(wheel_file, "w") as zf:
+        zf.writestr("power_framework/data/skills/power/../../evil.sh", "echo evil")
+
+    with pytest.raises(ReleaseValidationError, match="Unsafe or disallowed path"):
+        _extract_wheel_skill_tree(wheel_file)
+
+
+def test_download_and_verify_wheel(tmp_path: Path) -> None:
+    import hashlib
+
+    dummy_wheel = b"PK\x03\x04dummy_wheel_content"
+    wheel_hash = hashlib.sha256(dummy_wheel).hexdigest()
+
+    resp_mock = MagicMock()
+    resp_mock.read.side_effect = [dummy_wheel, b""]
+    resp_mock.__enter__.return_value = resp_mock
+
+    with patch("urllib.request.urlopen", return_value=resp_mock):
+        downloaded = download_and_verify_wheel(
+            wheel_url="https://example.com/wheel.whl",
+            expected_sha256=wheel_hash,
+            dest_dir=tmp_path,
+        )
+        assert downloaded.is_file()
+        assert sha256_file(downloaded) == wheel_hash
+
+
+def test_download_and_verify_wheel_digest_mismatch_fails_closed(tmp_path: Path) -> None:
+    dummy_wheel = b"PK\x03\x04dummy_wheel_content"
+    resp_mock = MagicMock()
+    resp_mock.read.side_effect = [dummy_wheel, b""]
+    resp_mock.__enter__.return_value = resp_mock
+
+    with (
+        patch("urllib.request.urlopen", return_value=resp_mock),
+        pytest.raises(ReleaseValidationError, match="SHA-256 mismatch"),
+    ):
+        download_and_verify_wheel(
+            wheel_url="https://example.com/wheel.whl",
+            expected_sha256="0" * 64,
+            dest_dir=tmp_path,
+        )
+
+
+# ============================================================================
+# 7. Bounded Virtual Environments Discovery, pip3 / python3 & Root Guards
+# ============================================================================
+
+
+def test_is_system_prefix() -> None:
+    assert is_system_prefix(Path("/")) is True
+    assert is_system_prefix(Path("/var")) is True
+    assert is_system_prefix(Path("/var/log")) is True
+    assert is_system_prefix(Path("/var/lib/venvs/test")) is True
+    assert is_system_prefix(Path("/run")) is True
+    assert is_system_prefix(Path("/run/user/1000")) is True
+    assert is_system_prefix(Path("/usr/bin/python3")) is True
+    assert is_system_prefix(Path("/usr/lib/python3.13")) is True
+    assert is_system_prefix(Path("/bin/sh")) is True
+    assert is_system_prefix(Path("/etc/passwd")) is True
+    assert is_system_prefix(Path("/root/.local/share/power/venv")) is False
+    assert is_system_prefix(Path("/root/geminicli/projects/P.O.W.E.R/.venv")) is False
+
+
+def test_discover_bounded_venvs_with_python3_and_pip3(tmp_path: Path) -> None:
+    root = tmp_path / "venvs"
+    root.mkdir()
+
+    # Venv with bin/python3 and bin/pip3 (no bin/python or bin/pip)
+    venv1 = root / "venv_py3"
+    venv1.mkdir()
+    (venv1 / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding="utf-8")
+    bin1 = venv1 / "bin"
+    bin1.mkdir()
+    (bin1 / "python3").write_text("#!/bin/sh\n", encoding="utf-8")
+    (bin1 / "pip3").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    dist_info = venv1 / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    discovered = discover_bounded_venvs([root])
+    assert venv1.resolve() in discovered
+    assert find_venv_python(venv1) == bin1 / "python3"
+    assert find_venv_pip(venv1) == [str(bin1 / "pip3")]
+    assert get_venv_power_framework_version(venv1) == "3.7.8"
+
+
+def test_audit_venv_system_prefix_guard() -> None:
+    res = audit_venv(Path("/usr"), "3.7.8")
+    assert res.status == "unwritable"
+    assert "System Python" in str(res.error)
+
+
+def test_get_venv_power_framework_version_system_prefix_exclusion() -> None:
+    for prefix in (
+        "/",
+        "/usr",
+        "/var",
+        "/run",
+        "/bin",
+        "/sbin",
+        "/lib",
+        "/lib64",
+        "/opt/local",
+        "/etc",
+        "/sys",
+        "/proc",
+        "/dev",
+    ):
+        assert get_venv_power_framework_version(Path(prefix)) is None
+
+
+def test_apply_venv_update_prohibits_unverified_pypi(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    venv.mkdir()
+    (venv / "bin").mkdir()
+    (venv / "bin" / "python").write_text("#!/bin/sh\n", encoding="utf-8")
+    (venv / "bin" / "pip").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    audit = VenvAuditResult(
+        path=str(venv),
+        python_path=str(venv / "bin" / "python"),
+        installed_version="3.4.5",
+        is_writable=True,
+        status="outdated",
+    )
+    rel = ReleasePayload(tag="v3.7.8", version="3.7.8", pyproject_version="3.7.8", wheel_path=None)
+    action, err = apply_venv_update(audit, rel, dry_run=False)
+    assert action == "failed"
+    assert "unverified PyPI is prohibited" in str(err)
+
+
+# ============================================================================
+# 8. MCP Client Config & Runtime Shebang Inspection Tests
+# ============================================================================
+
+
+def test_resolve_mcp_runtime_via_shebang(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    power_mcp = bin_dir / "power-mcp"
+    power_mcp.write_text(f"#!{py_bin}\nimport sys\n", encoding="utf-8")
+    power_mcp.chmod(0o755)
+
+    exe, run_py, inst_ver, err = resolve_mcp_runtime(str(power_mcp))
+    assert exe == str(power_mcp)
+    assert run_py == str(py_bin)
+    assert inst_ver == "3.7.8"
+    assert err is None
+
+
+def test_resolve_mcp_runtime_env_shebang_via_which(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    fake_python = bin_dir / "python3"
+    fake_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    fake_python.chmod(0o755)
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    power_mcp = bin_dir / "power-mcp"
+    power_mcp.write_text("#!/usr/bin/env python3\nimport sys\n", encoding="utf-8")
+    power_mcp.chmod(0o755)
+
+    with patch("shutil.which", return_value=str(fake_python)):
+        exe, run_py, inst_ver, err = resolve_mcp_runtime(str(power_mcp))
+        assert exe == str(power_mcp)
+        assert run_py == str(fake_python)
+        assert inst_ver == "3.7.8"
+        assert err is None
+
+
+def test_audit_mcp_config_outdated_runtime(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.4.5.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.4.5\n",
+        encoding="utf-8",
+    )
+
+    power_mcp = bin_dir / "power-mcp"
+    power_mcp.write_text(f"#!{py_bin}\nimport sys\n", encoding="utf-8")
+
+    config = tmp_path / "opencode.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "power": {
+                        "type": "local",
+                        "command": [str(power_mcp)],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    res = audit_mcp_config(config, target_version="3.7.8")
+    assert res.status == "outdated"
+    assert res.installed_version == "3.4.5"
+
+
+def test_audit_mcp_config_missing_runtime(tmp_path: Path) -> None:
+    config = tmp_path / "mcp_config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "power": {
+                        "command": "/non/existent/path/to/power-mcp",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    res = audit_mcp_config(config, target_version="3.7.8")
+    assert res.status == "missing_runtime"
+
+
+def test_audit_mcp_foreign_entry_marked_mismatch(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('[mcp_servers.power]\ncommand = "some-foreign-cmd"\n', encoding="utf-8")
+
+    res = audit_mcp_config(config)
+    assert res.status == "mismatch"
+
+
+def test_is_python_interpreter_matrix() -> None:
+    # Valid python interpreter paths and names
+    assert is_python_interpreter("python") is True
+    assert is_python_interpreter("python3") is True
+    assert is_python_interpreter("python3.11") is True
+    assert is_python_interpreter("python3.13") is True
+    assert is_python_interpreter("python3.13t") is True
+    assert is_python_interpreter("python.exe") is True
+    assert is_python_interpreter("pypy3") is True
+    assert is_python_interpreter(Path("/root/venv/bin/python")) is True
+    assert is_python_interpreter(Path("/usr/bin/python3.13")) is True
+
+    # Shells and non-python binaries MUST be rejected
+    assert is_python_interpreter("/bin/sh") is False
+    assert is_python_interpreter("/bin/bash") is False
+    assert is_python_interpreter("sh") is False
+    assert is_python_interpreter("bash") is False
+    assert is_python_interpreter("dash") is False
+    assert is_python_interpreter("zsh") is False
+    assert is_python_interpreter("ksh") is False
+    assert is_python_interpreter("fish") is False
+    assert is_python_interpreter("busybox") is False
+    assert is_python_interpreter("env") is False
+    assert is_python_interpreter("node") is False
+    assert is_python_interpreter("perl") is False
+    assert is_python_interpreter("ruby") is False
+    assert is_python_interpreter("power-mcp") is False
+    assert is_python_interpreter("") is False
+
+
+def test_resolve_mcp_runtime_shell_wrapper_with_exec_resolves_venv_python(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    py_bin.chmod(0o755)
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    # Shell wrapper at /tmp_path/local_bin/power-mcp
+    local_bin = tmp_path / "local_bin"
+    local_bin.mkdir()
+    power_mcp = local_bin / "power-mcp"
+    power_mcp.write_text(
+        f'#!/bin/sh\nexec {py_bin} -m power_framework.mcp "$@"\n',
+        encoding="utf-8",
+    )
+    power_mcp.chmod(0o755)
+
+    exe, run_py, inst_ver, err = resolve_mcp_runtime(str(power_mcp))
+    assert exe == str(power_mcp)
+    assert run_py == str(py_bin)
+    assert inst_ver == "3.7.8"
+    assert err is None
+
+
+def test_resolve_mcp_runtime_shell_wrapper_variants_quoted_and_multiline(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python3"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    py_bin.chmod(0o755)
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    local_bin = tmp_path / "local_bin"
+    local_bin.mkdir()
+
+    # 1. Double-quoted exec with environment variables
+    wrapper1 = local_bin / "wrapper1"
+    wrapper1.write_text(
+        f'#!/bin/bash\nexport POWER_VAULT_DIR="/root/brain"\nexec "{py_bin}" -m power_framework.mcp "$@"\n',
+        encoding="utf-8",
+    )
+    wrapper1.chmod(0o755)
+    exe1, run_py1, inst_ver1, err1 = resolve_mcp_runtime(str(wrapper1))
+    assert exe1 == str(wrapper1)
+    assert run_py1 == str(py_bin)
+    assert inst_ver1 == "3.7.8"
+    assert err1 is None
+
+    # 2. Single-quoted exec with semicolon
+    wrapper2 = local_bin / "wrapper2"
+    wrapper2.write_text(
+        f"#!/bin/sh\ncd /tmp; exec '{py_bin}' \"$@\"\n",
+        encoding="utf-8",
+    )
+    wrapper2.chmod(0o755)
+    exe2, run_py2, inst_ver2, err2 = resolve_mcp_runtime(str(wrapper2))
+    assert exe2 == str(wrapper2)
+    assert run_py2 == str(py_bin)
+    assert inst_ver2 == "3.7.8"
+    assert err2 is None
+
+
+def test_extract_exec_python_from_wrapper_unit(tmp_path: Path) -> None:
+    fake_py = tmp_path / "bin" / "python3"
+    fake_py.parent.mkdir(parents=True)
+    fake_py.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    content1 = f'#!/bin/sh\nexec "{fake_py}" -m power_framework.mcp "$@"\n'
+    assert _extract_exec_python_from_wrapper(content1) == fake_py
+
+    content2 = f"#!/bin/bash\n# comment\nexec '{fake_py}' \"$@\"\n"
+    assert _extract_exec_python_from_wrapper(content2) == fake_py
+
+    # Non-existent python returns None
+    content_missing = '#!/bin/sh\nexec "/nonexistent/python" "$@"\n'
+    assert _extract_exec_python_from_wrapper(content_missing) is None
+
+    # Shell executable returns None
+    content_sh = '#!/bin/sh\nexec "/bin/sh" "$@"\n'
+    assert _extract_exec_python_from_wrapper(content_sh) is None
+
+    # No exec line returns None
+    assert _extract_exec_python_from_wrapper("#!/bin/sh\necho hello\n") is None
+
+
+def test_resolve_mcp_runtime_shell_wrapper_never_treats_bin_sh_as_python(tmp_path: Path) -> None:
+    local_bin = tmp_path / "local_bin"
+    local_bin.mkdir()
+
+    # Shell script without Python exec
+    wrapper_sh = local_bin / "power-mcp"
+    wrapper_sh.write_text("#!/bin/sh\necho 'running shell wrapper'\n", encoding="utf-8")
+    wrapper_sh.chmod(0o755)
+
+    exe, run_py, inst_ver, err = resolve_mcp_runtime(str(wrapper_sh))
+    assert exe == str(wrapper_sh)
+    assert run_py != "/bin/sh"
+    assert run_py is None
+    assert inst_ver is None
+    assert err is None
+
+    # Shell script execing /bin/sh
+    wrapper_exec_sh = local_bin / "power-mcp-sh"
+    wrapper_exec_sh.write_text('#!/bin/sh\nexec /bin/sh "$@"\n', encoding="utf-8")
+    wrapper_exec_sh.chmod(0o755)
+
+    exe2, run_py2, inst_ver2, err2 = resolve_mcp_runtime(str(wrapper_exec_sh))
+    assert exe2 == str(wrapper_exec_sh)
+    assert run_py2 != "/bin/sh"
+    assert run_py2 is None
+    assert inst_ver2 is None
+    assert err2 is None
+
+
+def test_extract_exec_target_from_wrapper_unit(tmp_path: Path) -> None:
+    fake_py = tmp_path / "bin" / "python3"
+    base_dir = tmp_path / "wrappers"
+    base_dir.mkdir(parents=True)
+
+    # 1. Absolute target
+    content_abs = f'#!/bin/sh\nexec "{fake_py}" -m power_framework.mcp "$@"\n'
+    assert _extract_exec_target_from_wrapper(content_abs) == fake_py
+
+    # 2. Relative target with base_dir
+    content_rel = '#!/bin/sh\nexec ../bin/python3 "$@"\n'
+    assert _extract_exec_target_from_wrapper(content_rel, base_dir=base_dir) == fake_py.resolve()
+
+    # 3. Target with spaces in quotes
+    spaced_target = tmp_path / "my bin" / "power-mcp"
+    content_spaced = f'#!/bin/sh\nexec "{spaced_target}" "$@"\n'
+    assert _extract_exec_target_from_wrapper(content_spaced) == spaced_target
+
+    # 4. Command preceded by export or cd
+    content_multi = f'#!/bin/bash\nexport FOO="bar"; exec \'{fake_py}\' "$@"\n'
+    assert _extract_exec_target_from_wrapper(content_multi) == fake_py
+
+    # 5. Commented exec line is ignored
+    content_commented = "#!/bin/sh\n# exec /ignore/this\necho ok\n"
+    assert _extract_exec_target_from_wrapper(content_commented) is None
+
+    # 6. Inline comment stripped
+    content_inline = f'#!/bin/sh\nexec {fake_py} "$@" # launch python\n'
+    assert _extract_exec_target_from_wrapper(content_inline) == fake_py
+
+
+def test_resolve_mcp_runtime_nested_two_level_wrapper_prxmx(tmp_path: Path) -> None:
+    # Simulates: /root/.local/bin/power-mcp -> exec /root/.local/share/power/current/venv/bin/power-mcp
+    # where the second script has shebang: #!/root/.local/share/power/current/venv/bin/python3
+    venv = tmp_path / ".local" / "share" / "power" / "current" / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python3"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    py_bin.chmod(0o755)
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    # Level 2 console script
+    level2_script = bin_dir / "power-mcp"
+    level2_script.write_text(
+        f"#!{py_bin}\nimport sys\nfrom power_framework.mcp import main\nif __name__ == '__main__':\n    sys.exit(main())\n",
+        encoding="utf-8",
+    )
+    level2_script.chmod(0o755)
+
+    # Level 1 shell wrapper
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    level1_wrapper = local_bin / "power-mcp"
+    level1_wrapper.write_text(
+        f'#!/bin/sh\nexec {level2_script} "$@"\n',
+        encoding="utf-8",
+    )
+    level1_wrapper.chmod(0o755)
+
+    exe, run_py, inst_ver, err = resolve_mcp_runtime(str(level1_wrapper))
+    assert exe == str(level1_wrapper)
+    assert run_py == str(py_bin)
+    assert inst_ver == "3.7.8"
+    assert err is None
+
+    # Verify audit_mcp_config also passes with Level 1 wrapper
+    config = tmp_path / "opencode.jsonc"
+    config.write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "power": {
+                        "command": str(level1_wrapper),
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    res = audit_mcp_config(config, target_version="3.7.8")
+    assert res.status == "canonical"
+    assert res.installed_version == "3.7.8"
+    assert res.runtime_python == str(py_bin)
+    assert res.resolved_executable == str(level1_wrapper)
+    assert res.error is None
+
+
+def test_resolve_mcp_runtime_wrapper_relative_two_level_wrapper(tmp_path: Path) -> None:
+    # Level 1 wrapper at /tmp_path/local/bin/power-mcp execing ../../share/power/current/venv/bin/power-mcp
+    venv = tmp_path / "share" / "power" / "current" / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    py_bin.chmod(0o755)
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    level2_script = bin_dir / "power-mcp"
+    level2_script.write_text(f"#!{py_bin}\nimport sys\n", encoding="utf-8")
+    level2_script.chmod(0o755)
+
+    local_bin = tmp_path / "local" / "bin"
+    local_bin.mkdir(parents=True)
+    level1_wrapper = local_bin / "power-mcp"
+    level1_wrapper.write_text(
+        '#!/bin/sh\nexec ../../share/power/current/venv/bin/power-mcp "$@"\n',
+        encoding="utf-8",
+    )
+    level1_wrapper.chmod(0o755)
+
+    exe, run_py, inst_ver, err = resolve_mcp_runtime(str(level1_wrapper))
+    assert exe == str(level1_wrapper)
+    assert run_py == str(py_bin)
+    assert inst_ver == "3.7.8"
+    assert err is None
+
+
+def test_resolve_mcp_runtime_cyclic_wrappers_fail_closed(tmp_path: Path) -> None:
+    # Direct mutual recursion: wrapper_a -> exec wrapper_b -> exec wrapper_a
+    dir_a = tmp_path / "a"
+    dir_a.mkdir()
+    dir_b = tmp_path / "b"
+    dir_b.mkdir()
+    wrapper_a = dir_a / "power-mcp"
+    wrapper_b = dir_b / "power-mcp"
+
+    wrapper_a.write_text(f'#!/bin/sh\nexec {wrapper_b} "$@"\n', encoding="utf-8")
+    wrapper_a.chmod(0o755)
+    wrapper_b.write_text(f'#!/bin/sh\nexec {wrapper_a} "$@"\n', encoding="utf-8")
+    wrapper_b.chmod(0o755)
+
+    exe_a, run_py_a, inst_ver_a, err_a = resolve_mcp_runtime(str(wrapper_a))
+    assert exe_a == str(wrapper_a)
+    assert run_py_a is None
+    assert inst_ver_a is None
+    assert err_a is not None
+    assert "Cyclic exec wrapper" in err_a
+
+    # Self-referencing wrapper
+    dir_self = tmp_path / "self"
+    dir_self.mkdir()
+    wrapper_self = dir_self / "power-mcp"
+    wrapper_self.write_text(f'#!/bin/sh\nexec {wrapper_self} "$@"\n', encoding="utf-8")
+    wrapper_self.chmod(0o755)
+
+    exe_s, run_py_s, inst_ver_s, err_s = resolve_mcp_runtime(str(wrapper_self))
+    assert exe_s == str(wrapper_self)
+    assert run_py_s is None
+    assert inst_ver_s is None
+    assert err_s is not None
+    assert "Cyclic exec wrapper" in err_s
+
+    # audit_mcp_config fails closed to missing_runtime on cyclic wrapper
+    config = tmp_path / "mcp_cyclic.json"
+    config.write_text(
+        json.dumps({"mcpServers": {"power": {"command": str(wrapper_a)}}}),
+        encoding="utf-8",
+    )
+    res = audit_mcp_config(config)
+    assert res.status == "missing_runtime"
+    assert res.error is not None
+    assert "Cyclic exec wrapper" in res.error
+
+
+def test_resolve_mcp_runtime_depth_limit_fail_closed(tmp_path: Path) -> None:
+    # Chain of wrappers exceeding MAX_WRAPPER_DEPTH
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python3"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    py_bin.chmod(0o755)
+
+    chain_len = MAX_WRAPPER_DEPTH + 3
+    wrappers: list[Path] = []
+    for i in range(chain_len):
+        w_dir = tmp_path / f"w_{i}"
+        w_dir.mkdir()
+        wrappers.append(w_dir / "power-mcp")
+
+    for i in range(chain_len - 1):
+        wrappers[i].write_text(f'#!/bin/sh\nexec {wrappers[i + 1]} "$@"\n', encoding="utf-8")
+        wrappers[i].chmod(0o755)
+    # Last wrapper points to python
+    wrappers[-1].write_text(f'#!/bin/sh\nexec {py_bin} "$@"\n', encoding="utf-8")
+    wrappers[-1].chmod(0o755)
+
+    exe, run_py, inst_ver, err = resolve_mcp_runtime(str(wrappers[0]))
+    assert exe == str(wrappers[0])
+    assert run_py is None
+    assert inst_ver is None
+    assert err is not None
+    assert "depth limit" in err
+
+    # audit_mcp_config fails closed to missing_runtime on depth limit
+    config = tmp_path / "mcp_deep.json"
+    config.write_text(
+        json.dumps({"mcpServers": {"power": {"command": str(wrappers[0])}}}),
+        encoding="utf-8",
+    )
+    res = audit_mcp_config(config)
+    assert res.status == "missing_runtime"
+    assert res.error is not None
+    assert "depth limit" in res.error
+
+
+def test_resolve_mcp_runtime_nonexistent_exec_target_fails_closed(tmp_path: Path) -> None:
+    wrapper = tmp_path / "wrapper_missing_target.sh"
+    wrapper.write_text('#!/bin/sh\nexec /nonexistent/target/path "$@"\n', encoding="utf-8")
+    wrapper.chmod(0o755)
+
+    exe, run_py, inst_ver, err = resolve_mcp_runtime(str(wrapper))
+    assert exe == str(wrapper)
+    assert run_py is None
+    assert inst_ver is None
+    assert err is not None
+    assert "not found" in err
+
+
+def test_resolve_mcp_runtime_non_regular_file_exec_target_fails_closed(tmp_path: Path) -> None:
+    target_dir = tmp_path / "a_directory"
+    target_dir.mkdir()
+    wrapper = tmp_path / "wrapper_dir_target.sh"
+    wrapper.write_text(f'#!/bin/sh\nexec {target_dir} "$@"\n', encoding="utf-8")
+    wrapper.chmod(0o755)
+
+    exe, run_py, inst_ver, err = resolve_mcp_runtime(str(wrapper))
+    assert exe == str(wrapper)
+    assert run_py is None
+    assert inst_ver is None
+    assert err is not None
+    assert "not a regular file" in err
+
+
+def test_audit_mcp_config_with_shell_wrapper(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    py_bin.chmod(0o755)
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    power_mcp = bin_dir / "power-mcp"
+    power_mcp.write_text(
+        f'#!/bin/sh\nexec {py_bin} -m power_framework.mcp "$@"\n',
+        encoding="utf-8",
+    )
+    power_mcp.chmod(0o755)
+
+    config = tmp_path / "gemini_mcp.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "power": {
+                        "command": str(power_mcp),
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    res = audit_mcp_config(config, target_version="3.7.8")
+    assert res.status == "canonical"
+    assert res.installed_version == "3.7.8"
+    assert res.runtime_python == str(py_bin)
+    assert res.resolved_executable == str(power_mcp)
+
+
+def test_audit_mcp_extract_and_validate_structure(tmp_path: Path) -> None:
+    config = tmp_path / "mcp_config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "power": {
+                        "command": "/root/.local/bin/power-mcp",
+                        "args": [],
+                        "env": {"POWER_VAULT_DIR": "/root/geminicli/brain", "SECRET": "xyz"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    res = audit_mcp_config(config)
+    assert res.executable == "/root/.local/bin/power-mcp"
+    assert res.env_keys == ["POWER_VAULT_DIR", "SECRET"]
+    assert "xyz" not in json.dumps(res.as_dict())
+
+
+# ============================================================================
+# 9. Skill Targets Allowlist, Path Traversal & Atomic Replacement
+# ============================================================================
+
+
+def test_is_safe_skill_relative_path_rules() -> None:
+    assert "SKILL.md" in ALLOWED_SKILL_TOP_LEVEL_FILES
+    assert "README.md" in ALLOWED_SKILL_TOP_LEVEL_FILES
+    assert "references" in ALLOWED_SKILL_DIRECTORIES
+    assert "scripts" in ALLOWED_SKILL_DIRECTORIES
+    assert ".md" in ALLOWED_SKILL_EXTENSIONS
+    assert ".py" in ALLOWED_SKILL_EXTENSIONS
+
+    # Top-level allowlist
+    assert is_safe_skill_relative_path("SKILL.md") is True
+    assert is_safe_skill_relative_path("README.md") is True
+    assert is_safe_skill_relative_path("script.py") is False  # not top-level allowed
+    assert is_safe_skill_relative_path("evil.sh") is False
+
+    # Allowed subdirectories with safe extensions
+    assert is_safe_skill_relative_path("references/architecture.md") is True
+    assert is_safe_skill_relative_path("scripts/sync_vault.py") is True
+    assert is_safe_skill_relative_path("templates/config.toml") is True
+    assert is_safe_skill_relative_path("assets/diagram.png") is True
+
+    # Disallowed extensions or directory traversal
+    assert is_safe_skill_relative_path("references/evil.exe") is False
+    assert is_safe_skill_relative_path("untrusted/doc.md") is False
+    assert is_safe_skill_relative_path("../SKILL.md") is False
+    assert is_safe_skill_relative_path("references/../../evil.md") is False
+    assert is_safe_skill_relative_path("/absolute/path.md") is False
+    assert is_safe_skill_relative_path(".hidden") is False
+
+
+def test_is_allowed_skill_target_protection() -> None:
+    # Disallowed: system prefixes, root directory, user home root
+    assert is_allowed_skill_target(Path("/usr/local/skills/power")) is False
+    assert is_allowed_skill_target(Path("/etc/power")) is False
+    assert is_allowed_skill_target(Path("/root")) is False
+    assert is_allowed_skill_target(Path("/")) is False
+
+    # Allowed: standard default targets
+    assert is_allowed_skill_target(Path("/root/geminicli/.agents/skills/power")) is True
+    assert is_allowed_skill_target(Path("/root/.gemini/config/skills/power")) is True
+
+
+def test_audit_skill_and_extract_metadata(tmp_path: Path) -> None:
+    target = tmp_path / "skills" / "power"
+    target.mkdir(parents=True)
+    skill_content = "---\nname: power\nversion: 3.7.8\n---\n# Power Skill\n"
+    (target / "SKILL.md").write_text(skill_content, encoding="utf-8")
+
+    assert extract_skill_version(skill_content) == "3.7.8"
+    assert is_managed_skill_tree({"SKILL.md": skill_content.encode("utf-8")}) is True
+
+    rel = ReleasePayload(
+        tag="v3.7.8",
+        version="3.7.8",
+        pyproject_version="3.7.8",
+        skill_tree_sha256=aggregate_tree_hash({"SKILL.md": skill_content.encode("utf-8")}),
+        skill_files={"SKILL.md": skill_content.encode("utf-8")},
+    )
+    res = audit_skill(target, rel, allowed_roots=[tmp_path / "skills"])
+    assert res.status == "up_to_date"
+    assert res.installed_version == "3.7.8"
+
+
+def test_apply_skill_update_path_traversal_fails(tmp_path: Path) -> None:
+    target = tmp_path / "skills" / "power"
+    files = {
+        "SKILL.md": b"---\nname: power\nversion: 3.7.8\n---\n",
+        "../traversal.txt": b"evil",
+    }
+    rel = ReleasePayload(
+        tag="v3.7.8",
+        version="3.7.8",
+        pyproject_version="3.7.8",
+        skill_files=files,
+    )
+    audit = SkillAuditResult(
+        target_path=str(target),
+        installed_version=None,
+        tree_sha256=None,
+        status="ready",
+    )
+    action, err = apply_skill_update(audit, rel, dry_run=False, allowed_roots=[tmp_path / "skills"])
+    assert action == "failed"
+    assert "Unsafe or disallowed skill relative path" in str(err)
+
+
+def test_apply_skill_update_outside_allowed_roots_fails() -> None:
+    target = Path("/etc/cron.d/power")
+    files = {"SKILL.md": b"---\nname: power\nversion: 3.7.8\n---\n"}
+    rel = ReleasePayload(
+        tag="v3.7.8",
+        version="3.7.8",
+        pyproject_version="3.7.8",
+        skill_files=files,
+    )
+    audit = SkillAuditResult(
+        target_path=str(target),
+        installed_version=None,
+        tree_sha256=None,
+        status="ready",
+    )
+    action, err = apply_skill_update(audit, rel, dry_run=False)
+    assert action == "failed"
+    assert "outside allowed roots" in str(err)
+
+
+# ============================================================================
+# 10. Process Lock, Dedup, State Persistence & Pipeline Tests
+# ============================================================================
+
+
+def test_process_lock_prevents_concurrency(tmp_path: Path) -> None:
+    lock_file = tmp_path / ".test.lock"
+    with (
+        ProcessLock(lock_file),
+        pytest.raises(RuntimeError, match="Another audit/update process is currently running"),
+        ProcessLock(lock_file),
+    ):
+        pass
+
+
+def test_persist_state_report_unique_filenames(tmp_path: Path) -> None:
+    state_dir = tmp_path / "audit_state"
+    rep = AuditReport(
+        timestamp="2026-08-29 18:00:00",
+        release={"version": "3.7.8", "tag": "v3.7.8"},
+        venvs=[],
+        mcp_configs=[],
+        skills=[],
+        applied=False,
+        recorded=False,
+        has_drift=False,
+    )
+    saved1 = persist_state_report(rep, state_dir)
+    saved2 = persist_state_report(rep, state_dir)
+
+    assert saved1.is_file()
+    assert saved2.is_file()
+    assert saved1 != saved2  # Distinct filename avoiding timestamp collision
+    assert (state_dir / "latest.json").is_file()
+
+    data = json.loads(saved1.read_text(encoding="utf-8"))
+    assert data["release"]["version"] == "3.7.8"
+
+
+def test_run_audit_release_failure_persists_state_and_log(tmp_path: Path) -> None:
+    vault = tmp_path / "brain"
+    vault.mkdir()
+    (vault / "log.md").write_text("# Operational Log\n", encoding="utf-8")
+    state_dir = tmp_path / "state"
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.HTTPError(
+            url="https://api.github.com/repos/invalid/power/releases/latest",
+            code=404,
+            msg="Not Found",
+            hdrs={},  # type: ignore[arg-type]
+            fp=None,
+        ),
+    ):
+        report, code = run_audit(
+            repo="invalid/power",
+            ref="latest",
+            vault_path=vault,
+            state_dir=state_dir,
+            record=True,
+            fail_on_drift=True,
+        )
+
+    assert code == 1
+    assert "error" in report.release
+    assert (state_dir / "latest.json").is_file()
+    log_content = (vault / "log.md").read_text(encoding="utf-8")
+    assert "Release validation failed" in log_content
+
+
+def test_run_audit_fail_on_drift_detects_manual_review_and_missing(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "pyproject.toml").write_text(
+        '[project]\nname = "power-framework"\nversion = "3.7.8"\n',
+        encoding="utf-8",
+    )
+    (source / "skills" / "power").mkdir(parents=True)
+    (source / "skills" / "power" / "SKILL.md").write_text(
+        "---\nname: power\nversion: 3.7.8\n---\n",
+        encoding="utf-8",
+    )
+
+    # MCP config with JSONC comment -> manual_review
+    mcp_file = tmp_path / "opencode.jsonc"
+    mcp_file.write_text('{\n  // custom user comment\n  "mcp": {}\n}\n', encoding="utf-8")
+
+    state_dir = tmp_path / "state"
+    vault = tmp_path / "brain"
+    vault.mkdir()
+
+    report, code = run_audit(
+        source_dir=source,
+        vault_path=vault,
+        state_dir=state_dir,
+        venv_roots=[],
+        skill_targets=[],
+        mcp_configs=[mcp_file],
+        apply=False,
+        record=False,
+        fail_on_drift=True,
+    )
+
+    assert report.has_drift is True
+    assert report.mcp_configs[0].status == "manual_review"
+    assert code == 2  # Drift exit code
+
+
+def test_record_brain_log_distinguishes_audit_and_apply(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    log_file = vault / "log.md"
+    log_file.write_text("# Operational Log\n", encoding="utf-8")
+
+    rep_audit = AuditReport(
+        timestamp="2026-08-29 18:00:00",
+        release={"version": "3.7.8", "tag": "v3.7.8"},
+        venvs=[],
+        mcp_configs=[],
+        skills=[],
+        applied=False,
+        recorded=False,
+        has_drift=False,
+    )
+    rep_apply = AuditReport(
+        timestamp="2026-08-29 18:00:00",
+        release={"version": "3.7.8", "tag": "v3.7.8"},
+        venvs=[],
+        mcp_configs=[],
+        skills=[],
+        applied=True,
+        recorded=False,
+        has_drift=False,
+    )
+
+    # 1. Audit log recorded
+    assert record_brain_log(vault, rep_audit) is True
+    # 2. Apply log is NOT deduplicated against audit log
+    assert record_brain_log(vault, rep_apply) is True
+
+    content = log_file.read_text(encoding="utf-8")
+    assert "Runtime Audit (v3.7.8)" in content
+    assert "Runtime Apply (v3.7.8)" in content
+
+    # 3. Second identical apply log IS deduplicated
+    assert record_brain_log(vault, rep_apply) is False
+
+
+def test_format_human_report() -> None:
+    rep = AuditReport(
+        timestamp="2026-08-29 18:00:00",
+        release={"version": "3.7.8", "tag": "v3.7.8"},
+        venvs=[
+            VenvAuditResult(
+                path="/root/.local/share/power/current/venv",
+                python_path="/root/.local/share/power/current/venv/bin/python",
+                installed_version="3.7.8",
+                is_writable=True,
+                status="up_to_date",
+            )
+        ],
+        mcp_configs=[],
+        skills=[],
+        applied=False,
+        recorded=False,
+        has_drift=False,
+    )
+    formatted = format_human_report(rep)
+    assert "P.O.W.E.R Host-side Runtime Audit Report" in formatted
+    assert "ALL UP TO DATE" in formatted
+
+
+def test_run_audit_pipeline_reads_back_updated_version(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "pyproject.toml").write_text(
+        '[project]\nname = "power-framework"\nversion = "3.7.8"\n',
+        encoding="utf-8",
+    )
+    (source / ".agents" / "skills" / "power").mkdir(parents=True)
+    (source / ".agents" / "skills" / "power" / "SKILL.md").write_text(
+        "---\nname: power\nversion: 3.7.8\n---\n",
+        encoding="utf-8",
+    )
+
+    vault = tmp_path / "brain"
+    vault.mkdir()
+    (vault / "log.md").write_text("# Log\n", encoding="utf-8")
+    state_dir = tmp_path / "state"
+
+    skill_target = tmp_path / "skills_dest" / "power"
+
+    report, code = run_audit(
+        source_dir=source,
+        vault_path=vault,
+        state_dir=state_dir,
+        venv_roots=[tmp_path / "venvs"],
+        skill_targets=[skill_target],
+        mcp_configs=[],
+        apply=True,
+        record=True,
+        fail_on_drift=False,
+    )
+
+    assert code == 0
+    assert report.applied is True
+    assert report.recorded is True
+    assert report.skills[0].status == "up_to_date"
+    assert report.skills[0].installed_version == "3.7.8"
+
+    latest_data = json.loads((state_dir / "latest.json").read_text(encoding="utf-8"))
+    assert latest_data["recorded"] is True
+
+
+def test_main_cli_json_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "pyproject.toml").write_text(
+        '[project]\nname = "power-framework"\nversion = "3.7.8"\n',
+        encoding="utf-8",
+    )
+    (source / "skills" / "power").mkdir(parents=True)
+    (source / "skills" / "power" / "SKILL.md").write_text(
+        "---\nname: power\nversion: 3.7.8\n---\n",
+        encoding="utf-8",
+    )
+
+    skill_target = tmp_path / "skill_target"
+    skill_target.mkdir(parents=True)
+    (skill_target / "SKILL.md").write_text(
+        "---\nname: power\nversion: 3.7.8\n---\n",
+        encoding="utf-8",
+    )
+
+    stdout_capture = io.StringIO()
+    monkeypatch.setattr("sys.stdout", stdout_capture)
+
+    code = main(
+        [
+            "--source-dir",
+            str(source),
+            "--state-dir",
+            str(tmp_path / "state"),
+            "--vault",
+            str(tmp_path / "vault"),
+            "--venv-root",
+            str(tmp_path / "venvs"),
+            "--skill-target",
+            str(skill_target),
+            "--mcp-config",
+            str(tmp_path / "mcp_clean.json"),
+            "--json",
+        ]
+    )
+
+    parsed = json.loads(stdout_capture.getvalue())
+    assert parsed["release"]["version"] == "3.7.8"
+    assert code == 0
+
+
+def test_fetch_from_github_apply_requires_verified_wheel(tmp_path: Path) -> None:
+    release_json = {
+        "tag_name": "v3.7.8",
+        "prerelease": False,
+        "draft": False,
+        "assets": [],  # No wheel asset
+    }
+    pyproject_text = '[project]\nname = "power-framework"\nversion = "3.7.8"\n'
+
+    def urlopen_side_effect(req: urllib.request.Request, **kwargs: Any) -> MagicMock:
+        url = req.full_url
+        mock = MagicMock()
+        mock.__enter__.return_value = mock
+        if "releases" in url:
+            mock.read.return_value = json.dumps(release_json).encode("utf-8")
+        elif "pyproject.toml" in url:
+            mock.read.return_value = pyproject_text.encode("utf-8")
+        elif "power-release-manifest.json" in url:
+            raise urllib.error.HTTPError(url=url, code=404, msg="Not Found", hdrs={}, fp=None)  # type: ignore[arg-type]
+        return mock
+
+    state_dir = tmp_path / "state"
+    vault = tmp_path / "brain"
+    vault.mkdir()
+
+    with patch("urllib.request.urlopen", side_effect=urlopen_side_effect):
+        # 1. Audit-only mode preserves audit report without failing on wheel absence
+        rep_audit, code_audit = run_audit(
+            repo="weby-homelab/power-framework",
+            ref="latest",
+            vault_path=vault,
+            state_dir=state_dir,
+            venv_roots=[],
+            skill_targets=[],
+            mcp_configs=[],
+            apply=False,
+            fail_on_drift=False,
+        )
+        assert code_audit == 0
+        assert rep_audit.applied is False
+
+        # 2. Apply mode fails closed with explicit actionable error
+        rep_apply, code_apply = run_audit(
+            repo="weby-homelab/power-framework",
+            ref="latest",
+            vault_path=vault,
+            state_dir=state_dir,
+            venv_roots=[],
+            skill_targets=[],
+            mcp_configs=[],
+            apply=True,
+            fail_on_drift=False,
+        )
+        assert code_apply == 1
+        assert rep_apply.applied is True
+        assert any("verified release wheel" in err for err in rep_apply.errors)
+
+
+def test_fetch_from_github_apply_missing_wheel_digest_fails_closed(tmp_path: Path) -> None:
+    release_json = {
+        "tag_name": "v3.7.8",
+        "prerelease": False,
+        "draft": False,
+        "assets": [
+            {
+                "name": "power_framework-3.7.8-py3-none-any.whl",
+                "browser_download_url": "https://example.com/power_framework-3.7.8-py3-none-any.whl",
+            }
+        ],
+    }
+    pyproject_text = '[project]\nname = "power-framework"\nversion = "3.7.8"\n'
+
+    def urlopen_side_effect(req: urllib.request.Request, **kwargs: Any) -> MagicMock:
+        url = req.full_url
+        mock = MagicMock()
+        mock.__enter__.return_value = mock
+        if "releases" in url:
+            mock.read.return_value = json.dumps(release_json).encode("utf-8")
+        elif "pyproject.toml" in url:
+            mock.read.return_value = pyproject_text.encode("utf-8")
+        elif "power-release-manifest.json" in url:
+            raise urllib.error.HTTPError(url=url, code=404, msg="Not Found", hdrs={}, fp=None)  # type: ignore[arg-type]
+        return mock
+
+    state_dir = tmp_path / "state"
+    vault = tmp_path / "brain"
+    vault.mkdir()
+
+    with patch("urllib.request.urlopen", side_effect=urlopen_side_effect):
+        # 1. Audit-only mode preserves audit report without failing on missing digest
+        rep_audit, code_audit = run_audit(
+            repo="weby-homelab/power-framework",
+            ref="latest",
+            vault_path=vault,
+            state_dir=state_dir,
+            venv_roots=[],
+            skill_targets=[],
+            mcp_configs=[],
+            apply=False,
+            fail_on_drift=False,
+        )
+        assert code_audit == 0
+        assert rep_audit.applied is False
+
+        # 2. Apply mode fails closed because wheel digest is missing
+        rep_apply, code_apply = run_audit(
+            repo="weby-homelab/power-framework",
+            ref="latest",
+            vault_path=vault,
+            state_dir=state_dir,
+            venv_roots=[],
+            skill_targets=[],
+            mcp_configs=[],
+            apply=True,
+            fail_on_drift=False,
+        )
+        assert code_apply == 1
+        assert rep_apply.applied is True
+        assert any("verified release wheel" in err for err in rep_apply.errors)
+
+
+def test_apply_updates_mcp_backed_venv_and_retains_comment_guard(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "pyproject.toml").write_text(
+        '[project]\nname = "power-framework"\nversion = "3.7.8"\n',
+        encoding="utf-8",
+    )
+    (source / "skills" / "power").mkdir(parents=True)
+    (source / "skills" / "power" / "SKILL.md").write_text(
+        "---\nname: power\nversion: 3.7.8\n---\n",
+        encoding="utf-8",
+    )
+
+    # Build dummy wheel in source/dist
+    dist_dir = source / "dist"
+    dist_dir.mkdir()
+    wheel_path = dist_dir / "power_framework-3.7.8-py3-none-any.whl"
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        zf.writestr(
+            "power_framework/data/skills/power/SKILL.md", "---\nname: power\nversion: 3.7.8\n---\n"
+        )
+
+    # Create target venv with old version 3.4.5
+    venv_dir = tmp_path / "venvs" / "power_venv"
+    bin_dir = venv_dir / "bin"
+    bin_dir.mkdir(parents=True)
+    (venv_dir / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding="utf-8")
+    py_bin = bin_dir / "python"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    (bin_dir / "pip").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    site_pkg = venv_dir / "lib" / "python3.13" / "site-packages"
+    dist_info = site_pkg / "power_framework-3.4.5.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.4.5\n",
+        encoding="utf-8",
+    )
+
+    # power-mcp binary pointing to venv
+    power_mcp = bin_dir / "power-mcp"
+    power_mcp.write_text(f"#!{py_bin}\nimport sys\n", encoding="utf-8")
+    power_mcp.chmod(0o755)
+
+    # Canonical clean MCP config
+    clean_mcp = tmp_path / "mcp_clean.json"
+    clean_mcp.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "power": {
+                        "command": str(power_mcp),
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Commented MCP config
+    commented_mcp = tmp_path / "mcp_commented.jsonc"
+    commented_mcp.write_text(
+        f'{{\n  // User comments to preserve\n  "mcpServers": {{\n    "power": {{\n      "command": "{power_mcp}"\n    }}\n  }}\n}}\n',
+        encoding="utf-8",
+    )
+
+    state_dir = tmp_path / "state"
+    vault = tmp_path / "brain"
+    vault.mkdir()
+
+    # Mock subprocess.run for pip install to simulate successful installation
+    def fake_subprocess_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        # Simulate pip upgrade: replace 3.4.5 with 3.7.8
+        import shutil
+
+        shutil.rmtree(dist_info)
+        new_dist_info = site_pkg / "power_framework-3.7.8.dist-info"
+        new_dist_info.mkdir(parents=True)
+        (new_dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    import subprocess
+
+    with patch("subprocess.run", side_effect=fake_subprocess_run):
+        rep, code = run_audit(
+            source_dir=source,
+            vault_path=vault,
+            state_dir=state_dir,
+            venv_roots=[tmp_path / "venvs"],
+            skill_targets=[],
+            mcp_configs=[clean_mcp, commented_mcp],
+            apply=True,
+            record=False,
+            fail_on_drift=True,
+        )
+
+    # Venv was updated to 3.7.8
+    assert rep.venvs[0].status == "up_to_date"
+    assert rep.venvs[0].installed_version == "3.7.8"
+
+    # Clean MCP config reflects post-update installed version and status=canonical
+    clean_res = next(m for m in rep.mcp_configs if m.config_path == str(clean_mcp))
+    assert clean_res.installed_version == "3.7.8"
+    assert clean_res.status == "canonical"
+
+    # Commented MCP config remains manual_review and was NOT mutated, but populates runtime version
+    commented_res = next(m for m in rep.mcp_configs if m.config_path == str(commented_mcp))
+    assert commented_res.status == "manual_review"
+    assert commented_res.has_comments is True
+    assert commented_res.entry_present is True
+    assert commented_res.installed_version == "3.7.8"
+    assert "// User comments to preserve" in commented_mcp.read_text(encoding="utf-8")
+
+    # Exit code is 2 because commented_mcp has drift (manual_review)
+    assert code == 2
+
+
+# ============================================================================
+# 11. Additional Hermetic Hardening & Regression Tests
+# ============================================================================
+
+
+def test_root_var_run_guards_discovery_and_audit() -> None:
+    # discover_bounded_venvs rejects scanning / or /var or /run
+    assert discover_bounded_venvs(["/"]) == []
+    assert discover_bounded_venvs(["/var"]) == []
+    assert discover_bounded_venvs(["/run"]) == []
+    assert discover_bounded_venvs(["/usr"]) == []
+
+    res_root = audit_venv(Path("/"), "3.7.8")
+    assert res_root.status == "unwritable"
+    assert "System Python" in str(res_root.error)
+
+    res_var = audit_venv(Path("/var"), "3.7.8")
+    assert res_var.status == "unwritable"
+    assert "System Python" in str(res_var.error)
+
+    res_run = audit_venv(Path("/run"), "3.7.8")
+    assert res_run.status == "unwritable"
+    assert "System Python" in str(res_run.error)
+
+
+def test_extract_skill_version_quoted_and_unquoted() -> None:
+    # Double quotes
+    assert extract_skill_version('---\nname: power\nversion: "3.7.8"\n---\n') == "3.7.8"
+    # Single quotes
+    assert extract_skill_version("---\nname: power\nversion: '3.7.8'\n---\n") == "3.7.8"
+    # Unquoted
+    assert extract_skill_version("---\nname: power\nversion: 3.7.8\n---\n") == "3.7.8"
+    # Double quotes with inline comment
+    assert extract_skill_version('---\nname: power\nversion: "3.7.8" # comment\n---\n') == "3.7.8"
+    # Single quotes with prerelease
+    assert (
+        extract_skill_version("---\nname: power\nversion: '3.8.0rc1'  # release candidate\n---\n")
+        == "3.8.0rc1"
+    )
+    # Empty or missing
+    assert extract_skill_version("---\nname: power\nversion:\n---\n") is None
+    assert extract_skill_version("---\nname: power\n---\n") is None
+    assert extract_skill_version("# No frontmatter\n") is None
+
+
+@pytest.mark.parametrize(
+    "shebang_line",
+    [
+        "#!/usr/bin/env python3\n",
+        "#!/usr/bin/env -S python3\n",
+        "#!/usr/bin/env -S python3 -u\n",
+        "#!/usr/bin/env -S python3 -B -u\n",
+        "#!/usr/bin/env -Spython3\n",
+        "#!/bin/env -S python3\n",
+    ],
+)
+def test_resolve_mcp_runtime_env_shebang_variants(tmp_path: Path, shebang_line: str) -> None:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    fake_python = bin_dir / "python3"
+    fake_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    fake_python.chmod(0o755)
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    power_mcp = bin_dir / "power-mcp"
+    power_mcp.write_text(f"{shebang_line}import sys\n", encoding="utf-8")
+    power_mcp.chmod(0o755)
+
+    with patch("shutil.which", return_value=str(fake_python)):
+        exe, run_py, inst_ver, err = resolve_mcp_runtime(str(power_mcp))
+        assert exe == str(power_mcp)
+        assert run_py == str(fake_python)
+        assert inst_ver == "3.7.8"
+        assert err is None
+
+
+def test_run_audit_fail_on_drift_missing_mcp_config_file(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "pyproject.toml").write_text(
+        '[project]\nname = "power-framework"\nversion = "3.7.8"\n',
+        encoding="utf-8",
+    )
+    (source / "skills" / "power").mkdir(parents=True)
+    (source / "skills" / "power" / "SKILL.md").write_text(
+        "---\nname: power\nversion: 3.7.8\n---\n",
+        encoding="utf-8",
+    )
+
+    nonexistent_mcp = tmp_path / "missing_config.json"
+    state_dir = tmp_path / "state"
+    vault = tmp_path / "brain"
+    vault.mkdir()
+
+    report, code = run_audit(
+        source_dir=source,
+        vault_path=vault,
+        state_dir=state_dir,
+        venv_roots=[],
+        skill_targets=[],
+        mcp_configs=[nonexistent_mcp],
+        apply=False,
+        record=False,
+        fail_on_drift=True,
+    )
+
+    assert report.has_drift is True
+    assert report.mcp_configs[0].status == "missing_file"
+    assert code == 2
+
+
+def test_apply_skill_update_post_write_hash_failure_rolls_back(tmp_path: Path) -> None:
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    target = skill_root / "power"
+    target.mkdir(parents=True)
+    original_skill_md = "---\nname: power\nversion: 3.4.5\n---\n# Original Skill\n"
+    original_ref = "# Original Ref\n"
+    (target / "SKILL.md").write_text(original_skill_md, encoding="utf-8")
+    (target / "references").mkdir()
+    (target / "references" / "ref.md").write_text(original_ref, encoding="utf-8")
+
+    new_skill_files = {
+        "SKILL.md": b"---\nname: power\nversion: 3.7.8\n---\n# New Skill\n",
+        "references/ref.md": b"# New Ref\n",
+    }
+    expected_new_hash = aggregate_tree_hash(new_skill_files)
+
+    rel = ReleasePayload(
+        tag="v3.7.8",
+        version="3.7.8",
+        pyproject_version="3.7.8",
+        skill_tree_sha256=expected_new_hash,
+        skill_files=new_skill_files,
+    )
+    audit = SkillAuditResult(
+        target_path=str(target),
+        installed_version="3.4.5",
+        tree_sha256=aggregate_tree_hash(tree_from_directory(target)),
+        status="upgrade_ready",
+    )
+
+    # Mock aggregate_tree_hash so that during post-replacement verification it simulates a mismatch
+    real_aggregate_tree_hash = aggregate_tree_hash
+    call_count = 0
+
+    def mock_aggregate(files: dict[str, bytes]) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count > 1:
+            return "corrupted_hash_" + "0" * 49
+        return real_aggregate_tree_hash(files)
+
+    with patch("scripts.prxmx_power_runtime_audit.aggregate_tree_hash", side_effect=mock_aggregate):
+        action, err = apply_skill_update(
+            audit,
+            rel,
+            dry_run=False,
+            allowed_roots=[skill_root],
+        )
+
+    assert action == "failed"
+    assert "Installed skill tree hash mismatch" in str(err)
+
+    # Assert target was restored to original version 3.4.5 files
+    assert target.is_dir()
+    assert (target / "SKILL.md").read_text(encoding="utf-8") == original_skill_md
+    assert (target / "references" / "ref.md").read_text(encoding="utf-8") == original_ref
+
+    # Assert no staging or prev directories left behind
+    remaining = [p.name for p in skill_root.iterdir() if p.name != "power"]
+    assert remaining == []
+
+
+def test_run_audit_state_report_persist_failure_is_redacted_and_truthful(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "pyproject.toml").write_text(
+        '[project]\nname = "power-framework"\nversion = "3.7.8"\n',
+        encoding="utf-8",
+    )
+    (source / "skills" / "power").mkdir(parents=True)
+    (source / "skills" / "power" / "SKILL.md").write_text(
+        "---\nname: power\nversion: 3.7.8\n---\n",
+        encoding="utf-8",
+    )
+
+    state_dir = tmp_path / "state"
+    vault = tmp_path / "brain"
+    vault.mkdir()
+
+    with patch(
+        "scripts.prxmx_power_runtime_audit.persist_state_report",
+        side_effect=OSError("Disk write error with token=<set-via-env> and password=<set-via-env>"),
+    ):
+        report, code = run_audit(
+            source_dir=source,
+            vault_path=vault,
+            state_dir=state_dir,
+            venv_roots=[],
+            skill_targets=[],
+            mcp_configs=[],
+            apply=False,
+            record=False,
+            fail_on_drift=False,
+        )
+
+    assert code == 1
+    assert any("Failed to persist state report" in err for err in report.errors)
+    for err in report.errors:
+        assert "<set-via-env>" not in err
+        assert "[REDACTED]" in err
+
+
+def test_audit_mcp_config_commented_opencode_jsonc_canonical_entry(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python3"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    py_bin.chmod(0o755)
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    power_mcp = bin_dir / "power-mcp"
+    power_mcp.write_text(f"#!{py_bin}\nimport sys\n", encoding="utf-8")
+    power_mcp.chmod(0o755)
+
+    config_path = tmp_path / "opencode.jsonc"
+    raw_content = f"""{{
+      // OpenCode Configuration for P.O.W.E.R MCP Server
+      /* Multi-line metadata block
+         containing special symbols * / and settings */
+      "endpoint": "https://opencode.internal/api//v1",
+      "escaped_note": "Includes \\"quotes\\" and // double-slash inside string",
+      "mcp": {{
+        "power": {{
+          "type": "local",
+          "command": ["{power_mcp}"],
+          "environment": {{
+            "POWER_VAULT": "/root/brain"
+          }}
+        }}
+      }}
+      // Trailing configuration comment
+    }}"""
+    config_path.write_text(raw_content, encoding="utf-8")
+
+    res = audit_mcp_config(config_path, target_version="3.7.8")
+
+    assert res.client == "opencode"
+    assert res.config_format == "jsonc"
+    assert res.status == "manual_review"
+    assert res.has_comments is True
+    assert res.entry_present is True
+    assert res.executable == str(power_mcp)
+    assert res.resolved_executable == str(power_mcp)
+    assert res.runtime_python == str(py_bin)
+    assert res.installed_version == "3.7.8"
+    assert res.env_keys == ["POWER_VAULT"]
+    assert res.error == "JSONC contains user comments; manual review required to preserve structure"
+
+    # Disk content must NEVER be mutated or rewritten
+    assert config_path.read_text(encoding="utf-8") == raw_content
+
+
+def test_audit_mcp_config_commented_opencode_jsonc_nested_shell_wrapper(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python3"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    py_bin.chmod(0o755)
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.7.8.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.7.8\n",
+        encoding="utf-8",
+    )
+
+    # Level 2 inner wrapper execs python interpreter
+    inner_wrapper = tmp_path / "power-mcp-inner.sh"
+    inner_wrapper.write_text(
+        f'#!/bin/sh\nexec {py_bin} -m power_framework.mcp "$@"\n',
+        encoding="utf-8",
+    )
+    inner_wrapper.chmod(0o755)
+
+    # Level 1 outer wrapper execs inner wrapper
+    outer_wrapper = tmp_path / "power-mcp"
+    outer_wrapper.write_text(
+        f'#!/bin/sh\nexec {inner_wrapper} "$@"\n',
+        encoding="utf-8",
+    )
+    outer_wrapper.chmod(0o755)
+
+    config_path = tmp_path / "opencode.jsonc"
+    raw_content = f"""{{
+      // OpenCode MCP Configuration with nested wrappers
+      /* Documentation: https://example.com/docs//setup */
+      "custom_url": "https://service.internal/v2//call",
+      "escaped_str": "Testing \\"inner quotes\\" // still string",
+      "mcp": {{
+        "power": {{
+          "command": ["{outer_wrapper}"]
+        }}
+      }}
+      /* End of settings */
+    }}"""
+    config_path.write_text(raw_content, encoding="utf-8")
+
+    res = audit_mcp_config(config_path, target_version="3.7.8")
+
+    assert res.client == "opencode"
+    assert res.config_format == "jsonc"
+    assert res.status == "manual_review"
+    assert res.has_comments is True
+    assert res.entry_present is True
+    assert res.executable == str(outer_wrapper)
+    assert res.resolved_executable == str(outer_wrapper)
+    assert res.runtime_python == str(py_bin)
+    assert res.installed_version == "3.7.8"
+    assert res.error == "JSONC contains user comments; manual review required to preserve structure"
+
+    # Disk content must NEVER be mutated or rewritten
+    assert config_path.read_text(encoding="utf-8") == raw_content
+
+
+def test_audit_mcp_config_commented_opencode_jsonc_outdated_version(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    py_bin = bin_dir / "python"
+    py_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    py_bin.chmod(0o755)
+
+    dist_info = venv / "lib" / "python3.13" / "site-packages" / "power_framework-3.4.5.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: power-framework\nVersion: 3.4.5\n",
+        encoding="utf-8",
+    )
+
+    power_mcp = bin_dir / "power-mcp"
+    power_mcp.write_text(f"#!{py_bin}\nimport sys\n", encoding="utf-8")
+    power_mcp.chmod(0o755)
+
+    config_path = tmp_path / "opencode.jsonc"
+    config_path.write_text(
+        f'{{\n  // User custom comment\n  "mcp": {{\n    "power": {{\n      "command": "{power_mcp}"\n    }}\n  }}\n}}\n',
+        encoding="utf-8",
+    )
+
+    res = audit_mcp_config(config_path, target_version="3.7.8")
+
+    assert res.status == "manual_review"
+    assert res.has_comments is True
+    assert res.entry_present is True
+    assert res.executable == str(power_mcp)
+    assert res.runtime_python == str(py_bin)
+    assert res.installed_version == "3.4.5"
+    assert res.error == "JSONC contains user comments; manual review required to preserve structure"


### PR DESCRIPTION
## Summary
- Add `scripts/prxmx_power_runtime_audit.py` for PRXMX-01-wide POWER version checks.
- Audit bounded Python venvs, OpenCode/AGY/Codex MCP configs, and all allowlisted POWER Skill targets.
- Use verified GitHub release wheel/manifest data for explicit `--apply`; never mutate system Python, foreign configs, or commented JSONC.
- Persist redacted state and optional deduplicated Action/Result entries in the canonical brain.

## Validation
- AGY Gemini 3.7 Flash (High) implementation/review.
- 77 hermetic tests passed.
- Ruff check and format passed.
- PyCompile passed.
- Real PRXMX audit resolves all installed POWER runtimes to `3.7.8`.
- Current GitHub v3.7.8 wheel asset/manifest SHA mismatch is reported fail-closed; no update was applied.

The script is stdlib-first and performs no embedding or heavy sync work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a host-side command-line audit tool for checking P.O.W.E.R. runtime environments, MCP configurations, and Skill installations against a release.
  - Supports read-only auditing and controlled updates with version, integrity, and configuration validation.
  - Produces redacted state reports and drift-based exit statuses.

- **Bug Fixes**
  - Added safeguards for unsafe paths, system environments, secrets, incomplete releases, and failed updates.

- **Tests**
  - Added comprehensive coverage for auditing, updates, validation, rollback, locking, redaction, and CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->