### PR TITLE
fix: admit signed merge release source

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - ".github/workflows/release.yml"
   pull_request:
     branches: [main]
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - ".github/workflows/release.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,15 @@ jobs:
           PY
 
           commit_verification="$RUNNER_TEMP/power-release-admission-commit-verification.txt"
-          git verify-commit --raw "$local_tag_target" > "$commit_verification" 2>&1
+          verified_commit="$local_tag_target"
+          if ! git verify-commit --raw "$local_tag_target" > "$commit_verification" 2>&1; then
+            read -r -a merge_parents <<< "$(git show -s --format=%P "$local_tag_target")"
+            test "${#merge_parents[@]}" -eq 2
+            test "$(git show -s --format=%T "$local_tag_target")" = "$(git show -s --format=%T "${merge_parents[1]}")"
+            verified_commit="${merge_parents[1]}"
+            git verify-commit --raw "$verified_commit" > "$commit_verification" 2>&1
+            printf '%s\n' "GitHub merge commit is unsigned; exact-tree signed PR head is admitted" >&2
+          fi
           python3 - "$commit_verification" <<'PY'
           from pathlib import Path
           import sys
@@ -150,7 +158,7 @@ jobs:
               and fields[-1] == expected_primary
           ]
           if len(valid) != 1:
-              raise SystemExit("release tag target commit is not verified by the pinned maintainer key")
+              raise SystemExit("release source commit is not verified by the pinned maintainer key")
           PY
 
           printf 'tag_object=%s\n' "$remote_tag_object" >> "$GITHUB_OUTPUT"

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -182,6 +182,10 @@ def test_release_publish_is_blocked_by_a_tag_validation_job() -> None:
     )
     assert 'git verify-tag --raw "$RELEASE_TAG"' in admission_run
     assert 'git verify-commit --raw "$local_tag_target"' in admission_run
+    assert "read -r -a merge_parents" in admission_run
+    assert 'git show -s --format=%P "$local_tag_target"' in admission_run
+    assert 'git show -s --format=%T "$local_tag_target"' in admission_run
+    assert 'verified_commit="${merge_parents[1]}"' in admission_run
     assert 'git cat-file -t "$local_tag_object"' in admission_run
     assert "uv run" not in admission_run
     assert "pytest" not in admission_run

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -36,6 +36,12 @@ def test_ci_defers_non_linux_runtime_smoke_for_3_6_2() -> None:
     assert "runs-on: ubuntu-latest" in ci_text
 
 
+def test_docs_build_covers_release_workflow_changes() -> None:
+    docs_text = (WORKFLOWS_DIR / "docs.yml").read_text(encoding="utf-8")
+
+    assert docs_text.count('".github/workflows/release.yml"') == 2
+
+
 def test_ci_aggregates_all_supported_ubuntu_reports() -> None:
     ci_text = (WORKFLOWS_DIR / "ci.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- Repair only the canonical release tag-admission control plane.
- Keep the immutable `v3.7.11` tag and its source tree unchanged.
- Admit a GitHub-generated unsigned merge commit only when its signed second
  parent has the exact same tree and is verified by the pinned maintainer key.

## Evidence

- Release run `33624941368` failed before `validate`/`release` because the
  GitHub merge commit is not itself GPG-signed.
- Local recovery simulation verified the existing tag signature, two-parent
  merge shape, exact-tree equality, and signed PR-head parent.
- `tests/test_ci_policy.py` passes; YAML parses successfully.

## Safety boundary

This is control-plane-only recovery. It does not move or recreate `v3.7.11`,
change package/source bytes, or publish a release. After merge, dispatch the
canonical `release.yml` workflow from updated `main` with `release_tag=v3.7.11`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Validation**
  - Release verification now supports eligible two-parent merge commits when the corresponding pull request head is properly signed and matches the merged tree.
  - Directly signed release target commits continue to be verified as before.
  - Verification failures now identify the release source commit more clearly.
- **Testing**
  - Added regression coverage for merge-commit admission and signed commit selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->