### PR TITLE
fix: isolate GHCR attestation home

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -800,17 +800,17 @@ jobs:
       - name: Authenticate GHCR for Web attestation
         env:
           GHCR_TOKEN: ${{ secrets.POWER_RELEASE_GHCR_TOKEN || github.token }}
-          DOCKER_CONFIG: ${{ runner.temp }}/power-release-attestation-docker-config
+          HOME: ${{ runner.temp }}/power-release-attestation-home
         run: |
           set -euo pipefail
-          install -d -m 700 "$DOCKER_CONFIG"
+          install -d -m 700 "$HOME"
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
 
       - name: Attest the published Web image digest
         id: web_attestation
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         env:
-          DOCKER_CONFIG: ${{ runner.temp }}/power-release-attestation-docker-config
+          HOME: ${{ runner.temp }}/power-release-attestation-home
         with:
           subject-name: ghcr.io/weby-homelab/power-framework-web
           subject-digest: ${{ steps.web_image.outputs.digest }}
@@ -819,7 +819,7 @@ jobs:
       - name: Clear GHCR credentials after Web attestation
         if: always()
         env:
-          DOCKER_CONFIG: ${{ runner.temp }}/power-release-attestation-docker-config
+          HOME: ${{ runner.temp }}/power-release-attestation-home
         run: docker logout ghcr.io
 
       - name: Generate the exact unified release manifest

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -327,18 +327,16 @@ def test_release_harness_and_publication_guards_are_tag_bound() -> None:
     web_auth_step = next(
         step for step in steps if step.get("name") == "Authenticate GHCR for Web attestation"
     )
-    assert web_auth_step["env"]["DOCKER_CONFIG"] == (
-        "${{ runner.temp }}/power-release-attestation-docker-config"
-    )
+    assert web_auth_step["env"]["HOME"] == ("${{ runner.temp }}/power-release-attestation-home")
     web_attestation = next(
         step for step in steps if step.get("name") == "Attest the published Web image digest"
     )
-    assert web_attestation["env"]["DOCKER_CONFIG"] == web_auth_step["env"]["DOCKER_CONFIG"]
+    assert web_attestation["env"]["HOME"] == web_auth_step["env"]["HOME"]
     clear_auth_step = next(
         step for step in steps if step.get("name") == "Clear GHCR credentials after Web attestation"
     )
     assert clear_auth_step["if"] == "always()"
-    assert clear_auth_step["env"]["DOCKER_CONFIG"] == web_auth_step["env"]["DOCKER_CONFIG"]
+    assert clear_auth_step["env"]["HOME"] == web_auth_step["env"]["HOME"]
     assert clear_auth_step["run"] == "docker logout ghcr.io"
 
     evidence_step = next(


### PR DESCRIPTION
## Problem
The immutable v3.7.10 recovery run could not find GHCR credentials inside the composite attestation action.

## Fix
Use an isolated runner-temp HOME shared by docker login, the attestation action, and cleanup.

## Scope
No tag or release is moved; v3.7.8, v3.7.9, and v3.7.10 remain unchanged.