### PR TITLE
fix: authenticate private GHCR public readback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1109,8 +1109,10 @@ jobs:
       - name: Verify public asset checksums, manifest bindings, and OCI readback
         env:
           GH_TOKEN: ${{ github.token }}
+          GHCR_TOKEN: ${{ secrets.POWER_RELEASE_GHCR_TOKEN || github.token }}
           WEB_IMAGE_REF: ${{ steps.web_image.outputs.final_reference }}
           WEB_IMAGE_DIGEST: ${{ steps.web_image.outputs.digest }}
+          DOCKER_CONFIG: ${{ runner.temp }}/power-release-readback-docker-config
         run: |
           set -euo pipefail
           readback_dir="$RUNNER_TEMP/power-public-readback"
@@ -1125,9 +1127,14 @@ jobs:
             --expected-tag-target "$REMOTE_TAG_TARGET")"
           printf '%s\n' "$binding_result" > "$RUNNER_TEMP/power-public-bindings.json"
           verified_image_digest="$(printf '%s\n' "$binding_result" | python3 -c 'import json, sys; print(json.load(sys.stdin)["web_image_digest"])')"
+          install -d -m 700 "$DOCKER_CONFIG"
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          trap 'docker logout ghcr.io' EXIT
           registry_digest="$(docker buildx imagetools inspect "$WEB_IMAGE_REF" | python3 -c 'import sys; print(next(line.split()[1] for line in sys.stdin if line.startswith("Digest:")))')"
           test "$verified_image_digest" = "$WEB_IMAGE_DIGEST"
           test "$registry_digest" = "$verified_image_digest"
+          docker logout ghcr.io
+          trap - EXIT
 
       - name: Verify public artifact and Web attestations
         env:

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -315,6 +315,12 @@ def test_release_harness_and_publication_guards_are_tag_bound() -> None:
     assert '"$RELEASE_CONTROL_ROOT/verify_public_release_bindings.py"' in public_binding_step["run"]
     assert 'verified_image_digest"' in public_binding_step["run"]
     assert 'registry_digest" = "$verified_image_digest"' in public_binding_step["run"]
+    assert public_binding_step["env"]["DOCKER_CONFIG"] == (
+        "${{ runner.temp }}/power-release-readback-docker-config"
+    )
+    assert "GHCR_TOKEN" in public_binding_step["env"]
+    assert "docker login ghcr.io" in public_binding_step["run"]
+    assert "docker logout ghcr.io" in public_binding_step["run"]
 
     attestation_step = next(
         step for step in steps if step.get("name") == "Verify public artifact and Web attestations"


### PR DESCRIPTION
## Problem
The v3.7.10 release was created successfully, but the final OCI readback ran after logout and received GHCR 401.

## Fix
Authenticate the readback step with an isolated runner-temp Docker config, verify the digest, then logout.

## Scope
No tag or existing Release is moved or replaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release verification when checking promoted web image data stored in GHCR.
  * Ensured temporary authentication credentials are securely cleared after verification.

* **Tests**
  * Added regression coverage for authenticated container registry checks during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->