### PR TITLE
fix: harden immutable v3.7.9 recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python 3.13
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -56,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Download platform upgrade matrix evidence
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -96,6 +99,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -148,6 +152,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.13
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -181,6 +187,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -296,6 +303,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -317,6 +325,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Existing signed tag to validate; publication requires a tag push"
+        description: "Existing signed tag for immutable recovery; never create or move a tag"
         required: true
         type: string
 
 permissions: {}
 
 concurrency:
-  group: power-release-${{ github.ref_name }}
+  group: power-release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -33,10 +33,135 @@ jobs:
           [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
           printf 'release_tag=%s\n' "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
 
-  validate:
+  signed_tag_admission:
+    name: Signed tag admission
     needs: release_input
+    if: needs.release_input.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag_object: ${{ steps.admit.outputs.tag_object }}
+      tag_target: ${{ steps.admit.outputs.tag_target }}
+    steps:
+      - name: Checkout requested tag metadata
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          ref: ${{ format('refs/tags/{0}', needs.release_input.outputs.release_tag) }}
+          persist-credentials: false
+
+      - name: Admit exact signed annotated tag
+        id: admit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GNUPGHOME: ${{ runner.temp }}/power-release-admission-gnupg
+          RELEASE_TAG: ${{ needs.release_input.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          install -d -m 700 "$GNUPGHOME"
+          tag_ref="refs/tags/${RELEASE_TAG}"
+          local_tag_object="$(git rev-parse --verify "${tag_ref}^{tag}")"
+          local_tag_target="$(git rev-parse --verify "${tag_ref}^{commit}")"
+          test "$(git cat-file -t "$local_tag_object")" = tag
+
+          remote_tag_object="$(
+            git ls-remote origin "$tag_ref" |
+              EXPECTED_REF="$tag_ref" python3 -c '
+          import os
+          import sys
+
+          expected_ref = os.environ["EXPECTED_REF"]
+          rows = [fields for line in sys.stdin if (fields := line.split())]
+          if len(rows) != 1 or len(rows[0]) != 2 or rows[0][1] != expected_ref:
+              raise SystemExit("unexpected annotated tag response")
+          print(rows[0][0])
+          '
+          )"
+          remote_tag_target="$(
+            git ls-remote origin "${tag_ref}^{}" |
+              EXPECTED_REF="${tag_ref}^{}" python3 -c '
+          import os
+          import sys
+
+          expected_ref = os.environ["EXPECTED_REF"]
+          rows = [fields for line in sys.stdin if (fields := line.split())]
+          if len(rows) != 1 or len(rows[0]) != 2 or rows[0][1] != expected_ref:
+              raise SystemExit("unexpected peeled tag response")
+          print(rows[0][0])
+          '
+          )"
+          test -n "$remote_tag_object"
+          test -n "$remote_tag_target"
+          test "$local_tag_object" = "$remote_tag_object"
+          test "$local_tag_target" = "$remote_tag_target"
+          test "$local_tag_target" = "$(git rev-parse HEAD)"
+
+          key_file="$RUNNER_TEMP/power-release-admission-signing-key.asc"
+          gh api users/weby-homelab/gpg_keys \
+            --jq '.[] | select(.key_id == "2D49E810C7F2527E") | .raw_key' \
+            > "$key_file"
+          test -s "$key_file"
+          fingerprint="$(
+            gpg --batch --with-colons --show-keys "$key_file" |
+              python3 -c 'import sys; print(next(field[9] for field in (line.split(":") for line in sys.stdin) if field[0] == "fpr"))'
+          )"
+          test "$fingerprint" = "7AF1EDA195FE29FF093FB1CA2D49E810C7F2527E"
+          gpg --batch --import "$key_file"
+          verification="$RUNNER_TEMP/power-release-admission-tag-verification.txt"
+          git verify-tag --raw "$RELEASE_TAG" > "$verification" 2>&1
+          python3 - "$verification" <<'PY'
+          from pathlib import Path
+          import sys
+
+          expected_signing = "166E0A4F873E897A8060DD38DD92FC45BD1D6C30"
+          expected_primary = "7AF1EDA195FE29FF093FB1CA2D49E810C7F2527E"
+          lines = Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace").splitlines()
+          valid = [
+              fields
+              for fields in (line.split() for line in lines)
+              if len(fields) >= 12
+              and fields[0] == "[GNUPG:]"
+              and fields[1] == "VALIDSIG"
+              and fields[2] == expected_signing
+              and fields[-1] == expected_primary
+          ]
+          if len(valid) != 1:
+              raise SystemExit("signed release tag is not verified by the pinned maintainer key")
+          PY
+
+          commit_verification="$RUNNER_TEMP/power-release-admission-commit-verification.txt"
+          git verify-commit --raw "$local_tag_target" > "$commit_verification" 2>&1
+          python3 - "$commit_verification" <<'PY'
+          from pathlib import Path
+          import sys
+
+          expected_signing = "166E0A4F873E897A8060DD38DD92FC45BD1D6C30"
+          expected_primary = "7AF1EDA195FE29FF093FB1CA2D49E810C7F2527E"
+          lines = Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace").splitlines()
+          valid = [
+              fields
+              for fields in (line.split() for line in lines)
+              if len(fields) >= 12
+              and fields[0] == "[GNUPG:]"
+              and fields[1] == "VALIDSIG"
+              and fields[2] == expected_signing
+              and fields[-1] == expected_primary
+          ]
+          if len(valid) != 1:
+              raise SystemExit("release tag target commit is not verified by the pinned maintainer key")
+          PY
+
+          printf 'tag_object=%s\n' "$remote_tag_object" >> "$GITHUB_OUTPUT"
+          printf 'tag_target=%s\n' "$remote_tag_target" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "Signed annotated tag admitted before tagged repository code" >&2
+
+  validate:
+    needs: [release_input, signed_tag_admission]
     if: >-
       always() &&
+      needs.signed_tag_admission.result == 'success' &&
       (github.event_name != 'workflow_dispatch' || needs.release_input.result == 'success')
     runs-on: ubuntu-latest
     permissions:
@@ -52,7 +177,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', needs.release_input.outputs.release_tag) || github.ref }}
+          ref: ${{ format('refs/tags/{0}', needs.release_input.outputs.release_tag) }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -181,11 +307,28 @@ jobs:
 
       - name: Generate content-free validation receipt
         run: |
-          uv run python scripts/generate_release_validation.py \
-             --junit-xml "$RUNNER_TEMP/power-release-junit.xml" \
-             --coverage-json "$RUNNER_TEMP/power-release-coverage.json" \
-             --gate-manifest "$RUNNER_TEMP/power-release-gates.json" \
-             --output "$RUNNER_TEMP/power-release-validation.json"
+          uv run python - \
+            "$RUNNER_TEMP/power-release-junit.xml" \
+            "$RUNNER_TEMP/power-release-coverage.json" \
+            "$RUNNER_TEMP/power-release-gates.json" \
+            "$RUNNER_TEMP/power-release-validation.json" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          from scripts.generate_release_validation import build_validation_receipt
+
+          junit_xml, coverage_json, gate_manifest, output = map(Path, sys.argv[1:])
+          receipt = build_validation_receipt(
+              junit_xml=junit_xml,
+              coverage_json=coverage_json,
+              gate_manifest=gate_manifest,
+          )
+          if receipt["status"] not in {"passed", "prepublication-passed"}:
+              raise SystemExit("release validation receipt contains failing checks")
+          output.write_text(json.dumps(receipt, ensure_ascii=False, indent=2) + "\n")
+          print(f"Release validation receipt written to {output}")
+          PY
 
       - name: Upload content-free Phase 8 technical receipts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -204,9 +347,10 @@ jobs:
           uv run pytest tests/test_release_contract.py -q --no-cov --override-ini=addopts=
 
   upgrade-matrix:
-    needs: [release_input, validate]
+    needs: [release_input, signed_tag_admission, validate]
     if: >-
       always() &&
+      needs.signed_tag_admission.result == 'success' &&
       needs.validate.result == 'success' &&
       (github.event_name != 'workflow_dispatch' || needs.release_input.result == 'success')
     strategy:
@@ -220,7 +364,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', needs.release_input.outputs.release_tag) || github.ref }}
+          ref: ${{ format('refs/tags/{0}', needs.release_input.outputs.release_tag) }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -252,9 +397,10 @@ jobs:
           retention-days: 7
 
   upgrade-matrix-aggregate:
-    needs: [release_input, upgrade-matrix]
+    needs: [release_input, signed_tag_admission, upgrade-matrix]
     if: >-
       always() &&
+      needs.signed_tag_admission.result == 'success' &&
       needs.upgrade-matrix.result == 'success' &&
       (github.event_name != 'workflow_dispatch' || needs.release_input.result == 'success')
     runs-on: ubuntu-latest
@@ -263,7 +409,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', needs.release_input.outputs.release_tag) || github.ref }}
+          ref: ${{ format('refs/tags/{0}', needs.release_input.outputs.release_tag) }}
+          persist-credentials: false
 
       - name: Download platform upgrade evidence
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -288,9 +435,10 @@ jobs:
           retention-days: 7
 
   release:
-    needs: [release_input, validate, upgrade-matrix-aggregate]
+    needs: [release_input, signed_tag_admission, validate, upgrade-matrix-aggregate]
     if: >-
       always() &&
+      needs.signed_tag_admission.result == 'success' &&
       needs.validate.result == 'success' &&
       needs.upgrade-matrix-aggregate.result == 'success' &&
       (github.event_name != 'workflow_dispatch' || needs.release_input.result == 'success')
@@ -302,27 +450,54 @@ jobs:
       attestations: write
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && needs.release_input.outputs.release_tag || github.ref_name }}
-      GNUPGHOME: ${{ runner.temp }}/power-release-gnupg
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', needs.release_input.outputs.release_tag) || github.ref }}
+          ref: ${{ format('refs/tags/{0}', needs.release_input.outputs.release_tag) }}
+          persist-credentials: false
+
+      - name: Fetch exact release control verifier
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_CONTROL_ROOT: ${{ runner.temp }}/power-release-control
+          RELEASE_CONTROL_REF: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          install -d -m 700 "$RELEASE_CONTROL_ROOT"
+          for file in scripts/release_bindings.py scripts/verify_public_release_bindings.py; do
+            gh api "repos/${GITHUB_REPOSITORY}/contents/${file}?ref=${RELEASE_CONTROL_REF}" \
+              --jq '.content' |
+              base64 --decode > "$RELEASE_CONTROL_ROOT/${file##*/}"
+          done
+          printf 'RELEASE_CONTROL_ROOT=%s\n' "$RELEASE_CONTROL_ROOT" >> "$GITHUB_ENV"
 
       - name: Validate the exact release tag checkout
+        env:
+          EXPECTED_TAG_OBJECT: ${{ needs.signed_tag_admission.outputs.tag_object }}
+          EXPECTED_TAG_TARGET: ${{ needs.signed_tag_admission.outputs.tag_target }}
         run: |
           set -euo pipefail
           [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          local_tag_object="$(git rev-parse --verify "${RELEASE_TAG}^{tag}")"
           local_tag_target="$(git rev-parse --verify "${RELEASE_TAG}^{commit}")"
+          test "$(git cat-file -t "$local_tag_object")" = tag
           remote_tag_target="$(git ls-remote origin "refs/tags/${RELEASE_TAG}^{}" | python3 -c 'import sys; fields=sys.stdin.read().split(); print(fields[0] if fields else "")')"
+          remote_tag_object="$(git ls-remote origin "refs/tags/${RELEASE_TAG}" | python3 -c 'import sys; fields=sys.stdin.read().split(); print(fields[0] if fields else "")')"
+          test -n "$remote_tag_object"
           test -n "$remote_tag_target"
+          test "$local_tag_object" = "$remote_tag_object"
           test "$local_tag_target" = "$remote_tag_target"
+          test "$remote_tag_object" = "$EXPECTED_TAG_OBJECT"
+          test "$remote_tag_target" = "$EXPECTED_TAG_TARGET"
           test "$remote_tag_target" = "$(git rev-parse HEAD)"
+          printf 'REMOTE_TAG_OBJECT=%s\n' "$remote_tag_object" >> "$GITHUB_ENV"
           printf 'REMOTE_TAG_TARGET=%s\n' "$remote_tag_target" >> "$GITHUB_ENV"
 
       - name: Verify signed release tag and maintainer fingerprint
         env:
           GH_TOKEN: ${{ github.token }}
+          GNUPGHOME: ${{ runner.temp }}/power-release-gnupg
         run: |
           set -euo pipefail
           install -d -m 700 "$GNUPGHOME"
@@ -357,16 +532,35 @@ jobs:
           print("signed release tag and maintainer fingerprint verified")
           PY
 
-      - name: Reject mutable manual release recovery
+      - name: Validate immutable manual release recovery
         if: github.event_name == 'workflow_dispatch'
-        run: |
-          printf '%s\n' "Manual release recovery is validation-only; publish a new signed tag push" >&2
-          exit 1
-
-      - name: Reject an existing GitHub release for this tag
+        env:
+          EXPECTED_TAG_OBJECT: ${{ needs.signed_tag_admission.outputs.tag_object }}
+          EXPECTED_TAG_TARGET: ${{ needs.signed_tag_admission.outputs.tag_target }}
+          EXPECTED_RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
+          test "$RELEASE_TAG" = "$EXPECTED_RELEASE_TAG"
+          test "$REMOTE_TAG_OBJECT" = "$EXPECTED_TAG_OBJECT"
+          test "$REMOTE_TAG_TARGET" = "$EXPECTED_TAG_TARGET"
+          test "$REMOTE_TAG_TARGET" = "$(git rev-parse HEAD)"
+          printf '%s\n' "Manual recovery is immutable; tag mutation is forbidden" >&2
+          printf '%s\n' "Recovery may publish only the existing signed tag when no Release exists" >&2
+
+      - name: Reject an existing GitHub release for this tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          umask 077
+          api_config="$RUNNER_TEMP/power-release-api-curl.conf"
+          printf '%s\n' \
+            'header = "Accept: application/vnd.github+json"' \
+            'header = "X-GitHub-Api-Version: 2022-11-28"' \
+            'header = "Authorization: Bearer '"$GH_TOKEN"'"' \
+            > "$api_config"
           api_status="$(curl --silent --show-error \
+            --config "$api_config" \
             --output "$RUNNER_TEMP/release-probe.json" \
             --write-out "%{http_code}" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
@@ -462,6 +656,7 @@ jobs:
           file: ${{ runner.temp }}/power-framework-package.whl
           format: spdx-json
           output-file: dist/power-framework.spdx.json
+          upload-release-assets: false
 
       - name: Normalize package SBOM identity
         run: |
@@ -469,19 +664,39 @@ jobs:
           version="${RELEASE_TAG#v}"
           mv -- dist/power-framework.spdx.json "dist/power-framework-${version}.spdx.json"
 
-      - name: Authenticate to GHCR for the Web-only image
+      - name: Re-read immutable tag objects before Web image publication
         env:
-          GH_TOKEN: ${{ secrets.POWER_RELEASE_GHCR_TOKEN || github.token }}
-        run: printf '%s' "$GH_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          EXPECTED_TAG_OBJECT: ${{ needs.signed_tag_admission.outputs.tag_object }}
+          EXPECTED_TAG_TARGET: ${{ needs.signed_tag_admission.outputs.tag_target }}
+        run: |
+          set -euo pipefail
+          tag_ref="refs/tags/${RELEASE_TAG}"
+          remote_tag_object="$(git ls-remote origin "$tag_ref" | python3 -c 'import sys; fields=sys.stdin.read().split(); print(fields[0] if fields else "")')"
+          remote_tag_target="$(git ls-remote origin "${tag_ref}^{}" | python3 -c 'import sys; fields=sys.stdin.read().split(); print(fields[0] if fields else "")')"
+          test -n "$remote_tag_object"
+          test -n "$remote_tag_target"
+          test "$remote_tag_object" = "$EXPECTED_TAG_OBJECT"
+          test "$remote_tag_target" = "$EXPECTED_TAG_TARGET"
+          test "$(git rev-parse --verify "${tag_ref}^{tag}")" = "$remote_tag_object"
+          test "$(git rev-parse --verify "${tag_ref}^{commit}")" = "$remote_tag_target"
+          test "$(git cat-file -t "$remote_tag_object")" = tag
+          test "$remote_tag_target" = "$(git rev-parse HEAD)"
 
-      - name: Build and publish the Web-only image
+      - name: Authenticate and publish Web-only image
         id: web_image
         env:
+          GH_TOKEN: ${{ secrets.POWER_RELEASE_GHCR_TOKEN || github.token }}
+          DOCKER_CONFIG: ${{ runner.temp }}/power-release-docker-config
           IMAGE_REF: ghcr.io/weby-homelab/power-framework-web:${{ env.RELEASE_TAG }}
+          STAGING_IMAGE_REF: ghcr.io/weby-homelab/power-framework-web:release-${{ github.run_id }}-${{ github.run_attempt }}
           POWER_VERSION: ${{ env.RELEASE_TAG }}
         run: |
           set -euo pipefail
-          image_ref="${IMAGE_REF/:v/:}"
+          install -d -m 700 "$DOCKER_CONFIG"
+          printf '%s' "$GH_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          trap 'docker logout ghcr.io' EXIT
+          final_image_ref="${IMAGE_REF/:v/:}"
+          staging_image_ref="$STAGING_IMAGE_REF"
           version="${POWER_VERSION#v}"
           source_revision="$(git rev-list -n 1 "$RELEASE_TAG")"
           wheel_name="power_framework-${version}-py3-none-any.whl"
@@ -495,14 +710,17 @@ jobs:
             --build-arg "POWER_RELEASE_TAG=$RELEASE_TAG" \
             --build-arg "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH" \
             --build-arg "OCI_CREATED=$OCI_CREATED" \
-            --tag "$image_ref" \
+            --tag "$staging_image_ref" \
             --push \
             .
-          digest="$(docker buildx imagetools inspect "$image_ref" | python3 -c 'import sys; print(next(line.split()[1] for line in sys.stdin if line.startswith("Digest:")))')"
+          digest="$(docker buildx imagetools inspect "$staging_image_ref" | python3 -c 'import sys; print(next(line.split()[1] for line in sys.stdin if line.startswith("Digest:")))')"
           test "${digest#sha256:}" != "$digest"
           test "$(printf '%s' "$digest" | wc -c)" -eq 71
-          echo "reference=$image_ref" >> "$GITHUB_OUTPUT"
+          echo "reference=$staging_image_ref" >> "$GITHUB_OUTPUT"
+          echo "final_reference=$final_image_ref" >> "$GITHUB_OUTPUT"
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          docker logout ghcr.io
+          trap - EXIT
 
       - name: Prefetch locked model snapshots for real Web acceptance
         env:
@@ -524,27 +742,14 @@ jobs:
           print("locked model snapshots prefetched")
           PY
 
-      - name: Checkout current acceptance harness for tag recovery
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 1
-          ref: ${{ github.sha }}
-          path: ${{ runner.temp }}/.release-acceptance-harness
-          sparse-checkout: |
-            scripts/profile_acceptance.py
-            tests/__init__.py
-            tests/mcp_test_client.py
-          sparse-checkout-cone-mode: false
-
       - name: Verify acceptance harness revision
-        if: github.event_name == 'workflow_dispatch'
         env:
-          EXPECTED_HARNESS_REVISION: ${{ github.sha }}
+          EXPECTED_HARNESS_REVISION: ${{ needs.signed_tag_admission.outputs.tag_target }}
         run: |
           set -euo pipefail
-          harness_revision="$(git -C "$RUNNER_TEMP/.release-acceptance-harness" rev-parse --verify HEAD)"
+          harness_revision="$(git rev-parse --verify HEAD)"
           test "$harness_revision" = "$EXPECTED_HARNESS_REVISION"
+          test -f scripts/profile_acceptance.py
           printf 'ACCEPTANCE_HARNESS_REVISION=%s\n' "$harness_revision" >> "$GITHUB_ENV"
 
       - name: Prove Profile A/B against the exact Web image
@@ -559,8 +764,8 @@ jobs:
           POWER_RERANKER_DEVICE: cpu
           WEB_IMAGE_REF: ${{ steps.web_image.outputs.reference }}
           WEB_IMAGE_DIGEST: ${{ steps.web_image.outputs.digest }}
-          ACCEPTANCE_HARNESS_ROOT: ${{ github.event_name == 'workflow_dispatch' && format('{0}/.release-acceptance-harness', runner.temp) || '.' }}
-          ACCEPTANCE_HARNESS_REVISION: ${{ github.sha }}
+          ACCEPTANCE_HARNESS_ROOT: .
+          ACCEPTANCE_HARNESS_REVISION: ${{ needs.signed_tag_admission.outputs.tag_target }}
         run: |
           image_ref="${WEB_IMAGE_REF%@*}@${WEB_IMAGE_DIGEST}"
           uv run python "$ACCEPTANCE_HARNESS_ROOT/scripts/profile_acceptance.py" \
@@ -576,6 +781,7 @@ jobs:
           image: ${{ steps.web_image.outputs.reference }}@${{ steps.web_image.outputs.digest }}
           format: spdx-json
           output-file: dist/power-web.spdx.json
+          upload-release-assets: false
 
       - name: Normalize Web SBOM identity
         run: |
@@ -601,7 +807,7 @@ jobs:
 
       - name: Generate the exact unified release manifest
         env:
-          WEB_IMAGE_REF: ${{ steps.web_image.outputs.reference }}
+          WEB_IMAGE_REF: ${{ steps.web_image.outputs.final_reference }}
           WEB_IMAGE_DIGEST: ${{ steps.web_image.outputs.digest }}
           PACKAGE_ATTESTATION_ID: ${{ steps.package_attestation.outputs.attestation-id }}
           WEB_ATTESTATION_ID: ${{ steps.web_attestation.outputs.attestation-id }}
@@ -630,6 +836,8 @@ jobs:
             --output dist/power-release-manifest.json
 
       - name: Generate and verify tag-bound release baseline
+        env:
+          GNUPGHOME: ${{ runner.temp }}/power-release-gnupg
         run: |
           set -euo pipefail
           mkdir -p dist
@@ -707,7 +915,7 @@ jobs:
 
       - name: Verify frozen release bindings before publication
         run: |
-          uv run python scripts/verify_public_release_bindings.py \
+          uv run python "$RELEASE_CONTROL_ROOT/verify_public_release_bindings.py" \
             --tag "$RELEASE_TAG" \
             --manifest "dist/power-release-manifest.json" \
             --checksums "dist/SHA256SUMS" \
@@ -715,13 +923,106 @@ jobs:
             --receipt "dist/power-framework.release-receipt.json" \
             --expected-tag-target "$REMOTE_TAG_TARGET"
 
+      - name: Promote exact Web image digest to release tag
+        env:
+          GH_TOKEN: ${{ secrets.POWER_RELEASE_GHCR_TOKEN || github.token }}
+          DOCKER_CONFIG: ${{ runner.temp }}/power-release-docker-config
+          SOURCE_IMAGE_REF: ${{ steps.web_image.outputs.reference }}
+          FINAL_IMAGE_REF: ${{ steps.web_image.outputs.final_reference }}
+          WEB_IMAGE_DIGEST: ${{ steps.web_image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          final_version="${FINAL_IMAGE_REF##*:}"
+          registry_basic="$(printf '%s:%s' "$GITHUB_ACTOR" "$GH_TOKEN" | base64 --wrap=0)"
+          umask 077
+          registry_config="$RUNNER_TEMP/power-release-ghcr-curl.conf"
+          printf '%s\n' 'header = "Authorization: Basic '"$registry_basic"'"' > "$registry_config"
+          registry_token="$(
+            curl --silent --show-error --fail \
+              --config "$registry_config" \
+              "https://ghcr.io/token?service=ghcr.io&scope=repository:weby-homelab/power-framework-web:pull" \
+              | python3 -c 'import json, sys; print(json.load(sys.stdin)["token"])'
+          )"
+          printf '%s\n' 'header = "Authorization: Bearer '"$registry_token"'"' > "$registry_config"
+          manifest_url="https://ghcr.io/v2/weby-homelab/power-framework-web/manifests/${final_version}"
+          manifest_status="$(
+            curl --silent --show-error \
+              --header "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json" \
+              --config "$registry_config" \
+              --output "$RUNNER_TEMP/power-release-final-image-probe.json" \
+              --write-out '%{http_code}' \
+              "$manifest_url"
+          )"
+          case "$manifest_status" in
+            404) promote_mode="create" ;;
+            200) promote_mode="verify" ;;
+            *) printf '%s\n' "Unable to establish GHCR release tag state (HTTP $manifest_status)" >&2; exit 1 ;;
+          esac
+
+          install -d -m 700 "$DOCKER_CONFIG"
+          printf '%s' "$GH_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          trap 'docker logout ghcr.io' EXIT
+          if [[ "$promote_mode" == "create" ]]; then
+            docker buildx imagetools create \
+              --tag "$FINAL_IMAGE_REF" \
+              "${SOURCE_IMAGE_REF}@${WEB_IMAGE_DIGEST}"
+          fi
+          promoted_digest="$(
+            docker buildx imagetools inspect "$FINAL_IMAGE_REF" |
+              python3 -c 'import sys; print(next(line.split()[1] for line in sys.stdin if line.startswith("Digest:")))'
+          )"
+          test "$promoted_digest" = "$WEB_IMAGE_DIGEST"
+          docker logout ghcr.io
+          trap - EXIT
+
+      - name: Reconfirm authenticated release absence before publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          umask 077
+          api_config="$RUNNER_TEMP/power-release-final-api-curl.conf"
+          printf '%s\n' \
+            'header = "Accept: application/vnd.github+json"' \
+            'header = "X-GitHub-Api-Version: 2022-11-28"' \
+            'header = "Authorization: Bearer '"$GH_TOKEN"'"' \
+            > "$api_config"
+          api_status="$(curl --silent --show-error \
+            --config "$api_config" \
+            --output "$RUNNER_TEMP/release-probe-final.json" \
+            --write-out "%{http_code}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
+          case "$api_status" in
+            404) printf '%s\n' "No existing GitHub Release found immediately before publication" ;;
+            200) printf '%s\n' "A GitHub Release already exists for $RELEASE_TAG" >&2; exit 1 ;;
+            *) printf '%s\n' "Unable to prove release absence for $RELEASE_TAG (HTTP $api_status)" >&2; exit 1 ;;
+          esac
+
+      - name: Re-read immutable tag objects immediately before publication
+        env:
+          EXPECTED_TAG_OBJECT: ${{ needs.signed_tag_admission.outputs.tag_object }}
+          EXPECTED_TAG_TARGET: ${{ needs.signed_tag_admission.outputs.tag_target }}
+        run: |
+          set -euo pipefail
+          tag_ref="refs/tags/${RELEASE_TAG}"
+          remote_tag_object="$(git ls-remote origin "$tag_ref" | python3 -c 'import sys; fields=sys.stdin.read().split(); print(fields[0] if fields else "")')"
+          remote_tag_target="$(git ls-remote origin "${tag_ref}^{}" | python3 -c 'import sys; fields=sys.stdin.read().split(); print(fields[0] if fields else "")')"
+          test -n "$remote_tag_object"
+          test -n "$remote_tag_target"
+          test "$remote_tag_object" = "$EXPECTED_TAG_OBJECT"
+          test "$remote_tag_target" = "$EXPECTED_TAG_TARGET"
+          test "$(git rev-parse --verify "${tag_ref}^{tag}")" = "$remote_tag_object"
+          test "$(git rev-parse --verify "${tag_ref}^{commit}")" = "$remote_tag_target"
+          test "$(git cat-file -t "$remote_tag_object")" = tag
+          test "$remote_tag_target" = "$(git rev-parse HEAD)"
+          printf '%s\n' "Annotated tag object and peeled commit re-read and unchanged" >&2
+
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          body_path: ${{ steps.release_notes.outputs.path }}
-          generate_release_notes: false
-          files: |
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          assets=(
             dist/power-framework.release-baseline.json
             dist/power-release-manifest.json
             dist/power-profile-acceptance.json
@@ -730,6 +1031,26 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
             dist/*.spdx.json
+          )
+          gh release create "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "POWER $RELEASE_TAG" \
+            --notes-file "${{ steps.release_notes.outputs.path }}" \
+            "${assets[@]}"
+
+      - name: Verify public tag binding after release creation
+        env:
+          EXPECTED_TAG_OBJECT: ${{ needs.signed_tag_admission.outputs.tag_object }}
+          EXPECTED_TAG_TARGET: ${{ needs.signed_tag_admission.outputs.tag_target }}
+        run: |
+          set -euo pipefail
+          tag_ref="refs/tags/${RELEASE_TAG}"
+          remote_tag_object="$(git ls-remote origin "$tag_ref" | python3 -c 'import sys; fields=sys.stdin.read().split(); print(fields[0] if fields else "")')"
+          remote_tag_target="$(git ls-remote origin "${tag_ref}^{}" | python3 -c 'import sys; fields=sys.stdin.read().split(); print(fields[0] if fields else "")')"
+          test "$remote_tag_object" = "$EXPECTED_TAG_OBJECT"
+          test "$remote_tag_target" = "$EXPECTED_TAG_TARGET"
+          printf '%s\n' "Public annotated tag binding remained unchanged after release creation" >&2
 
       - name: Read back GitHub release metadata and assets
         env:
@@ -770,19 +1091,69 @@ jobs:
       - name: Verify public asset checksums, manifest bindings, and OCI readback
         env:
           GH_TOKEN: ${{ github.token }}
-          WEB_IMAGE_REF: ${{ steps.web_image.outputs.reference }}
+          WEB_IMAGE_REF: ${{ steps.web_image.outputs.final_reference }}
           WEB_IMAGE_DIGEST: ${{ steps.web_image.outputs.digest }}
         run: |
           set -euo pipefail
           readback_dir="$RUNNER_TEMP/power-public-readback"
           mkdir -p "$readback_dir"
           gh release download "$RELEASE_TAG" --dir "$readback_dir" --clobber
-          uv run python scripts/verify_public_release_bindings.py \
+          binding_result="$(uv run python "$RELEASE_CONTROL_ROOT/verify_public_release_bindings.py" \
             --tag "$RELEASE_TAG" \
             --manifest "$readback_dir/power-release-manifest.json" \
             --checksums "$readback_dir/SHA256SUMS" \
             --asset-dir "$readback_dir" \
             --receipt "$readback_dir/power-framework.release-receipt.json" \
-            --expected-tag-target "$REMOTE_TAG_TARGET"
+            --expected-tag-target "$REMOTE_TAG_TARGET")"
+          printf '%s\n' "$binding_result" > "$RUNNER_TEMP/power-public-bindings.json"
+          verified_image_digest="$(printf '%s\n' "$binding_result" | python3 -c 'import json, sys; print(json.load(sys.stdin)["web_image_digest"])')"
           registry_digest="$(docker buildx imagetools inspect "$WEB_IMAGE_REF" | python3 -c 'import sys; print(next(line.split()[1] for line in sys.stdin if line.startswith("Digest:")))')"
-          test "$registry_digest" = "$WEB_IMAGE_DIGEST"
+          test "$verified_image_digest" = "$WEB_IMAGE_DIGEST"
+          test "$registry_digest" = "$verified_image_digest"
+
+      - name: Verify public artifact and Web attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DOCKER_CONFIG: ${{ runner.temp }}/power-release-docker-config
+          GHCR_TOKEN: ${{ secrets.POWER_RELEASE_GHCR_TOKEN || github.token }}
+          WEB_IMAGE_REF: ${{ steps.web_image.outputs.final_reference }}
+          WEB_IMAGE_DIGEST: ${{ steps.web_image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          readback_dir="$RUNNER_TEMP/power-public-readback"
+          gh attestation verify \
+            "$readback_dir/power_framework-${RELEASE_TAG#v}-py3-none-any.whl" \
+            --repo "$GITHUB_REPOSITORY" \
+            --format json \
+            > "$RUNNER_TEMP/power-wheel-attestation.json"
+          gh attestation verify \
+            "$readback_dir/power_framework-${RELEASE_TAG#v}.tar.gz" \
+            --repo "$GITHUB_REPOSITORY" \
+            --format json \
+            > "$RUNNER_TEMP/power-sdist-attestation.json"
+          install -d -m 700 "$DOCKER_CONFIG"
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          trap 'docker logout ghcr.io' EXIT
+          gh attestation verify \
+            "oci://${WEB_IMAGE_REF}@${WEB_IMAGE_DIGEST}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --bundle-from-oci \
+            --format json \
+            > "$RUNNER_TEMP/power-web-attestation.json"
+          docker logout ghcr.io
+          trap - EXIT
+
+      - name: Upload release evidence on success or failure
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: power-release-final-evidence-${{ github.run_id }}
+          path: |
+            dist/
+            ${{ runner.temp }}/power-public-readback/
+            ${{ runner.temp }}/power-public-bindings.json
+            ${{ runner.temp }}/power-wheel-attestation.json
+            ${{ runner.temp }}/power-sdist-attestation.json
+            ${{ runner.temp }}/power-web-attestation.json
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -964,6 +964,7 @@ jobs:
           trap 'docker logout ghcr.io' EXIT
           if [[ "$promote_mode" == "create" ]]; then
             docker buildx imagetools create \
+              --prefer-index=false \
               --tag "$FINAL_IMAGE_REF" \
               "${SOURCE_IMAGE_REF}@${WEB_IMAGE_DIGEST}"
           fi

--- a/docs/release-3.7.9.md
+++ b/docs/release-3.7.9.md
@@ -53,11 +53,18 @@ GHCR digest. A missing or contradictory identity is a public-release NO-GO.
 
 ## Recovery policy
 
-Manual `workflow_dispatch` is validation-only. It cannot republish an existing
-tag or release, because a new attestation identity or image digest would not be
-the same immutable release object. Publication is allowed only from the one
-validated signed tag push; a failed publication must preserve evidence and use a
-new corrective patch version after the workflow is fixed.
+Manual `workflow_dispatch` is a narrowly scoped immutable recovery path for an
+existing signed annotated tag. It may complete publication only for the exact
+requested tag after signed-tag admission and authenticated API checks prove that
+no GitHub Release exists for that tag.
+
+Recovery never creates, moves, force-updates, or deletes a Git tag, and never
+edits or replaces an existing GitHub Release. If a Release exists—or any
+identity check is inconclusive—the workflow fails closed. The checkout, package,
+Web image, SBOMs, attestations, manifest, receipt, and readback remain bound to
+the admitted annotated tag object and peeled commit. A failed publication must
+preserve its evidence; a later corrective release uses a new patch tag, while
+the historical `v3.7.8` tag and release remain untouched.
 
 ## Status boundary
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
   - POWER 3.4.0 Release Notes: release-3.4.0.md
   - POWER 3.3.2 Release Notes: release-3.3.2.md
   - POWER 3.6.7 Release Notes: release-3.6.7.md
+  - POWER 3.7.9 Release Notes: release-3.7.9.md
   - POWER 3.6.5 Release Notes: release-3.6.5.md
   - POWER 3.6.4 Release Notes: release-3.6.4.md
   - POWER 3.6.2 Release Notes: release-3.6.2.md

--- a/scripts/generate_release_validation.py
+++ b/scripts/generate_release_validation.py
@@ -117,7 +117,7 @@ def build_validation_receipt(
     """Return exact test/coverage counts without including test or vault content."""
     passed, skipped, failures, errors = _test_counts(junit_xml)
     coverage = _load_json(coverage_json).get("totals", {}).get("percent_covered")
-    if not isinstance(coverage, (int, float)) or isinstance(coverage, bool):
+    if not isinstance(coverage, int | float) or isinstance(coverage, bool):
         raise ValueError("coverage JSON totals.percent_covered must be numeric")
     if not 0 <= float(coverage) <= 100:
         raise ValueError("coverage JSON totals.percent_covered must be between 0 and 100")
@@ -181,8 +181,8 @@ def main(argv: list[str] | None = None) -> int:
     except (OSError, ValueError, UnicodeError, json.JSONDecodeError) as exc:
         parser.error(str(exc))
         return 2
-    if receipt["status"] != "passed":
-        parser.error("release validation receipt cannot be generated from failing tests")
+    if receipt["status"] not in {"passed", "prepublication-passed"}:
+        parser.error("release validation receipt cannot be generated from failing checks")
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(
         json.dumps(receipt, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"

--- a/scripts/verify_public_release_bindings.py
+++ b/scripts/verify_public_release_bindings.py
@@ -137,6 +137,8 @@ def _manifest_file_artifacts(
         if not isinstance(entry, dict):
             raise ValueError(f"release manifest artifact {key} must be an object")
         filename = entry.get("filename")
+        if key in expected_filenames and not isinstance(filename, str):
+            raise ValueError(f"manifest artifact {key} must declare a filename")
         if filename is None:
             continue
         if key in expected_filenames and filename != expected_filenames[key]:
@@ -173,6 +175,10 @@ def _verify_receipt(
     required_files: set[str],
 ) -> list[dict[str, Any]]:
     """Verify receipt identity, file hashes, attestation IDs, and subjects."""
+    if receipt.get("schema_version") != 2:
+        raise ValueError("release receipt schema_version must be 2")
+    if manifest_path.parent.resolve() != asset_dir.resolve():
+        raise ValueError("release manifest must be inside the public asset directory")
     release = receipt.get("release")
     if not isinstance(release, dict):
         raise ValueError("release receipt release must be an object")
@@ -208,6 +214,9 @@ def _verify_receipt(
     missing = required_files - receipt_hashes.keys()
     if missing:
         raise ValueError(f"release receipt is missing hash bindings: {sorted(missing)}")
+    unexpected = receipt_hashes.keys() - required_files
+    if unexpected:
+        raise ValueError(f"release receipt has unexpected asset bindings: {sorted(unexpected)}")
 
     return receipt.get("attestation_subjects", [])
 
@@ -275,13 +284,55 @@ def verify_public_release_bindings(
 
     profile_name = manifest["artifacts"]["profile_evidence"]["filename"]
     profile = _load_json(_safe_asset_path(asset_root, profile_name), "Profile A/B evidence")
+    if profile.get("schema") != "power.profile.acceptance.v1":
+        raise ValueError("Profile A/B evidence schema is invalid")
     if profile.get("version") != version:
         raise ValueError("Profile A/B evidence version does not match tag")
+    if profile.get("acceptance_harness_revision") != commit:
+        raise ValueError("Profile A/B evidence harness revision does not match tag commit")
     if profile.get("image_digest") != image_digest:
         raise ValueError("Profile B image digest does not match manifest image digest")
+    profile_a = profile.get("profile_a")
+    if not isinstance(profile_a, dict):
+        raise ValueError("Profile A evidence is missing")
+    for field in ("native_cli", "native_mcp_stdio"):
+        if profile_a.get(field) is not True:
+            raise ValueError(f"Profile A evidence {field} must be true")
+    if profile_a.get("docker_web_containers") != 0:
+        raise ValueError("Profile A evidence must contain zero Web containers")
+    profile_b = profile.get("profile_b")
+    if not isinstance(profile_b, dict):
+        raise ValueError("Profile B evidence is missing")
+    for field in (
+        "web_health",
+        "web_authenticated_read",
+        "web_semantic_non_fallback",
+        "web_reranked_non_fallback",
+        "web_governed_mutation",
+        "host_cli_readback",
+        "host_mcp_readback",
+        "same_canonical_vault",
+        "cache_delete_rebuild",
+        "cap_drop_all",
+        "read_only_rootfs",
+    ):
+        if profile_b.get(field) is not True:
+            raise ValueError(f"Profile B evidence {field} must be true")
+    if profile_b.get("container_user") != "10001:10001":
+        raise ValueError("Profile B evidence container user is invalid")
+    if profile_b.get("web_mcp_services") != 0:
+        raise ValueError("Profile B evidence must contain zero MCP services")
+    if profile_b.get("web_applicationservice_bypass_count") != 0:
+        raise ValueError("Profile B evidence reports an ApplicationService bypass")
+    profile_image = profile.get("image")
+    if not isinstance(profile_image, str) or not profile_image.endswith(f"@{image_digest}"):
+        raise ValueError("Profile B evidence must bind an image reference to a digest")
 
-    receipt = _load_json(receipt_path.expanduser().absolute(), "release receipt")
-    required_receipt_files = set(file_hashes) | {manifest_file.name}
+    receipt_file = receipt_path.expanduser().absolute()
+    if receipt_file.parent.resolve() != asset_root:
+        raise ValueError("release receipt must be inside the public asset directory")
+    receipt = _load_json(receipt_file, "release receipt")
+    required_receipt_files = set(checksums)
     _verify_receipt(
         receipt,
         tag=tag,

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import yaml
+
 WORKFLOWS_DIR = Path(__file__).resolve().parent.parent / ".github" / "workflows"
 REPO_ROOT = WORKFLOWS_DIR.parent.parent
 FORBIDDEN_WORKFLOW_PATTERNS = ("continue-on-error", "|| true", "/root/gemma/brain")
@@ -76,6 +78,7 @@ def test_release_workflow_publishes_sbom_and_attestation() -> None:
     assert "dist/*.spdx.json" in release_text
     assert "Generate package SPDX SBOM bound to the exact wheel" in release_text
     assert "Generate Web SPDX SBOM bound to the exact image" in release_text
+    assert release_text.count("upload-release-assets: false") == 2
     assert (
         "image: ${{ steps.web_image.outputs.reference }}@${{ steps.web_image.outputs.digest }}"
         in release_text
@@ -84,12 +87,11 @@ def test_release_workflow_publishes_sbom_and_attestation() -> None:
     assert "subject-digest:" in release_text
     assert "scripts/profile_acceptance.py" in release_text
     assert "Prefetch locked model snapshots for real Web acceptance" in release_text
-    assert "Checkout current acceptance harness for tag recovery" in release_text
-    assert "path: ${{ runner.temp }}/.release-acceptance-harness" in release_text
     assert "ACCEPTANCE_HARNESS_ROOT" in release_text
     assert "Verify acceptance harness revision" in release_text
     assert "ACCEPTANCE_HARNESS_REVISION" in release_text
-    assert "format('{0}/.release-acceptance-harness', runner.temp)" in release_text
+    assert "ACCEPTANCE_HARNESS_ROOT: ." in release_text
+    assert "Checkout current acceptance harness for tag recovery" not in release_text
     assert "Remove tag recovery harness checkout" not in release_text
     assert "rm -rf -- .release-acceptance-harness" not in release_text
     assert "--profile-evidence" in release_text
@@ -98,8 +100,14 @@ def test_release_workflow_publishes_sbom_and_attestation() -> None:
     assert "gh release view" in release_text
     assert "GitHub release readback verified" in release_text
     assert "scripts/verify_public_release_bindings.py" in release_text
+    assert release_text.count("$RELEASE_CONTROL_ROOT/verify_public_release_bindings.py") == 2
     assert "--expected-tag-target" in release_text
     assert "--attestation-subject" in release_text
+    assert 'header = "Authorization: Bearer ' in release_text
+    assert "Re-read immutable tag objects immediately before publication" in release_text
+    assert "gh release create" in release_text
+    assert "--verify-tag" in release_text
+    assert "softprops/action-gh-release" not in release_text
     assert release_text.index("Generate release receipt from frozen assets") < release_text.index(
         "Create GitHub Release"
     )
@@ -114,8 +122,50 @@ def test_release_package_sbom_scans_the_wheel_as_a_file() -> None:
 
 def test_release_publish_is_blocked_by_a_tag_validation_job() -> None:
     release_text = (WORKFLOWS_DIR / "release.yml").read_text(encoding="utf-8")
+    workflow = yaml.safe_load(release_text)
+    jobs = workflow["jobs"]
 
     assert "  validate:" in release_text
+    assert "signed_tag_admission" in jobs
+    admission = jobs["signed_tag_admission"]
+    assert admission["needs"] == "release_input"
+    assert admission["outputs"] == {
+        "tag_object": "${{ steps.admit.outputs.tag_object }}",
+        "tag_target": "${{ steps.admit.outputs.tag_target }}",
+    }
+    admission_run = next(
+        step["run"]
+        for step in admission["steps"]
+        if step.get("name") == "Admit exact signed annotated tag"
+    )
+    assert 'git verify-tag --raw "$RELEASE_TAG"' in admission_run
+    assert 'git verify-commit --raw "$local_tag_target"' in admission_run
+    assert 'git cat-file -t "$local_tag_object"' in admission_run
+    assert "uv run" not in admission_run
+    assert "pytest" not in admission_run
+    assert "scripts/" not in admission_run
+    assert (
+        admission["steps"][0]["with"]["ref"]
+        == "${{ format('refs/tags/{0}', needs.release_input.outputs.release_tag) }}"
+    )
+    assert admission["steps"][0]["with"]["persist-credentials"] is False
+    assert workflow["concurrency"]["group"] == (
+        "power-release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}"
+    )
+    for job_id in ("validate", "upgrade-matrix", "upgrade-matrix-aggregate", "release"):
+        needs = jobs[job_id]["needs"]
+        needs_set = {needs} if isinstance(needs, str) else set(needs)
+        assert "signed_tag_admission" in needs_set
+    control_fetch = next(
+        step
+        for step in jobs["release"]["steps"]
+        if step.get("name") == "Fetch exact release control verifier"
+    )
+    assert control_fetch["env"]["RELEASE_CONTROL_REF"] == "${{ github.sha }}"
+    assert control_fetch["env"]["RELEASE_CONTROL_ROOT"] == (
+        "${{ runner.temp }}/power-release-control"
+    )
+    assert "base64 --decode" in control_fetch["run"]
     assert (
         "uv sync --locked --group dev --extra web --extra semantic --extra rerank" in release_text
     )
@@ -128,8 +178,12 @@ def test_release_publish_is_blocked_by_a_tag_validation_job() -> None:
     assert "macos-latest" not in release_text
     assert "windows-latest" not in release_text
     assert "  upgrade-matrix-aggregate:" in release_text
-    assert "needs: [release_input, validate]" in release_text
-    assert "needs: [release_input, validate, upgrade-matrix-aggregate]" in release_text
+    assert "needs: [release_input, signed_tag_admission, validate]" in release_text
+    assert "needs: [release_input, signed_tag_admission, upgrade-matrix]" in release_text
+    assert (
+        "needs: [release_input, signed_tag_admission, validate, upgrade-matrix-aggregate]"
+        in release_text
+    )
     assert "--require-signed-tag" in release_text
     assert "Verify signed release tag and maintainer fingerprint" in release_text
     assert "Install the pinned maintainer release signing key" not in release_text
@@ -142,14 +196,21 @@ def test_release_publish_is_blocked_by_a_tag_validation_job() -> None:
     assert "Reject an existing GitHub release for this tag" in release_text
     assert "api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" in release_text
     assert "Unable to prove release absence" in release_text
-    assert "Reject mutable manual release recovery" in release_text
-    assert "Manual release recovery is validation-only" in release_text
+    assert "Validate immutable manual release recovery" in release_text
+    assert "Manual recovery is immutable; tag mutation is forbidden" in release_text
+    assert (
+        "Recovery may publish only the existing signed tag when no Release exists" in release_text
+    )
+    assert release_text.count('header = "Authorization: Bearer ') == 3
+    assert '"Authorization: Bearer ${GH_TOKEN}"' not in release_text
     assert "workflow_dispatch" in release_text
     assert "inputs.release_tag" in release_text
     assert "Validate the exact release tag checkout" in release_text
     assert '[[ "$RELEASE_TAG" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]' in release_text
     assert 'git ls-remote origin "refs/tags/${RELEASE_TAG}^{}"' in release_text
+    assert 'git ls-remote origin "refs/tags/${RELEASE_TAG}"' in release_text
     assert "REMOTE_TAG_TARGET" in release_text
+    assert "REMOTE_TAG_OBJECT" in release_text
     assert "permissions: {}" in release_text
     assert (
         "RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && needs.release_input.outputs.release_tag || github.ref_name }}"
@@ -160,6 +221,170 @@ def test_release_publish_is_blocked_by_a_tag_validation_job() -> None:
     assert "--pending-mandatory web-semantic-acceptance" in release_text
     assert "--pending-mandatory web-rerank-acceptance" in release_text
     assert "--pending-mandatory public-release-readback" in release_text
+
+
+def test_release_harness_and_publication_guards_are_tag_bound() -> None:
+    workflow = yaml.safe_load((WORKFLOWS_DIR / "release.yml").read_text(encoding="utf-8"))
+    release_job = workflow["jobs"]["release"]
+    steps = release_job["steps"]
+
+    harness_revision = next(
+        step for step in steps if step.get("name") == "Verify acceptance harness revision"
+    )
+    assert (
+        harness_revision["env"]["EXPECTED_HARNESS_REVISION"]
+        == "${{ needs.signed_tag_admission.outputs.tag_target }}"
+    )
+    profile_acceptance = next(
+        step
+        for step in steps
+        if step.get("name") == "Prove Profile A/B against the exact Web image"
+    )
+    assert (
+        profile_acceptance["env"]["ACCEPTANCE_HARNESS_REVISION"]
+        == "${{ needs.signed_tag_admission.outputs.tag_target }}"
+    )
+    assert profile_acceptance["env"]["ACCEPTANCE_HARNESS_ROOT"] == "."
+
+    registry_step = next(
+        step for step in steps if step.get("name") == "Authenticate and publish Web-only image"
+    )
+    assert registry_step["env"]["DOCKER_CONFIG"] == (
+        "${{ runner.temp }}/power-release-docker-config"
+    )
+    assert "GH_TOKEN" in registry_step["env"]
+    assert "docker login ghcr.io" in registry_step["run"]
+    assert "docker buildx build" in registry_step["run"]
+    assert "trap 'docker logout ghcr.io' EXIT" in registry_step["run"]
+    assert "docker logout ghcr.io" in registry_step["run"]
+    assert "STAGING_IMAGE_REF" in registry_step["env"]
+    promote_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Promote exact Web image digest to release tag"
+    )
+    promote_step = steps[promote_index]
+    assert promote_step["env"]["SOURCE_IMAGE_REF"] == "${{ steps.web_image.outputs.reference }}"
+    assert promote_step["env"]["FINAL_IMAGE_REF"] == (
+        "${{ steps.web_image.outputs.final_reference }}"
+    )
+    assert "ghcr.io/token?service=ghcr.io" in promote_step["run"]
+    assert "Unable to establish GHCR release tag state" in promote_step["run"]
+    assert "docker buildx imagetools create" in promote_step["run"]
+    assert '"${SOURCE_IMAGE_REF}@${WEB_IMAGE_DIGEST}"' in promote_step["run"]
+    assert "docker logout ghcr.io" in promote_step["run"]
+    assert "DOCKER_CONFIG" not in release_job.get("env", {})
+    assert "POWER_RELEASE_GHCR_TOKEN" not in "\n".join(
+        str(step.get("run", "")) for step in steps[promote_index + 1 :]
+    )
+
+    final_absence_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Reconfirm authenticated release absence before publication"
+    )
+    final_tag_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Re-read immutable tag objects immediately before publication"
+    )
+    create_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == "Create GitHub Release"
+    )
+    assert final_absence_index + 1 == final_tag_index
+    assert final_tag_index + 1 == create_index
+
+    post_create_tag_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Verify public tag binding after release creation"
+    )
+    assert create_index + 1 == post_create_tag_index
+    assert post_create_tag_index + 1 == next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Read back GitHub release metadata and assets"
+    )
+
+    public_binding_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Verify public asset checksums, manifest bindings, and OCI readback"
+    )
+    assert '"$RELEASE_CONTROL_ROOT/verify_public_release_bindings.py"' in public_binding_step["run"]
+    assert 'verified_image_digest"' in public_binding_step["run"]
+    assert 'registry_digest" = "$verified_image_digest"' in public_binding_step["run"]
+
+    attestation_step = next(
+        step for step in steps if step.get("name") == "Verify public artifact and Web attestations"
+    )
+    assert "gh attestation verify" in attestation_step["run"]
+    assert "--bundle-from-oci" in attestation_step["run"]
+    assert "docker login ghcr.io" in attestation_step["run"]
+    assert "docker logout ghcr.io" in attestation_step["run"]
+
+    evidence_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Upload release evidence on success or failure"
+    )
+    assert evidence_step["if"] == "always()"
+    assert evidence_step["with"]["if-no-files-found"] == "ignore"
+    assert "dist/" in evidence_step["with"]["path"]
+
+    final_tag_run = steps[final_tag_index]["run"]
+    for required in (
+        'git ls-remote origin "$tag_ref"',
+        'git ls-remote origin "${tag_ref}^{}"',
+        'git rev-parse --verify "${tag_ref}^{tag}"',
+        'git rev-parse --verify "${tag_ref}^{commit}"',
+        'git cat-file -t "$remote_tag_object"',
+        '"$remote_tag_object" = "$EXPECTED_TAG_OBJECT"',
+        '"$remote_tag_target" = "$EXPECTED_TAG_TARGET"',
+    ):
+        assert required in final_tag_run
+
+    create_step = steps[create_index]
+    token_key = "GH" + "_TOKEN"
+    github_token_expression = "${{" + " github.token }}"
+    assert create_step["env"][token_key] == github_token_expression
+    assert 'gh release create "$RELEASE_TAG"' in create_step["run"]
+    assert "--verify-tag" in create_step["run"]
+    for forbidden in ("git push", "gh release edit", "gh release delete", "git tag "):
+        assert forbidden not in create_step["run"]
+
+
+def test_every_checkout_disables_persisted_credentials() -> None:
+    for workflow_path in WORKFLOWS_DIR.glob("*.yml"):
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        for job in workflow.get("jobs", {}).values():
+            for step in job.get("steps", []):
+                if str(step.get("uses", "")).startswith("actions/checkout@"):
+                    assert step.get("with", {}).get("persist-credentials") is False, (
+                        f"{workflow_path.name} checkout must not persist credentials"
+                    )
+
+
+def test_release_runner_context_is_scoped_to_steps() -> None:
+    """Job-level expressions cannot access runner.temp during workflow validation."""
+
+    workflow = yaml.safe_load((WORKFLOWS_DIR / "release.yml").read_text(encoding="utf-8"))
+    release_job = workflow["jobs"]["release"]
+    job_environment = release_job["env"]
+    signed_step = next(
+        step
+        for step in release_job["steps"]
+        if step.get("name") == "Verify signed release tag and maintainer fingerprint"
+    )
+    baseline_step = next(
+        step
+        for step in release_job["steps"]
+        if step.get("name") == "Generate and verify tag-bound release baseline"
+    )
+
+    assert "GNUPGHOME" not in job_environment
+    assert signed_step["env"]["GNUPGHOME"] == "${{ runner.temp }}/power-release-gnupg"
+    assert baseline_step["env"]["GNUPGHOME"] == "${{ runner.temp }}/power-release-gnupg"
 
 
 def test_release_does_not_require_private_phase8_secrets() -> None:
@@ -193,13 +418,15 @@ def test_ci_uses_locked_dependencies_and_clean_package_smoke() -> None:
     assert "--skipped-optional real-vault-quality" in release_text
     assert "run_outcome_benchmark.py" in release_text
     assert "run_continuity_benchmark.py" in release_text
-    assert "scripts/generate_release_validation.py" in release_text
+    assert (
+        "from scripts.generate_release_validation import build_validation_receipt" in release_text
+    )
     assert "scripts/generate_release_gate_manifest.py" in release_text
     assert "scripts/build_release_manifest.py" in release_text
     assert '--commit "$commit"' in release_text
     assert "power-release-gates.json" in release_text
     assert "power-release-validation.json" in release_text
-    assert "--gate-manifest" in release_text
+    assert "gate_manifest" in release_text
     assert '--junitxml="$RUNNER_TEMP/power-release-junit.xml"' in release_text
     assert '--cov-report=json:"$RUNNER_TEMP/power-release-coverage.json"' in release_text
     assert "power-release-phase8-technical-receipts" in release_text

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -271,6 +271,7 @@ def test_release_harness_and_publication_guards_are_tag_bound() -> None:
     assert "ghcr.io/token?service=ghcr.io" in promote_step["run"]
     assert "Unable to establish GHCR release tag state" in promote_step["run"]
     assert "docker buildx imagetools create" in promote_step["run"]
+    assert "--prefer-index=false" in promote_step["run"]
     assert '"${SOURCE_IMAGE_REF}@${WEB_IMAGE_DIGEST}"' in promote_step["run"]
     assert "docker logout ghcr.io" in promote_step["run"]
     assert "DOCKER_CONFIG" not in release_job.get("env", {})

--- a/tests/test_public_release_bindings.py
+++ b/tests/test_public_release_bindings.py
@@ -46,7 +46,41 @@ def _write_fixture(tmp_path: Path) -> dict[str, Path | str]:
     sdist.write_bytes(b"sdist bytes from the frozen candidate")
     package_sbom.write_bytes(b'{"spdxVersion":"SPDX-2.3","name":"package"}\n')
     web_sbom.write_bytes(b'{"spdxVersion":"SPDX-2.3","name":"web"}\n')
-    profile.write_bytes(b'{"version":"3.7.9","image_digest":"' + IMAGE_DIGEST.encode() + b'"}\n')
+    profile.write_text(
+        json.dumps(
+            {
+                "schema": "power.profile.acceptance.v1",
+                "version": "3.7.9",
+                "acceptance_harness_revision": COMMIT,
+                "image_digest": IMAGE_DIGEST,
+                "profile_a": {
+                    "native_cli": True,
+                    "native_mcp_stdio": True,
+                    "docker_web_containers": 0,
+                },
+                "profile_b": {
+                    "web_health": True,
+                    "web_authenticated_read": True,
+                    "web_semantic_non_fallback": True,
+                    "web_reranked_non_fallback": True,
+                    "web_governed_mutation": True,
+                    "host_cli_readback": True,
+                    "host_mcp_readback": True,
+                    "same_canonical_vault": True,
+                    "cache_delete_rebuild": True,
+                    "container_user": "10001:10001",
+                    "cap_drop_all": True,
+                    "read_only_rootfs": True,
+                    "web_mcp_services": 0,
+                    "web_applicationservice_bypass_count": 0,
+                },
+                "image": "ghcr.io/weby-homelab/power-framework-web:3.7.9@" + IMAGE_DIGEST,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
     manifest = {
         "schema": "power.release.manifest.v1",
@@ -77,7 +111,7 @@ def _write_fixture(tmp_path: Path) -> dict[str, Path | str]:
     checksum_files = [wheel, sdist, package_sbom, web_sbom, profile, manifest_path]
     _write_checksums(checksums_path, checksum_files)
 
-    receipt_path = tmp_path / "power-framework.release-receipt.json"
+    receipt_path = asset_dir / "power-framework.release-receipt.json"
     receipt = {
         "schema_version": 2,
         "release": {"tag": TAG, "commit": COMMIT},
@@ -123,7 +157,7 @@ def _refresh_manifest_receipt_and_checksum(paths: dict[str, Path | str]) -> None
     files = [
         path
         for path in Path(paths["asset_dir"]).iterdir()
-        if path.is_file() and path.name not in {checksum_path.name}
+        if path.is_file() and path.name not in {checksum_path.name, Path(paths["receipt"]).name}
     ]
     _write_checksums(checksum_path, files)
 
@@ -142,6 +176,35 @@ def _verify(paths: dict[str, Path | str]) -> dict[str, Any]:
 def test_valid_frozen_release_binding_passes(tmp_path: Path) -> None:
     result = _verify(_write_fixture(tmp_path))
     assert result["status"] == "verified"
+
+
+def test_required_manifest_filename_cannot_be_omitted(tmp_path: Path) -> None:
+    paths = _write_fixture(tmp_path)
+    _rewrite_manifest(paths, lambda data: data["artifacts"]["power_wheel"].pop("filename"))
+    _refresh_manifest_receipt_and_checksum(paths)
+    with pytest.raises(ValueError, match=r"power_wheel.*filename"):
+        _verify(paths)
+
+
+def test_release_receipt_schema_must_be_v2(tmp_path: Path) -> None:
+    paths = _write_fixture(tmp_path)
+    receipt_path = Path(paths["receipt"])
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["schema_version"] = 1
+    receipt_path.write_text(json.dumps(receipt, sort_keys=True) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="schema_version"):
+        _verify(paths)
+
+
+def test_release_receipt_must_be_inside_public_asset_directory(tmp_path: Path) -> None:
+    paths = _write_fixture(tmp_path)
+    receipt_path = Path(paths["receipt"])
+    external_receipt = tmp_path / receipt_path.name
+    external_receipt.write_bytes(receipt_path.read_bytes())
+    paths["receipt"] = external_receipt
+
+    with pytest.raises(ValueError, match="inside the public asset directory"):
+        _verify(paths)
 
 
 def test_manifest_wheel_sha_mismatch_fails_closed(tmp_path: Path) -> None:

--- a/tests/test_red_team_adversarial_suite.py
+++ b/tests/test_red_team_adversarial_suite.py
@@ -68,7 +68,41 @@ def _write_full_fixture(tmp_path: Path) -> dict[str, Any]:
     sdist.write_bytes(b"\x1f\x8b\x08\x00power_framework sdist content 3.7.9 candidate")
     package_sbom.write_bytes(b'{"spdxVersion":"SPDX-2.3","name":"power-framework"}\n')
     web_sbom.write_bytes(b'{"spdxVersion":"SPDX-2.3","name":"power-web"}\n')
-    profile.write_bytes(b'{"version":"3.7.9","image_digest":"' + IMAGE_DIGEST.encode() + b'"}\n')
+    profile.write_text(
+        json.dumps(
+            {
+                "schema": "power.profile.acceptance.v1",
+                "version": "3.7.9",
+                "acceptance_harness_revision": COMMIT,
+                "image_digest": IMAGE_DIGEST,
+                "profile_a": {
+                    "native_cli": True,
+                    "native_mcp_stdio": True,
+                    "docker_web_containers": 0,
+                },
+                "profile_b": {
+                    "web_health": True,
+                    "web_authenticated_read": True,
+                    "web_semantic_non_fallback": True,
+                    "web_reranked_non_fallback": True,
+                    "web_governed_mutation": True,
+                    "host_cli_readback": True,
+                    "host_mcp_readback": True,
+                    "same_canonical_vault": True,
+                    "cache_delete_rebuild": True,
+                    "container_user": "10001:10001",
+                    "cap_drop_all": True,
+                    "read_only_rootfs": True,
+                    "web_mcp_services": 0,
+                    "web_applicationservice_bypass_count": 0,
+                },
+                "image": "ghcr.io/weby-homelab/power-framework-web:3.7.9@" + IMAGE_DIGEST,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     baseline.write_bytes(b'{"schema":"power.release.baseline.v1","version":"3.7.9"}\n')
 
     manifest = {
@@ -401,7 +435,9 @@ def test_attack_6_web_attestation_subject_tampered(tmp_path: Path) -> None:
 def test_attack_6_profile_evidence_image_digest_mismatch(tmp_path: Path) -> None:
     """Attack 6b: Profile evidence image digest differs from manifest web image digest."""
     fix = _write_full_fixture(tmp_path)
-    fix["profile"].write_bytes(b'{"version":"3.7.9","image_digest":"sha256:' + b"8" * 64 + b'"}\n')
+    profile_data = json.loads(fix["profile"].read_text(encoding="utf-8"))
+    profile_data["image_digest"] = "sha256:" + "8" * 64
+    fix["profile"].write_text(json.dumps(profile_data, sort_keys=True) + "\n", encoding="utf-8")
 
     files = [
         fix["wheel"],

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -12,7 +12,7 @@ from scripts.generate_release_gate_manifest import (
     OPTIONAL_GATES,
     build_gate_manifest,
 )
-from scripts.generate_release_validation import build_validation_receipt
+from scripts.generate_release_validation import build_validation_receipt, main
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -123,3 +123,40 @@ def test_validation_receipt_records_unexecuted_mandatory_gates_as_pending(
     assert receipt["mandatory_skipped"] == 0
     assert receipt["pending_mandatory_gates"] == sorted(pending)
     assert receipt["publication_pending"] is True
+
+
+def test_validation_cli_writes_prepublication_receipt(tmp_path: Path) -> None:
+    junit, coverage = _inputs(tmp_path)
+    gates = tmp_path / "gates.json"
+    pending = {"profile-a-mcp-stdio", "public-release-readback"}
+    gates.write_text(
+        json.dumps(
+            build_gate_manifest(
+                passed_mandatory=set(MANDATORY_GATES) - pending,
+                skipped_mandatory=set(),
+                failed_mandatory=set(),
+                pending_mandatory=pending,
+                passed_optional=set(),
+                skipped_optional=set(OPTIONAL_GATES),
+            )
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "validation.json"
+
+    assert (
+        main(
+            [
+                "--junit-xml",
+                str(junit),
+                "--coverage-json",
+                str(coverage),
+                "--gate-manifest",
+                str(gates),
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    assert json.loads(output.read_text(encoding="utf-8"))["status"] == "prepublication-passed"


### PR DESCRIPTION
## Мета

- опублікувати recovery-fix для вже існуючого підписаного `v3.7.9`;
- зберегти `v3.7.8` та існуючий `v3.7.9` tag незмінними;
- виконати exact-SHA CI/CodeQL та merge лише після review і green checks.

## Перевірка

Локальний commit GPG-підписаний maintainer key. Untracked closure artifacts не додаються й не змінюються.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened release safeguards with signed, immutable tag admission and artifact verification.
  - Reduced credential persistence during automated checkout processes.

- **Release Management**
  - Added controlled recovery for publishing existing signed tags without modifying tags or releases.
  - Improved release evidence, attestations, and artifact verification.

- **Bug Fixes**
  - Enhanced validation of release receipts, manifests, profiles, and artifact bindings.

- **Documentation**
  - Added POWER 3.7.9 release notes and updated recovery policy documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->