### PR TITLE
fix: provide GHCR auth for v3.7.10 attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -797,13 +797,30 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
 
+      - name: Authenticate GHCR for Web attestation
+        env:
+          GHCR_TOKEN: ${{ secrets.POWER_RELEASE_GHCR_TOKEN || github.token }}
+          DOCKER_CONFIG: ${{ runner.temp }}/power-release-attestation-docker-config
+        run: |
+          set -euo pipefail
+          install -d -m 700 "$DOCKER_CONFIG"
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+
       - name: Attest the published Web image digest
         id: web_attestation
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/power-release-attestation-docker-config
         with:
           subject-name: ghcr.io/weby-homelab/power-framework-web
           subject-digest: ${{ steps.web_image.outputs.digest }}
           push-to-registry: true
+
+      - name: Clear GHCR credentials after Web attestation
+        if: always()
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/power-release-attestation-docker-config
+        run: docker logout ghcr.io
 
       - name: Generate the exact unified release manifest
         env:

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -324,6 +324,23 @@ def test_release_harness_and_publication_guards_are_tag_bound() -> None:
     assert "docker login ghcr.io" in attestation_step["run"]
     assert "docker logout ghcr.io" in attestation_step["run"]
 
+    web_auth_step = next(
+        step for step in steps if step.get("name") == "Authenticate GHCR for Web attestation"
+    )
+    assert web_auth_step["env"]["DOCKER_CONFIG"] == (
+        "${{ runner.temp }}/power-release-attestation-docker-config"
+    )
+    web_attestation = next(
+        step for step in steps if step.get("name") == "Attest the published Web image digest"
+    )
+    assert web_attestation["env"]["DOCKER_CONFIG"] == web_auth_step["env"]["DOCKER_CONFIG"]
+    clear_auth_step = next(
+        step for step in steps if step.get("name") == "Clear GHCR credentials after Web attestation"
+    )
+    assert clear_auth_step["if"] == "always()"
+    assert clear_auth_step["env"]["DOCKER_CONFIG"] == web_auth_step["env"]["DOCKER_CONFIG"]
+    assert clear_auth_step["run"] == "docker logout ghcr.io"
+
     evidence_step = next(
         step
         for step in steps


### PR DESCRIPTION
## Problem
The v3.7.10 release workflow reached Web attestation but the action could not find registry credentials.

## Fix
Provide a shared temporary Docker config to the attestation step, authenticate immediately before it, and log out afterward.

## Scope
No tag or release is moved. Existing v3.7.8, v3.7.9, and v3.7.10 refs remain unchanged.