### PR TITLE
fix: verify public attestations with exact identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1212,24 +1212,25 @@ jobs:
           wheel="$readback_dir/power_framework-${version}-py3-none-any.whl"
           sdist="$readback_dir/power_framework-${version}.tar.gz"
           lock="$readback_dir/power-native-requirements.txt"
+          attestation_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@${GITHUB_REF}"
           gh attestation verify \
             "$wheel" \
             --repo "$GITHUB_REPOSITORY" \
-            --signer-workflow .github/workflows/release.yml \
+            --cert-identity "$attestation_identity" \
             --predicate-type https://slsa.dev/provenance/v1 \
             --format json \
             > "$RUNNER_TEMP/power-wheel-attestation.json"
           gh attestation verify \
             "$sdist" \
             --repo "$GITHUB_REPOSITORY" \
-            --signer-workflow .github/workflows/release.yml \
+            --cert-identity "$attestation_identity" \
             --predicate-type https://slsa.dev/provenance/v1 \
             --format json \
             > "$RUNNER_TEMP/power-sdist-attestation.json"
           gh attestation verify \
             "$lock" \
             --repo "$GITHUB_REPOSITORY" \
-            --signer-workflow .github/workflows/release.yml \
+            --cert-identity "$attestation_identity" \
             --predicate-type https://slsa.dev/provenance/v1 \
             --format json \
             > "$RUNNER_TEMP/power-dependency-lock-attestation.json"
@@ -1240,7 +1241,7 @@ jobs:
             "oci://${WEB_IMAGE_REF}@${WEB_IMAGE_DIGEST}" \
             --repo "$GITHUB_REPOSITORY" \
             --bundle-from-oci \
-            --signer-workflow .github/workflows/release.yml \
+            --cert-identity "$attestation_identity" \
             --predicate-type https://slsa.dev/provenance/v1 \
             --format json \
             > "$RUNNER_TEMP/power-web-attestation.json"
@@ -1250,7 +1251,7 @@ jobs:
           common_args=(
             --repository "$GITHUB_REPOSITORY"
             --workflow .github/workflows/release.yml
-            --source-revision "$REMOTE_TAG_TARGET"
+            --source-revision "$GITHUB_SHA"
             --event "$GITHUB_EVENT_NAME"
             --ref "$GITHUB_REF"
             --run-id "$GITHUB_RUN_ID"

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -380,7 +380,8 @@ def test_release_harness_and_publication_guards_are_tag_bound() -> None:
     )
     assert "gh attestation verify" in attestation_step["run"]
     assert "--bundle-from-oci" in attestation_step["run"]
-    assert "--signer-workflow .github/workflows/release.yml" in attestation_step["run"]
+    assert '--cert-identity "$attestation_identity"' in attestation_step["run"]
+    assert '--source-revision "$GITHUB_SHA"' in attestation_step["run"]
     assert "verify_attestation_provenance.py" in attestation_step["run"]
     assert attestation_step["run"].count("power-native-requirements.txt") >= 2
     assert attestation_step["run"].count("verify_attestation_provenance.py") == 4


### PR DESCRIPTION
## Summary

- Repair the canonical public attestation readback command after release run
  `33626817991` failed post-publication.
- Use the exact certificate identity emitted by the GitHub Actions attestation
  (`https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@${GITHUB_REF}`)
  instead of the incomplete `--signer-workflow` value.
- Verify the attestation source against the actual workflow SHA (`GITHUB_SHA`),
  which is the control-plane revision for immutable recovery.

## Safety

- No package/source bytes, release assets, GHCR tag, or `v3.7.11` tag are
  modified.
- Public clean-room verification already confirms all four attestation subjects
  with the corrected identity/source binding.
- This is a control/readback-only repair for future runs and auditability.
