### PR TITLE
fix(security): close model egress and source-read boundaries

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,10 @@ The following boundaries are part of the current contract:
 - Paths supplied by a caller, note names, Markdown, YAML, search queries, and
   MCP arguments are untrusted input. A path must remain inside the configured
   vault; traversal, absolute paths, unsafe symlink resolution, and unsupported
-  note targets must be rejected before a write.
+  note targets must be rejected before a read or write. `source.read` is
+  authorized by canonical source-projection membership, not by filesystem
+  containment alone: only regular, non-symlink, in-scope Markdown with valid
+  OKF metadata may be returned.
 - Vault content returned by search or retrieval is data, not instructions.
   Agents and downstream LLM clients must not execute instructions found inside
   a note merely because P.O.W.E.R. returned it.
@@ -44,6 +47,16 @@ The following boundaries are part of the current contract:
   query-expansion, or ROT request requires an explicit policy appropriate to
   the content sensitivity. An endpoint configured by an operator is not, by
   itself, proof that a note may be sent there.
+- Model acquisition is a separate authorization boundary. Canonical neural
+  models require their pinned repository, immutable revision, and complete
+  runtime-file SHA-256 manifest plus the expected provider/license binding.
+  Custom model identities additionally require explicit opt-in and an exact
+  operation/provider/license/repository/revision approval manifest. Delegated
+  loaders receive only a private staging directory containing those verified
+  files. `POWER_MODEL_OFFLINE=1`,
+  `HF_HUB_OFFLINE=1`, and `TRANSFORMERS_OFFLINE=1` are cache-only controls and
+  cannot be overridden by a permissive egress policy. Remote HF acquisition is
+  restricted to the exact HTTPS `huggingface.co` origin.
 - MCP is a local stdio process interface and requires `POWER_VAULT_DIR` as its
   single configured vault boundary. The Web UI is a separate HTTP application;
   it is not an MCP transport. Remote MCP, MCP HTTP, SSE, and TCP transports are
@@ -76,6 +89,15 @@ CI gates:
 - `resolve_path_in_vault` and `atomic_write_in_vault` enforce vault containment,
   reject unsafe paths and symlink targets, and use atomic destination-local
   writes where the platform supports the required descriptor safeguards.
+- `core/source_service.py` resolves every source read through the canonical
+  projection, rejects control/non-source files, absolute and traversal paths,
+  and validates regular non-symlink files plus projection hash/metadata before
+  returning content. Web calls use this same `ApplicationService` boundary;
+  MCP does not publish an alternate raw-file reader.
+- Search result materialization, reranking, graph expansion, and provenance
+  hashing use the same request-scoped canonical source reader rather than
+  opening database-derived paths directly. Web retrieval disables the legacy
+  caller-selected search-database compatibility override.
 - YAML frontmatter is parsed with safe loading; typed models validate the
   supported schema while compatibility fields are handled as data rather than
   being treated as executable input.
@@ -88,6 +110,12 @@ CI gates:
   cancellation transitions rather than inferred from note text.
 - `POWER_EGRESS_POLICY` is checked before remote operations and rejects unknown
   policy or sensitivity values.
+- `core/model_policy.py` is the shared model boundary for direct HF and
+  delegated FastEmbed/Qwen/ColBERT loaders. It checks offline mode, calls the
+  central egress guard before any remote HF function, binds custom identities
+  to exact operation/provider/license/immutable-revision identities and
+  complete manifests, verifies every file, and hands delegated loaders only a
+  verified private staging directory.
 - The MCP server requires a configured vault root, constrains tool paths and
   write targets, rate-limits mutation/index operations, and masks internal
   tracebacks from client responses.
@@ -98,6 +126,24 @@ CI gates:
 These controls reduce risk but do not make a vault safe from a compromised host,
 malicious same-user process, compromised dependency, or an operator who
 deliberately enables a risky integration.
+
+## WEB-01 and WEB-05 closure record
+
+The following findings were identified against the `3.7.11` baseline commit
+`be83652aec2daedeb2c98b604b5a49d13e989c7e`. Their historical identity is
+preserved here; this record describes the security remediation and does not
+authorize a dependency refresh, version bump, tag, or release.
+
+| Finding | Remediation | Focused evidence | Status |
+| --- | --- | --- | --- |
+| **WEB-01 (P1):** `source.read` could expose an in-vault regular file outside the canonical Markdown/source boundary. | The core resolver requires projection membership, in-scope valid OKF Markdown, regular non-symlink containment, and freshness/hash checks before opening bytes. | `tests/test_source_projection.py`, `tests/test_application_v2.py`, and `tests/web/contract/test_app_routes.py`; the locked focused security matrix passed with 461 tests. | **CLOSED** |
+| **WEB-05 (P1):** HF/model acquisition could bypass central egress/offline and accept incomplete custom identity/integrity controls. | `core/model_policy.py` centralizes deny-before-network, offline precedence, exact operation/provider/license/immutable identity approval, complete SHA-256 verification, and private verified-file staging for embedding/reranking paths. | `tests/test_model_policy.py`, `tests/test_embeddings.py`, `tests/test_reranker.py`, `tests/test_egress.py`; the locked focused security matrix passed with 461 tests. | **CLOSED** |
+
+Remote CI, CodeQL, documentation, package-audit, release, and merge gates remain
+independent evidence requirements. They are not implied by this local closure.
+
+The full local locked suite subsequently passed with **1755 passed, 14 skipped,
+4 warnings**, and **82.94% coverage** under the repository's 70% gate.
 
 ## Report a vulnerability
 

--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -49,11 +49,17 @@ cache namespace, or a legacy index during a normal request. The explicit
 behavior and is not a production deployment profile. The bounded fallback is
 labelled `no_active_generation_bounded_scan` in result metadata.
 
-`source.read` reads one bounded file directly. Stem lookup consults the
-projection; multiple candidates produce a typed conflict rather than silently
-selecting the first file. `last_indexed_at` is the generation completion time,
-`healthy` means verified projection coverage/integrity, and `total_links` counts
-resolved links only. Ambiguities remain separately visible in graph data.
+`source.read` resolves both exact paths and stems through the canonical source
+projection before opening bytes. A readable source must be a current, regular,
+non-symlink Markdown file in the existing P.A.R.A./ignore scope with valid OKF
+metadata; filesystem containment alone is not authorization. Unsupported
+regular files, control directories, absolute paths, traversal, and projection
+misses use typed not-found/invalid failures without returning file contents,
+size, digest, or internal control metadata. Multiple stem candidates produce a
+typed conflict rather than silently selecting the first file. `last_indexed_at`
+is the generation completion time, `healthy` means verified projection
+coverage/integrity, and `total_links` counts resolved links only. Ambiguities
+remain separately visible in graph data.
 
 Graph `focus_path` and `max_depth` implement deterministic bounded BFS. A missing
 focus path is a typed not-found result; `max_depth` is not an echoed decorative
@@ -70,7 +76,7 @@ as typed `source_projection_stale` and fails closed; operators must run
 |---|---:|---:|---:|---:|
 | `source.list` | supported | not published | not published | supported through `PowerClient` |
 | `source.stats` | supported | not published | not published | supported through `PowerClient` |
-| `source.read` | supported | not published | not published | supported through `PowerClient` |
+| `source.read` | supported | not published | not published (catalog reads only) | supported through `PowerClient` |
 | `source.graph` | supported | not published | not published | supported through `PowerClient` |
 | `retrieve` | supported | supported | supported | supported through `PowerClient` |
 | Task/Decision/Proposal/Receipt | supported | supported adapter paths | supported adapter paths | supported through `PowerClient` |

--- a/docs/api/embeddings.md
+++ b/docs/api/embeddings.md
@@ -39,6 +39,28 @@ when it is unset. Supported values are `auto`, `cpu`, `cuda`, `rocm`, and
   the verified provider after successful session creation; a failed check does
   not retain the invalid session.
 
+### Model acquisition security contract
+
+The canonical BGE-M3 loader uses the pinned repository, immutable commit, and
+complete runtime-file SHA-256 manifest from `release/models.lock.json`. A
+complete cached canonical snapshot works with the default
+`POWER_EGRESS_POLICY=deny`; a missing file fails before any HF network call
+under deny/offline policy. An explicitly permissive policy may fetch the
+missing pinned files through the central egress gate and verifies them before
+loading.
+`POWER_MODEL_OFFLINE=1`, `HF_HUB_OFFLINE=1`, and `TRANSFORMERS_OFFLINE=1` all
+force cache-only behavior, even when a permissive egress policy is configured.
+Remote acquisition is restricted to the exact HTTPS `huggingface.co` origin.
+
+Legacy FastEmbed and Qwen model references are not authorization grants. A
+delegated custom model must use `org/model@<40-hex-commit>` and require both
+`POWER_ALLOW_CUSTOM_MODELS=1` and a `POWER_MODEL_APPROVAL` JSON manifest with
+exact `operation`, `provider`, `license`, `repo`, `revision`, and a complete
+`files` SHA-256 map. The model policy verifies every approved file and gives
+the delegated loader a private staging directory containing only those files.
+Unapproved, floating, partial, or mismatched models fail closed. Ollama remains
+local-loopback-only.
+
 `POWER_EMBED_DEVICE=cuda` and `POWER_RERANKER_DEVICE=cuda` are therefore
 runtime assertions, not performance hints. Set the corresponding variable to
 `auto` when CPU fallback is intended.
@@ -46,7 +68,7 @@ runtime assertions, not performance hints. Set the corresponding variable to
 ### Canonical — `BGEM3OnnxManager`
 
 ```python
-BGEM3OnnxManager(model_name: str = "BAAI/bge-m3")
+BGEM3OnnxManager(repo: str | None = None, revision: str | None = None)
 ```
 
 - Direct `onnxruntime` + `tokenizers` loader (no PyTorch, no fastembed).

--- a/docs/api/reranker.md
+++ b/docs/api/reranker.md
@@ -50,7 +50,7 @@ Predict relevance scores for document strings against a query in bounded batches
 
 Cross-encoder adapter for `jinaai/jina-reranker-v2-base-multilingual` or Qwen3 reranker. The Jina model is CC-BY-NC-4.0 and is **not** a production default.
 
-It is loaded only when **both** `POWER_RERANKER=jina` and `POWER_ALLOW_NONCOMMERCIAL_MODELS=1` are explicitly set for permitted non-commercial use. Otherwise, lazy model initialization on the first `rerank()` call raises `NonCommercialModelDisabledError`.
+It is loaded only when **both** `POWER_RERANKER=jina` and `POWER_ALLOW_NONCOMMERCIAL_MODELS=1` are explicitly set for permitted non-commercial use, and the central immutable approval/hash contract also passes. Otherwise, lazy model initialization on the first `rerank()` call raises a typed policy error.
 
 ### Constructor
 
@@ -59,6 +59,15 @@ RerankerManager(model_name: str = "jinaai/jina-reranker-v2-base-multilingual")
 ```
 
 - `model_name`: Cross-encoder model name to load when the license policy permits it.
+
+For the Jina/Qwen/ColBERT delegated paths, model loading also requires the
+central custom-model contract: an immutable `org/model@<40-hex-commit>`
+reference, `POWER_ALLOW_CUSTOM_MODELS=1`, and a `POWER_MODEL_APPROVAL` manifest
+binding exact operation/provider/license/repository/revision values to a
+complete runtime-file SHA-256 map. Verified files are staged privately before
+construction; `POWER_MODEL_OFFLINE=1`, `HF_HUB_OFFLINE=1`, and
+`TRANSFORMERS_OFFLINE=1` remain authoritative during import, construction, and
+inference. Missing approval or cache data fails before a remote loader call.
 
 ### Methods
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -35,6 +35,7 @@ environment is trustworthy.
 | --- | --- | --- | --- |
 | CLI/MCP input to core | validated core APIs | paths, note text, queries, proposal JSON, MCP arguments | Treat inputs as untrusted; validate before read/write/network use. |
 | Vault root to host filesystem | selected canonical vault | traversal strings, symlinks, absolute paths, arbitrary parents | No read or write may escape the configured vault. |
+| Canonical source projection to source.read | validated source records | in-vault regular files, invalid Markdown, hidden control material, projection aliases | Containment is necessary but not sufficient; only a current, regular, non-symlink source record may be read. |
 | Read-only retrieval to mutation | search and proposal creation | an agent or caller requesting a change | Proposal creation may write only its content-addressed `.power/proposals/` ledger; it cannot write the target note, catalog, or search. Apply requires explicit `approved=True` and an unchanged pre-image hash. |
 | Agent handoff to workflow execution | validated work-packet state | packet objective, next action, retrieved note text, and caller-supplied metadata | `.power/work-packets/` stores content-free Markdown checkpoints; state transitions are idempotent and approval-gated, and no packet operation executes its `next_action`. |
 | Local process to network | local ONNX/FTS/index paths | OpenRouter, non-loopback Ollama, link/ROT HTTP targets | Default deny; an explicit sensitivity-appropriate egress policy is required before contact. |
@@ -61,7 +62,9 @@ environment is trustworthy.
 ### Primary runtime surfaces
 
 1. **CLI and library calls** accept a vault directory, Markdown, search text,
-   policy settings, and transaction proposals.
+   policy settings, and transaction proposals. `source.read` is a
+   projection-backed core operation; the Web UI delegates to it and MCP has no
+   separate raw-file reader.
 2. **MCP tools** expose read, index, ingest, maintenance, and memory operations
    to an MCP client. The server resolves only `POWER_VAULT_DIR`
    before accepting a vault and rejects a substituted root.
@@ -78,6 +81,17 @@ environment is trustworthy.
   control characters, non-Markdown targets, missing parents, and symlink
   escapes. `atomic_write_in_vault` uses descriptor-relative operations and
   `O_NOFOLLOW` for the destination directory.
+- `core/source_service.py::_resolve_canonical_source` requires exact or stem
+  membership in the active or bounded source projection, applies the existing
+  P.A.R.A./ignore/catalog eligibility rules, rejects symlinks and unsupported
+  files, and checks source metadata, size, modification time, and SHA-256
+  before returning content. Rejected non-source paths use typed, redacted
+  not-found behavior.
+- Search FTS/vector/semantic/rerank/graph/provenance materialization reuses a
+  request-scoped canonical source reader for both file bytes and result
+  metadata. The Web client disables the legacy caller-selected search database
+  override, and application construction does not create task control state
+  until a task operation needs it.
 - `core/mutation.py` serializes same-vault mutations with an in-process lock
   plus an advisory cross-process file lock. `core/memory_api.py` requires
   explicit approval, validates content and pre-image hashes, and appends a
@@ -89,6 +103,14 @@ environment is trustworthy.
 - `core/egress.py` defaults `POWER_EGRESS_POLICY` to `deny`; remote embeddings,
   query expansion, and ROT paths call the policy guard before network use.
   Loopback model endpoints are treated as local.
+- `core/model_policy.py` is the single model-acquisition boundary. It treats
+  model names and overrides as untrusted, gives explicit offline flags
+  precedence, authorizes remote HF calls through `core/egress.py`, requires
+  immutable approved operation/provider/license identities and complete
+  runtime-file hashes, and verifies bytes before any model loader receives
+  them. Delegated loaders receive a private staging directory containing only
+  the approved files. Remote HF acquisition is restricted to the exact HTTPS
+  `huggingface.co` origin.
 - `mcp/power_server.py` validates the configured vault root, limits write and
   index request rates, masks error details, and fails closed for non-loopback
   HTTP transport.
@@ -101,6 +123,10 @@ environment is trustworthy.
 - A malicious note or MCP argument attempts `../`, a symlink swap, or an
   absolute filename to overwrite a host file. Path and atomic-write controls
   must reject it before a file descriptor outside the vault is used.
+- A caller requests `.power` state, a JSON/SQLite file, invalid Markdown, or a
+  symlink through `source.read`. Filesystem containment alone does not
+  authorize the request; the source projection must reject it without
+  returning file contents, size, digest, or control-path metadata.
 - An agent submits a memory proposal without approval, tampers with its durable content
   hash, or applies it after another writer changed the note. The transaction
   API must reject all three cases and preserve receipts without storing note
@@ -115,8 +141,10 @@ environment is trustworthy.
   not an authorization grant.
 - A hostile or unreliable remote link/model endpoint attempts to consume time,
   return malformed responses, or influence downstream reasoning. The current
-  controls limit which calls may start; callers must retain timeouts, response
-  validation, and treat returned text as untrusted data.
+  controls limit which calls may start. Model downloads additionally require
+  central egress authorization, offline precedence, immutable identity approval,
+  and complete hash verification before execution; callers must retain
+  timeouts, response validation, and treat returned text as untrusted data.
 - A local process with the same OS privileges uses the MCP stdio server or
   reads `.power` state. This is a host authorization concern; do not expose the
   server remotely until the transport has authenticated client identity and
@@ -158,3 +186,31 @@ credible boundary crossing are not security findings.
 
 Repository: weby-homelab/power-framework
 Version: 3.7.11
+
+## WEB-01 and WEB-05 closure record
+
+Both findings were identified against the `3.7.11` baseline commit
+`be83652aec2daedeb2c98b604b5a49d13e989c7e`; their identifiers remain preserved
+for traceability. The focused locked-environment security matrix passed with
+461 tests.
+
+- **WEB-01 (P1) — CLOSED:** source-read authority is now the canonical
+  projection boundary, with existing scope/ignore/Markdown/OKF rules, regular
+  non-symlink checks, typed redacted rejection, and projection freshness/hash
+  validation. Evidence: `tests/test_source_projection.py`,
+  `tests/test_application_v2.py`, and
+  `tests/web/contract/test_app_routes.py`.
+- **WEB-05 (P1) — CLOSED:** direct and delegated model loaders now share the
+  model policy boundary for deny-before-network, all maintained offline flags,
+  immutable approved operation/provider/license identity, complete runtime
+  hashes, and private verified-file staging before construction. Evidence:
+  `tests/test_model_policy.py`,
+  `tests/test_embeddings.py`, `tests/test_reranker.py`, and
+  `tests/test_egress.py`.
+
+This local closure does not claim remote CI, CodeQL, Docs, package-audit,
+dependency-refresh, merge, or release gates. Phase 4 and version `3.7.11`
+remain unchanged.
+
+The full local locked suite subsequently passed with **1755 passed, 14 skipped,
+4 warnings**, and **82.94% coverage**.

--- a/src/power_framework/core/application.py
+++ b/src/power_framework/core/application.py
@@ -200,7 +200,7 @@ class ApplicationService:
         self.vault_dir = Path(vault_dir).expanduser().resolve()
         self._audit_hook = audit_hook
         self._search_fn = search_fn or search_vault
-        self.task_service = task_service or TaskService(self.vault_dir)
+        self.task_service = task_service or TaskService(self.vault_dir, create_vault=False)
         self.decision_service = DecisionService(self.vault_dir, task_service=self.task_service)
 
     def discover(self, *, context: RequestContext | None = None) -> ApplicationEnvelope:

--- a/src/power_framework/core/application_models.py
+++ b/src/power_framework/core/application_models.py
@@ -72,7 +72,7 @@ class SourceReadResponse(BaseDTO):
     metadata: dict[str, Any] = Field(default_factory=dict)
     trust_label: str = "local"
     source_revision: str = ""
-    actual_capability: str = "direct_file_read"
+    actual_capability: str = "active_source_projection"
     degraded_reason: str | None = None
 
 

--- a/src/power_framework/core/generation_index.py
+++ b/src/power_framework/core/generation_index.py
@@ -839,15 +839,16 @@ def _migrate_legacy_database(
             # The legacy database may contain rows built from an older version
             # of a note at the same relative path. Preserve it in the archive,
             # but never pair that derived content with the current projection.
-            for table in (
-                "fts_notes",
-                "file_metadata",
-                "tf_vectors",
-                "doc_embeddings",
-                "chunk_embeddings",
-                "temporal_records",
+            for statement in (
+                "DELETE FROM fts_notes",
+                "DELETE FROM file_metadata",
+                "DELETE FROM tf_vectors",
+                "DELETE FROM doc_embeddings",
+                "DELETE FROM chunk_embeddings",
+                "DELETE FROM temporal_records",
+                "DELETE FROM dense_index_manifest",
             ):
-                staging_conn.execute(f"DELETE FROM {table}")  # noqa: S608
+                staging_conn.execute(statement)
             staging_conn.commit()
             _sync_vault_to_db(
                 vault_dir,

--- a/src/power_framework/core/generation_index.py
+++ b/src/power_framework/core/generation_index.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from threading import RLock
 
-from .constants import is_catalog_filename
+from .constants import SKIP_FILES, is_catalog_filename
 from .db import _init_db
 from .ignore import should_skip
 from .index_sync import _sync_vault_to_db
@@ -247,7 +247,7 @@ def _source_inventory(vault_dir: Path) -> SourceInventory:
     invalid_sources: dict[str, str] = {}
     total_scanned = 0
     for path in sorted(iter_vault_markdown_files(vault_dir)):
-        if path.name in {"index.md", "log.md"} or is_catalog_filename(path.name):
+        if path.name in SKIP_FILES or is_catalog_filename(path.name):
             continue
         rel_path = path.relative_to(vault_dir).as_posix()
         if should_skip(vault_dir, rel_path):
@@ -836,6 +836,25 @@ def _migrate_legacy_database(
         ):
             legacy_conn.backup(staging_conn)
             _init_db(staging_conn)
+            # The legacy database may contain rows built from an older version
+            # of a note at the same relative path. Preserve it in the archive,
+            # but never pair that derived content with the current projection.
+            for table in (
+                "fts_notes",
+                "file_metadata",
+                "tf_vectors",
+                "doc_embeddings",
+                "chunk_embeddings",
+                "temporal_records",
+            ):
+                staging_conn.execute(f"DELETE FROM {table}")  # noqa: S608
+            staging_conn.commit()
+            _sync_vault_to_db(
+                vault_dir,
+                staging_conn,
+                sync_embeddings=sync_embeddings,
+                force_rebuild=True,
+            )
             write_projection(staging_conn, scan_projection(vault_dir))
             actual_files, actual_chunks, provider, model = _validate_staging(
                 staging_conn,

--- a/src/power_framework/core/index_sync.py
+++ b/src/power_framework/core/index_sync.py
@@ -13,7 +13,7 @@ from collections import Counter
 from typing import TYPE_CHECKING, Any, cast
 
 from .chunker import SemanticChunker
-from .constants import DENSE_INDEX_SCHEMA_VERSION, is_catalog_filename
+from .constants import DENSE_INDEX_SCHEMA_VERSION, SKIP_FILES, is_catalog_filename
 from .ignore import should_skip
 from .parser import read_file_content, validate_metadata
 from .source_projection import scan_projection, write_projection
@@ -125,7 +125,7 @@ def _sync_vault_to_db(
     for filepath in iter_vault_markdown_files(vault_dir):
         # Generated catalogs are navigation, not knowledge. Keep every page
         # out of both sparse and dense indexes, including `_index-N.md` pages.
-        if filepath.name in ("index.md", "log.md") or is_catalog_filename(filepath.name):
+        if filepath.name in SKIP_FILES or is_catalog_filename(filepath.name):
             continue
         if should_skip(vault_dir, filepath.relative_to(vault_dir).as_posix()):
             continue

--- a/src/power_framework/core/index_sync.py
+++ b/src/power_framework/core/index_sync.py
@@ -389,7 +389,8 @@ def _sync_vault_to_db(
         embedding_dimension = embedding_bytes // 4
     elif dense_count == 0:
         try:
-            embedding_dimension = int(embedder.dimension)
+            dimension = embedder.dimension
+            embedding_dimension = int(dimension() if callable(dimension) else dimension)
         except (AttributeError, TypeError, ValueError):
             embedding_dimension = 0
     else:

--- a/src/power_framework/core/index_sync.py
+++ b/src/power_framework/core/index_sync.py
@@ -115,6 +115,7 @@ def _sync_vault_to_db(
             try:
                 cursor.execute("DELETE FROM doc_embeddings")
                 cursor.execute("DELETE FROM chunk_embeddings")
+                cursor.execute("DELETE FROM dense_index_manifest")
                 cursor.execute("UPDATE file_metadata SET mtime = 0")
                 conn.commit()
             except sqlite3.OperationalError:
@@ -385,18 +386,31 @@ def _sync_vault_to_db(
     ).fetchone()
     dense_count, embedding_bytes = dense_row
     if dense_count and embedding_bytes and embedding_bytes % 4 == 0:
-        provider, model = _embedding_manifest_identity(embedder)
-        cursor.executemany(
-            "INSERT OR REPLACE INTO dense_index_manifest (manifest_key, manifest_value) VALUES (?, ?)",
-            [
-                ("schema_version", DENSE_INDEX_SCHEMA_VERSION),
-                ("embedding_dimension", str(embedding_bytes // 4)),
-                ("chunk_count", str(dense_count)),
-                ("embedding_provider", provider),
-                ("embedding_model", model),
-            ],
-        )
+        embedding_dimension = embedding_bytes // 4
+    elif dense_count == 0:
+        try:
+            embedding_dimension = int(embedder.dimension)
+        except (AttributeError, TypeError, ValueError):
+            embedding_dimension = 0
+    else:
+        cursor.execute("DELETE FROM dense_index_manifest")
         conn.commit()
+        _maybe_vacuum(conn, to_delete, db_files)
+        conn.commit()
+        return
+
+    provider, model = _embedding_manifest_identity(embedder)
+    cursor.executemany(
+        "INSERT OR REPLACE INTO dense_index_manifest (manifest_key, manifest_value) VALUES (?, ?)",
+        [
+            ("schema_version", DENSE_INDEX_SCHEMA_VERSION),
+            ("embedding_dimension", str(embedding_dimension)),
+            ("chunk_count", str(dense_count)),
+            ("embedding_provider", provider),
+            ("embedding_model", model),
+        ],
+    )
+    conn.commit()
     _maybe_vacuum(conn, to_delete, db_files)
     conn.commit()
 

--- a/src/power_framework/core/model_policy.py
+++ b/src/power_framework/core/model_policy.py
@@ -1,0 +1,474 @@
+"""Central model acquisition policy for POWER optional neural backends.
+
+The model identifier is configuration input, not an authorization grant.  This
+module keeps the egress check, immutable revision check, approval binding, and
+runtime-file verification in one small boundary shared by direct Hugging Face
+loaders and adapters that delegate loading to another package.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from threading import RLock
+from typing import TYPE_CHECKING
+
+from . import egress
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
+    from .egress import EgressOperation
+
+
+MODEL_APPROVAL_ENV = "POWER_MODEL_APPROVAL"
+ALLOW_CUSTOM_MODELS_ENV = "POWER_ALLOW_CUSTOM_MODELS"
+MODEL_OFFLINE_ENV_VARS = (
+    "POWER_MODEL_OFFLINE",
+    "HF_HUB_OFFLINE",
+    "TRANSFORMERS_OFFLINE",
+)
+DEFAULT_MODEL_ENDPOINT = "https://huggingface.co"
+
+_IMMUTABLE_REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
+_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,95}/[A-Za-z0-9][A-Za-z0-9_.-]{0,95}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_MAX_APPROVAL_BYTES = 64 * 1024
+_MODEL_ENV_LOCK = RLock()
+
+
+class ModelPolicyError(RuntimeError):
+    """Base class for fail-closed model policy failures."""
+
+
+class ModelApprovalError(ModelPolicyError):
+    """Raised when a model identity is not explicitly approved."""
+
+
+class ModelOfflineError(ModelPolicyError):
+    """Raised when offline mode cannot satisfy a model request from cache."""
+
+
+class ModelIntegrityError(ModelPolicyError):
+    """Raised when a model snapshot is incomplete or its bytes are not pinned."""
+
+
+@dataclass(frozen=True)
+class ApprovedModel:
+    """One exact model identity and its complete runtime-file hash manifest."""
+
+    repo: str
+    revision: str
+    provider: str
+    license: str
+    files: tuple[tuple[str, str], ...]
+    canonical: bool
+
+    @property
+    def hashes(self) -> dict[str, str]:
+        """Return the expected hash for every approved runtime file."""
+        return dict(self.files)
+
+
+@dataclass(frozen=True)
+class PreparedModel:
+    """Verified local files ready to be handed to an external model loader."""
+
+    spec: ApprovedModel
+    files: dict[str, str]
+    local_reference: str
+
+
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes"}
+
+
+def model_offline() -> bool:
+    """Return whether any POWER or maintained HF offline flag is authoritative."""
+    return any(_env_flag(name) for name in MODEL_OFFLINE_ENV_VARS)
+
+
+def _validate_repository(repo: str) -> str:
+    if not isinstance(repo, str) or not _REPOSITORY_RE.fullmatch(repo):
+        raise ModelApprovalError("invalid_model_repository")
+    return repo
+
+
+def _validate_provider(provider: str) -> str:
+    if not isinstance(provider, str) or not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9_.-]{0,95}", provider
+    ):
+        raise ModelApprovalError("invalid_model_provider")
+    return provider
+
+
+def _validate_license(license_name: str) -> str:
+    if not isinstance(license_name, str) or not license_name.strip() or len(license_name) > 128:
+        raise ModelApprovalError("model_license_required")
+    return license_name.strip()
+
+
+def _validate_revision(revision: str | None) -> str:
+    if not isinstance(revision, str) or not _IMMUTABLE_REVISION_RE.fullmatch(revision):
+        raise ModelApprovalError("immutable_model_revision_required")
+    return revision
+
+
+def _validate_file_names(required_files: tuple[str, ...]) -> tuple[str, ...]:
+    if not required_files or len(set(required_files)) != len(required_files):
+        raise ModelIntegrityError("complete_model_file_manifest_required")
+    for filename in required_files:
+        if not isinstance(filename, str) or not filename or "\\" in filename:
+            raise ModelIntegrityError("invalid_model_runtime_file")
+        path = PurePosixPath(filename)
+        if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+            raise ModelIntegrityError("invalid_model_runtime_file")
+    return tuple(required_files)
+
+
+def _validate_hash_manifest(
+    files: Mapping[str, object], required_files: tuple[str, ...]
+) -> tuple[tuple[str, str], ...]:
+    expected_names = set(required_files)
+    if set(files) != expected_names:
+        raise ModelIntegrityError("complete_model_file_manifest_required")
+    normalized: list[tuple[str, str]] = []
+    for filename in required_files:
+        digest = files.get(filename)
+        if not isinstance(digest, str) or not _SHA256_RE.fullmatch(digest.lower()):
+            raise ModelIntegrityError(f"invalid_model_sha256:{filename}")
+        normalized.append((filename, digest.lower()))
+    return tuple(normalized)
+
+
+def _load_custom_approval(
+    *,
+    operation: EgressOperation,
+    repo: str,
+    revision: str,
+    provider: str,
+    expected_license: str | None,
+    required_files: tuple[str, ...],
+) -> ApprovedModel:
+    if not _env_flag(ALLOW_CUSTOM_MODELS_ENV):
+        raise ModelApprovalError("custom_model_requires_approval")
+    raw = os.getenv(MODEL_APPROVAL_ENV, "").strip()
+    if not raw or len(raw.encode("utf-8")) > _MAX_APPROVAL_BYTES:
+        raise ModelApprovalError("custom_model_requires_approval")
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ModelApprovalError("custom_model_approval_is_invalid") from exc
+    if not isinstance(payload, dict):
+        raise ModelApprovalError("custom_model_approval_is_invalid")
+    if payload.get("repo") != repo or payload.get("revision") != revision:
+        raise ModelApprovalError("custom_model_identity_not_approved")
+    if payload.get("operation") != operation.value:
+        raise ModelApprovalError("custom_model_operation_not_approved")
+    if payload.get("provider") != provider:
+        raise ModelApprovalError("custom_model_provider_not_approved")
+    license_name = _validate_license(payload.get("license", ""))
+    if expected_license is not None and license_name != _validate_license(expected_license):
+        raise ModelApprovalError("custom_model_license_not_approved")
+    files = payload.get("files")
+    if not isinstance(files, dict):
+        raise ModelIntegrityError("complete_model_file_manifest_required")
+    hashes = _validate_hash_manifest(files, required_files)
+    return ApprovedModel(
+        repo=repo,
+        revision=revision,
+        provider=provider,
+        license=license_name,
+        files=hashes,
+        canonical=False,
+    )
+
+
+def resolve_model(
+    *,
+    operation: EgressOperation,
+    repo: str,
+    revision: str | None,
+    provider: str,
+    required_files: tuple[str, ...],
+    canonical_repo: str,
+    canonical_revision: str,
+    canonical_provider: str,
+    canonical_license: str,
+    canonical_hashes: Mapping[str, str],
+    custom_license: str | None = None,
+) -> ApprovedModel:
+    """Resolve a canonical or explicitly approved custom model identity."""
+    validated_repo = _validate_repository(repo)
+    validated_revision = _validate_revision(revision)
+    validated_provider = _validate_provider(provider)
+    filenames = _validate_file_names(required_files)
+    if (
+        validated_repo == canonical_repo
+        and validated_revision == canonical_revision
+        and validated_provider == canonical_provider
+    ):
+        hashes = _validate_hash_manifest(canonical_hashes, filenames)
+        return ApprovedModel(
+            repo=validated_repo,
+            revision=validated_revision,
+            provider=validated_provider,
+            license=_validate_license(canonical_license),
+            files=hashes,
+            canonical=True,
+        )
+    expected_custom_license = (
+        custom_license
+        if custom_license is not None
+        else (canonical_license if validated_provider == canonical_provider else None)
+    )
+    return _load_custom_approval(
+        operation=operation,
+        repo=validated_repo,
+        revision=validated_revision,
+        provider=validated_provider,
+        expected_license=expected_custom_license,
+        required_files=filenames,
+    )
+
+
+def _cached_model_files(spec: ApprovedModel) -> dict[str, str]:
+    """Return complete local HF cache hits without performing network I/O."""
+    cache_override = os.getenv("HF_HUB_CACHE")
+    if cache_override:
+        cache_root = Path(cache_override).expanduser()
+    else:
+        hf_home = os.getenv("HF_HOME")
+        if hf_home:
+            cache_root = Path(hf_home).expanduser() / "hub"
+        else:
+            xdg_cache = os.getenv("XDG_CACHE_HOME")
+            cache_root = (
+                Path(xdg_cache).expanduser() / "huggingface" / "hub"
+                if xdg_cache
+                else Path.home() / ".cache" / "huggingface" / "hub"
+            )
+    snapshot_root = (
+        cache_root / f"models--{spec.repo.replace('/', '--')}" / "snapshots" / spec.revision
+    )
+    cached: dict[str, str] = {}
+    for filename, _expected in spec.files:
+        candidate = snapshot_root / filename
+        if candidate.is_file():
+            cached[filename] = str(candidate)
+    return cached
+
+
+def _verify_model_files(spec: ApprovedModel, paths: Mapping[str, str]) -> dict[str, str]:
+    """Verify every approved runtime file before returning paths to a loader."""
+    expected = spec.hashes
+    if set(paths) != set(expected):
+        missing = ",".join(sorted(set(expected) - set(paths)))
+        raise ModelIntegrityError(f"incomplete_model_snapshot:{missing}")
+    verified: dict[str, str] = {}
+    for filename, expected_digest in spec.files:
+        path = Path(paths[filename])
+        if not path.is_file():
+            raise ModelIntegrityError(f"missing_model_runtime_file:{filename}")
+        checksum = hashlib.sha256()
+        with path.open("rb") as model_file:
+            for chunk in iter(lambda: model_file.read(8 * 1024 * 1024), b""):
+                checksum.update(chunk)
+        actual_hash = checksum.hexdigest()
+        if actual_hash != expected_digest:
+            raise ModelIntegrityError(f"model_sha256_mismatch:{filename}")
+        verified[filename] = str(path)
+    return verified
+
+
+def verify_model_files(spec: ApprovedModel, paths: Mapping[str, str]) -> dict[str, str]:
+    """Verify a model file mapping without acquiring or loading any model."""
+    return _verify_model_files(spec, paths)
+
+
+def _acquire_resolved_model(spec: ApprovedModel, operation: EgressOperation) -> dict[str, str]:
+    """Use cache when complete; otherwise authorize and fetch exactly pinned files."""
+    cached = _cached_model_files(spec)
+    if len(cached) == len(spec.files):
+        return verify_model_files(spec, cached)
+    if model_offline():
+        raise ModelOfflineError("model_offline_cache_missing")
+
+    # This is intentionally before importing/calling any HF network-capable API.
+    egress.require_remote_egress(operation, "public")
+    configured_endpoint = os.getenv("HF_ENDPOINT", DEFAULT_MODEL_ENDPOINT).strip().rstrip("/")
+    try:
+        endpoint = egress.validate_remote_endpoint(
+            configured_endpoint,
+            require_https=True,
+            allowed_origins=frozenset({DEFAULT_MODEL_ENDPOINT}),
+            allow_query=False,
+        )
+    except egress.EgressDeniedError as exc:
+        raise ModelApprovalError("model_endpoint_not_approved") from exc
+    if endpoint.path not in {"", "/"}:
+        raise ModelApprovalError("model_endpoint_not_approved")
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as exc:
+        raise ModelPolicyError("huggingface_hub_required_for_model_acquisition") from exc
+
+    downloaded: dict[str, str] = {}
+    for filename, _expected in spec.files:
+        downloaded[filename] = str(
+            hf_hub_download(
+                spec.repo,
+                filename,
+                revision=spec.revision,
+                local_files_only=False,
+            )
+        )
+    return verify_model_files(spec, downloaded)
+
+
+def acquire_model_files(
+    *,
+    operation: EgressOperation,
+    repo: str,
+    revision: str | None,
+    provider: str,
+    required_files: tuple[str, ...],
+    canonical_repo: str,
+    canonical_revision: str,
+    canonical_provider: str,
+    canonical_license: str,
+    canonical_hashes: Mapping[str, str],
+    custom_license: str | None = None,
+) -> dict[str, str]:
+    """Authorize, acquire, and verify a direct HF model snapshot."""
+    spec = resolve_model(
+        operation=operation,
+        repo=repo,
+        revision=revision,
+        provider=provider,
+        required_files=required_files,
+        canonical_repo=canonical_repo,
+        canonical_revision=canonical_revision,
+        canonical_provider=canonical_provider,
+        canonical_license=canonical_license,
+        canonical_hashes=canonical_hashes,
+        custom_license=custom_license,
+    )
+    return _acquire_resolved_model(spec, operation)
+
+
+def _split_model_reference(model_reference: str) -> tuple[str, str]:
+    """Split ``org/model@40-hex-commit`` references used by delegated loaders."""
+    if not isinstance(model_reference, str) or "@" not in model_reference:
+        raise ModelApprovalError("immutable_model_revision_required")
+    repo, revision = model_reference.rsplit("@", 1)
+    return _validate_repository(repo), _validate_revision(revision)
+
+
+def prepare_external_model(
+    *,
+    operation: EgressOperation,
+    provider: str,
+    model_reference: str,
+    expected_license: str | None = None,
+) -> PreparedModel:
+    """Prepare a custom delegated-loader model and return a local verified snapshot.
+
+    Delegated loaders do not expose a stable revision/hash API.  They therefore
+    accept only the exact ``repo@revision`` reference from an approval manifest,
+    acquire every manifest file through this boundary, and receive a local path
+    while all maintained offline flags are forced during construction.
+    """
+    repo, revision = _split_model_reference(model_reference)
+    if not _env_flag(ALLOW_CUSTOM_MODELS_ENV):
+        raise ModelApprovalError("custom_model_requires_approval")
+    raw = os.getenv(MODEL_APPROVAL_ENV, "").strip()
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ModelApprovalError("custom_model_approval_is_invalid") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("files"), dict):
+        raise ModelIntegrityError("complete_model_file_manifest_required")
+    required_files = tuple(str(filename) for filename in payload["files"])
+    spec = resolve_model(
+        operation=operation,
+        repo=repo,
+        revision=revision,
+        provider=provider,
+        required_files=required_files,
+        canonical_repo="__no_delegated_canonical_model__",
+        canonical_revision="0" * 40,
+        canonical_provider="__no_delegated_provider__",
+        canonical_license="custom",
+        canonical_hashes={},
+        custom_license=expected_license,
+    )
+    files = _acquire_resolved_model(spec, operation)
+    # Never expose the shared HF snapshot to a delegated loader: it may contain
+    # unapproved config, code, tokenizer, or checkpoint files. Hardlinks avoid
+    # copying multi-gigabyte model sidecars; the fallback copy keeps the same
+    # isolated file set on filesystems that do not support hardlinks.
+    staging_root = Path(tempfile.mkdtemp(prefix="power-model-"))
+    staged_files: dict[str, str] = {}
+    try:
+        for filename, _digest in spec.files:
+            source = Path(files[filename]).resolve(strict=True)
+            destination = staging_root / filename
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                os.link(source, destination)
+            except OSError:
+                shutil.copyfile(source, destination)
+            staged_files[filename] = str(destination)
+        verified_staged = verify_model_files(spec, staged_files)
+    except (OSError, RuntimeError) as exc:
+        raise ModelIntegrityError("isolated_model_snapshot_failed") from exc
+    return PreparedModel(
+        spec=spec,
+        files=verified_staged,
+        local_reference=str(staging_root),
+    )
+
+
+@contextmanager
+def force_model_offline() -> Iterator[None]:
+    """Prevent delegated constructors from opening a second remote acquisition path."""
+    with _MODEL_ENV_LOCK:
+        previous = {name: os.environ.get(name) for name in MODEL_OFFLINE_ENV_VARS}
+        for name in MODEL_OFFLINE_ENV_VARS:
+            os.environ[name] = "1"
+        try:
+            yield
+        finally:
+            for name, value in previous.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+
+
+__all__ = [
+    "ALLOW_CUSTOM_MODELS_ENV",
+    "DEFAULT_MODEL_ENDPOINT",
+    "MODEL_APPROVAL_ENV",
+    "MODEL_OFFLINE_ENV_VARS",
+    "ApprovedModel",
+    "ModelApprovalError",
+    "ModelIntegrityError",
+    "ModelOfflineError",
+    "ModelPolicyError",
+    "PreparedModel",
+    "acquire_model_files",
+    "force_model_offline",
+    "model_offline",
+    "prepare_external_model",
+    "resolve_model",
+    "verify_model_files",
+]

--- a/src/power_framework/core/model_policy.py
+++ b/src/power_framework/core/model_policy.py
@@ -15,7 +15,7 @@ import re
 import shutil
 import tempfile
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from threading import RLock
 from typing import TYPE_CHECKING
@@ -77,13 +77,33 @@ class ApprovedModel:
         return dict(self.files)
 
 
-@dataclass(frozen=True)
+@dataclass
 class PreparedModel:
     """Verified local files ready to be handed to an external model loader."""
 
     spec: ApprovedModel
     files: dict[str, str]
     local_reference: str
+    _release_lock: RLock = field(default_factory=RLock, init=False, repr=False, compare=False)
+    _released: bool = field(default=False, init=False, repr=False, compare=False)
+
+    def release(self) -> None:
+        """Release this model's private staging tree exactly once."""
+        with self._release_lock:
+            if self._released:
+                return
+            staging_root = Path(self.local_reference)
+            if staging_root.is_symlink():
+                raise ModelIntegrityError("model_staging_root_is_symlink")
+            if staging_root.exists():
+                if not staging_root.is_dir():
+                    raise ModelIntegrityError("model_staging_root_is_not_directory")
+                shutil.rmtree(staging_root)
+            self._released = True
+
+    def close(self) -> None:
+        """Compatibility alias for :meth:`release` used by manager shutdown."""
+        self.release()
 
 
 def _env_flag(name: str) -> bool:
@@ -92,7 +112,8 @@ def _env_flag(name: str) -> bool:
 
 def model_offline() -> bool:
     """Return whether any POWER or maintained HF offline flag is authoritative."""
-    return any(_env_flag(name) for name in MODEL_OFFLINE_ENV_VARS)
+    with _MODEL_ENV_LOCK:
+        return any(_env_flag(name) for name in MODEL_OFFLINE_ENV_VARS)
 
 
 def _validate_repository(repo: str) -> str:
@@ -294,6 +315,14 @@ def verify_model_files(spec: ApprovedModel, paths: Mapping[str, str]) -> dict[st
 
 
 def _acquire_resolved_model(spec: ApprovedModel, operation: EgressOperation) -> dict[str, str]:
+    """Acquire one approved model while serializing constructor environment windows."""
+    with _MODEL_ENV_LOCK:
+        return _acquire_resolved_model_locked(spec, operation)
+
+
+def _acquire_resolved_model_locked(
+    spec: ApprovedModel, operation: EgressOperation
+) -> dict[str, str]:
     """Use cache when complete; otherwise authorize and fetch exactly pinned files."""
     cached = _cached_model_files(spec)
     if len(cached) == len(spec.files):
@@ -328,6 +357,7 @@ def _acquire_resolved_model(spec: ApprovedModel, operation: EgressOperation) -> 
                 filename,
                 revision=spec.revision,
                 local_files_only=False,
+                endpoint=endpoint.origin,
             )
         )
     return verify_model_files(spec, downloaded)
@@ -416,7 +446,7 @@ def prepare_external_model(
     # copying multi-gigabyte model sidecars; the fallback copy keeps the same
     # isolated file set on filesystems that do not support hardlinks.
     staging_root = Path(tempfile.mkdtemp(prefix="power-model-"))
-    staged_files: dict[str, str] = {}
+    prepared = PreparedModel(spec=spec, files={}, local_reference=str(staging_root))
     try:
         for filename, _digest in spec.files:
             source = Path(files[filename]).resolve(strict=True)
@@ -426,32 +456,40 @@ def prepare_external_model(
                 os.link(source, destination)
             except OSError:
                 shutil.copyfile(source, destination)
-            staged_files[filename] = str(destination)
-        verified_staged = verify_model_files(spec, staged_files)
-    except (OSError, RuntimeError) as exc:
-        raise ModelIntegrityError("isolated_model_snapshot_failed") from exc
-    return PreparedModel(
-        spec=spec,
-        files=verified_staged,
-        local_reference=str(staging_root),
-    )
+            prepared.files[filename] = str(destination)
+        prepared.files = verify_model_files(spec, prepared.files)
+    except BaseException as exc:
+        prepared.release()
+        if isinstance(exc, Exception):
+            raise ModelIntegrityError("isolated_model_snapshot_failed") from exc
+        raise
+    return prepared
 
 
 @contextmanager
-def force_model_offline() -> Iterator[None]:
-    """Prevent delegated constructors from opening a second remote acquisition path."""
+def force_model_offline(*, extra_environment: Mapping[str, str] | None = None) -> Iterator[None]:
+    """Protect one delegated import/constructor window from remote acquisition.
+
+    The lock is shared with :func:`model_offline`, so another POWER acquisition
+    waits for the temporary constructor state and then reads the real user/CI
+    policy after the environment is restored. Callers must not hold this context
+    around normal model inference.
+    """
     with _MODEL_ENV_LOCK:
-        previous = {name: os.environ.get(name) for name in MODEL_OFFLINE_ENV_VARS}
+        temporary = dict(extra_environment or {})
         for name in MODEL_OFFLINE_ENV_VARS:
-            os.environ[name] = "1"
+            temporary[name] = "1"
+        previous: dict[str, str | None] = {name: os.environ.get(name) for name in temporary}
+        for name, temporary_value in temporary.items():
+            os.environ[name] = temporary_value
         try:
             yield
         finally:
-            for name, value in previous.items():
-                if value is None:
+            for name, previous_value in previous.items():
+                if previous_value is None:
                     os.environ.pop(name, None)
                 else:
-                    os.environ[name] = value
+                    os.environ[name] = previous_value
 
 
 __all__ = [

--- a/src/power_framework/core/model_policy.py
+++ b/src/power_framework/core/model_policy.py
@@ -459,7 +459,10 @@ def prepare_external_model(
             prepared.files[filename] = str(destination)
         prepared.files = verify_model_files(spec, prepared.files)
     except BaseException as exc:
-        prepared.release()
+        try:
+            prepared.release()
+        except Exception as release_exc:
+            raise release_exc from exc
         if isinstance(exc, Exception):
             raise ModelIntegrityError("isolated_model_snapshot_failed") from exc
         raise

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -20,23 +20,33 @@ import sqlite3
 import time
 import warnings
 from collections import OrderedDict
+from contextvars import ContextVar
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from threading import RLock
 from typing import TYPE_CHECKING, Any
 
+from .application_models import SourceReadRequest
 from .constants import DENSE_INDEX_SCHEMA_VERSION, is_catalog_filename
 from .db import _init_db
 from .domains import DomainConfigError, resolve_search_policy
 from .generation_index import (
     ActiveGenerationError,
+    _state_db_path,
     resolve_active_generation,
     resolve_active_generation_path,
 )
 from .ignore import should_skip
 from .index_sync import _compute_tf_vector, _sync_vault_to_db, _tokenize
 from .models import OKFMetadata  # noqa: TC001
-from .parser import FRONTMATTER_PATTERN, read_file_content, validate_metadata
+from .parser import FRONTMATTER_PATTERN, validate_metadata
+from .source_service import (
+    SourceReadContext,
+    create_source_read_context,
+    read_source,
+    resolve_safe_vault_path,
+)
 from .temporal import (
     TemporalStatus,
     includes_temporal_status,
@@ -47,7 +57,7 @@ from .temporal import (
     scan_temporal_records,
 )
 from .timing import timing_span
-from .utils import iter_vault_markdown_files, resolve_path_in_vault
+from .utils import is_regular_vault_file, iter_vault_markdown_files
 from .vault_storage import existing_vault_db_path, vault_db_path
 
 if TYPE_CHECKING:
@@ -56,6 +66,10 @@ if TYPE_CHECKING:
     from power_framework.experimental.reranker import RerankerProtocol
 
 logger = logging.getLogger(__name__)
+
+_SOURCE_READ_CONTEXT: ContextVar[SourceReadContext | None] = ContextVar(
+    "power_source_read_context", default=None
+)
 
 
 def get_embedding_manager() -> Any:
@@ -97,6 +111,15 @@ class _DenseMatrixCacheEntry:
     rel_paths: tuple[str, ...]
     chunk_ids: tuple[str, ...]
     dimension: int
+
+
+@dataclass(frozen=True)
+class _IndexedSource:
+    """Validated source material from either an immutable generation or disk."""
+
+    content: str
+    metadata: OKFMetadata
+    sha256: str
 
 
 _DENSE_MATRIX_CACHE_MAX_ENTRIES = 4
@@ -450,13 +473,13 @@ def validate_dense_index(vault_dir: Path, resolved_db: _ResolvedDb | None = None
     return dimension
 
 
-def _make_snippet(content: str, terms: list[str]) -> str:
-    """Extract a relevant snippet around the first match."""
+def _make_snippet(content: str, terms: list[str], *, prefer_last: bool = False) -> str:
+    """Extract a bounded snippet around the first or last matching term."""
     lower = content.lower()
     best_pos = -1
     for term in terms:
         pos = lower.find(term.lower())
-        if pos != -1 and (best_pos == -1 or pos < best_pos):
+        if pos != -1 and (best_pos == -1 or (pos > best_pos if prefer_last else pos < best_pos)):
             best_pos = pos
 
     if best_pos == -1:
@@ -497,40 +520,125 @@ def _body_centered_text(text: str) -> str:
     return body.lstrip()
 
 
-def _matched_text(text: str, terms: list[str] | None = None) -> str:
+def _matched_text(text: str, terms: list[str] | None = None, *, prefer_last: bool = False) -> str:
     """Return a bounded, body-only passage for agent-facing result context."""
     body = _body_centered_text(text)
     if not body:
         return ""
     if terms:
-        return _make_snippet(body, terms)
+        return _make_snippet(body, terms, prefer_last=prefer_last)
     return body[:MAX_SNIPPET_LENGTH].replace("\n", " ").strip()
+
+
+def _source_read_context(vault_dir: Path) -> SourceReadContext:
+    """Return one request-local canonical source projection for retrieval reads."""
+    root = Path(vault_dir).expanduser().resolve()
+    current = _SOURCE_READ_CONTEXT.get()
+    if current is not None and current.root == root:
+        if current.generation_path is None:
+            current = None
+        elif resolve_active_generation_path(root) == current.generation_path:
+            return current
+    context = create_source_read_context(root)
+    _SOURCE_READ_CONTEXT.set(context)
+    return context
+
+
+@lru_cache(maxsize=512)
+def _generation_source_hash(state_path: str, generation_id: str, rel_path: str) -> str:
+    """Read one immutable generation source hash from the state ledger."""
+    state_db = Path(state_path)
+    with contextlib.closing(
+        sqlite3.connect(f"file:{state_db}?mode=ro", uri=True, timeout=30)
+    ) as conn:
+        row = conn.execute(
+            "SELECT content_hash FROM generation_sources WHERE generation_id = ? AND rel_path = ?",
+            (generation_id, rel_path),
+        ).fetchone()
+    if row is None or not isinstance(row[0], str):
+        raise ValueError("immutable generation source hash is missing")
+    return row[0]
+
+
+def _read_generation_source(
+    vault_dir: Path, resolved_db: _ResolvedDb, rel_path: str
+) -> _IndexedSource:
+    """Read one source from a verified immutable generation projection."""
+    if resolved_db.path is None or resolved_db.generation_id is None:
+        raise FileNotFoundError("immutable generation identity is missing")
+    with contextlib.closing(_open_readonly_db(resolved_db.path)) as conn:
+        row = conn.execute(
+            """
+            SELECT f.content, s.content_sha256
+            FROM fts_notes AS f
+            INNER JOIN source_metadata AS s ON s.rel_path = f.rel_path
+            WHERE f.rel_path = ?
+            """,
+            (rel_path,),
+        ).fetchone()
+    if row is None or not isinstance(row[0], str) or not isinstance(row[1], str):
+        raise FileNotFoundError("source is absent from the immutable projection")
+    content = row[0]
+    metadata = validate_metadata(content)
+    if metadata is None:
+        raise ValueError("immutable source projection metadata is invalid")
+    # The generation stores the raw-byte source hash while text extraction
+    # normalizes CRLF to LF. Keep the authoritative raw-byte digest from the
+    # source projection and validate the decoded snapshot through its own DB
+    # integrity/metadata contract.
+    digest = str(row[1])
+    if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise ValueError("immutable source projection digest is invalid")
+    normalized_hash = hashlib.blake2b(content.encode("utf-8"), digest_size=32).hexdigest()
+    expected_hash = _generation_source_hash(
+        str(_state_db_path(vault_dir)), resolved_db.generation_id, rel_path
+    )
+    if normalized_hash != expected_hash:
+        raise ValueError("immutable generation source content is stale or tampered")
+    return _IndexedSource(content=content, metadata=metadata, sha256=digest)
+
+
+def _read_indexed_source(
+    vault_dir: Path,
+    rel_path: str,
+    *,
+    resolved_db: _ResolvedDb | None = None,
+) -> _IndexedSource:
+    """Read indexed material through the canonical source or generation boundary."""
+    if resolved_db is not None and resolved_db.is_generation and resolved_db.path is not None:
+        return _read_generation_source(vault_dir, resolved_db, rel_path)
+    response = read_source(
+        vault_dir,
+        SourceReadRequest(rel_path=rel_path),
+        context=_source_read_context(vault_dir),
+    )
+    metadata = validate_metadata(response.content)
+    if metadata is None:
+        raise ValueError("canonical source metadata is invalid")
+    return _IndexedSource(content=response.content, metadata=metadata, sha256=response.sha256)
 
 
 def _read_matched_text(vault_dir: Path, rel_path: str, terms: list[str]) -> str:
     """Read one bounded source note to produce a body-only passage."""
-    filepath = _safe_indexed_note_path(vault_dir, rel_path)
-    if filepath is None:
-        return ""
     try:
-        return _matched_text(read_file_content(filepath), terms)
-    except (OSError, UnicodeError):
+        return _matched_text(_read_indexed_source(vault_dir, rel_path).content, terms)
+    except (OSError, UnicodeError, RuntimeError, ValueError):
         return ""
 
 
 def _safe_indexed_note_path(vault_dir: Path, rel_path: str) -> Path | None:
-    """Resolve an index path only when every filesystem component is in-vault."""
+    """Resolve an index path only when it is a canonical projected source."""
     if not isinstance(rel_path, str):
         return None
     try:
-        resolve_path_in_vault(vault_dir, rel_path)
-        parts = Path(rel_path).parts
-        candidate = vault_dir.joinpath(*parts)
-        if any(parent.is_symlink() for parent in (candidate.parent, *candidate.parent.parents)):
+        context = _source_read_context(vault_dir)
+        if rel_path not in {source.rel_path for source in context.projection.sources}:
             return None
-        if candidate.is_symlink() or not candidate.is_file():
+        root = context.root
+        candidate = root / rel_path
+        if not is_regular_vault_file(root, candidate):
             return None
-        return candidate
+        return resolve_safe_vault_path(root, rel_path)
     except (OSError, RuntimeError, TypeError, ValueError):
         return None
 
@@ -585,6 +693,7 @@ def _scan_and_search(
 ) -> list[SearchResult]:
     """Scan vault and return scored search results (fallback)."""
     results: list[SearchResult] = []
+    source_context = _source_read_context(vault_dir)
 
     for filepath in iter_vault_markdown_files(vault_dir):
         if filepath.name in ("index.md", "log.md") or is_catalog_filename(filepath.name):
@@ -593,7 +702,11 @@ def _scan_and_search(
             continue
 
         try:
-            content = read_file_content(filepath)
+            content = read_source(
+                vault_dir,
+                SourceReadRequest(rel_path=filepath.relative_to(vault_dir).as_posix()),
+                context=source_context,
+            ).content
             metadata = validate_metadata(content)
             if metadata is None:
                 continue
@@ -631,6 +744,7 @@ def _scan_and_vector_search(
         return []
     query_vec = _compute_tf_vector(query_tokens)
     results: list[SearchResult] = []
+    source_context = _source_read_context(vault_dir)
     scanned = 0
     for filepath in sorted(iter_vault_markdown_files(vault_dir)):
         rel_path = filepath.relative_to(vault_dir).as_posix()
@@ -644,7 +758,11 @@ def _scan_and_vector_search(
         try:
             if filepath.stat().st_size > 2_000_000:
                 continue
-            content = read_file_content(filepath)
+            content = read_source(
+                vault_dir,
+                SourceReadRequest(rel_path=rel_path),
+                context=source_context,
+            ).content
             metadata = validate_metadata(content)
             if metadata is None:
                 continue
@@ -787,20 +905,26 @@ def _fts_search(
         matched_terms = _tokenize(query)
         with timing_span("result_materialization"):
             for row in rows:
-                rel_path, title, description, note_type, score, snippet, tags_str = row
-                tags = tags_str.split(" ") if tags_str else []
+                rel_path, _title, _description, _note_type, score, _snippet, _tags_str = row
+                try:
+                    source = _read_indexed_source(vault_dir, rel_path, resolved_db=resolved_db)
+                except (OSError, UnicodeError, RuntimeError, ValueError):
+                    continue
+                metadata = validate_metadata(source.content)
+                if metadata is None:
+                    continue
                 match_count = 1
                 results.append(
                     SearchResult(
                         rel_path=rel_path,
-                        title=title,
-                        description=description,
-                        note_type=note_type,
+                        title=metadata.title,
+                        description=metadata.description,
+                        note_type=metadata.type,
                         score=float(score),
-                        snippet=snippet,
+                        snippet=_matched_text(source.content, matched_terms, prefer_last=True),
                         match_count=match_count,
-                        matched_text=_read_matched_text(vault_dir, rel_path, matched_terms),
-                        tags=tags,
+                        matched_text=_matched_text(source.content, matched_terms),
+                        tags=metadata.tags,
                     )
                 )
 
@@ -904,12 +1028,12 @@ def _vector_search(
     scored: list[tuple[float, SearchResult]] = []
 
     with timing_span("scoring"):
-        for rel_path, tf_data_str, title, description, note_type, tags_str, content in rows:
+        for rel_path, tf_data_str, _title, _description, _note_type, _tags_str, _content in rows:
             try:
-                filepath = _safe_indexed_note_path(vault_dir, rel_path)
-                if filepath is None:
-                    continue
-                if should_skip(vault_dir, rel_path):
+                source = _read_indexed_source(vault_dir, rel_path, resolved_db=resolved_db)
+                content = source.content
+                metadata = validate_metadata(content)
+                if metadata is None:
                     continue
 
                 doc_vec = json.loads(tf_data_str)
@@ -918,21 +1042,20 @@ def _vector_search(
                 if similarity == 0:
                     continue
 
-                tags = tags_str.split(" ") if tags_str else []
-                snippet = _make_snippet(content, query_tokens)
+                snippet = _matched_text(content, query_tokens, prefer_last=True)
                 scored.append(
                     (
                         similarity,
                         SearchResult(
                             rel_path=rel_path,
-                            title=title,
-                            description=description,
-                            note_type=note_type,
+                            title=metadata.title,
+                            description=metadata.description,
+                            note_type=metadata.type,
                             score=similarity,
                             snippet=snippet,
                             match_count=len(query_tokens),
                             matched_text=_matched_text(content, query_tokens),
-                            tags=tags,
+                            tags=metadata.tags,
                         ),
                     )
                 )
@@ -1177,39 +1300,15 @@ def _semantic_search(
     scored_docs = sorted(doc_best.items(), key=lambda x: -x[1][0])
     top_paths = [rel for rel, _ in scored_docs[:max_results]]
 
-    snippets: dict[str, str] = {}
-    wanted = [doc_best[rel][1] for rel in top_paths]
-    if wanted:
-        conn = None
-        try:
-            conn = _open_readonly_db(db_path)
-            placeholders = ",".join("?" * len(wanted))
-            with timing_span("sqlite_read"):
-                snippets = dict(
-                    conn.execute(
-                        f"SELECT chunk_id, content FROM chunk_embeddings "  # noqa: S608
-                        f"WHERE chunk_id IN ({placeholders})",
-                        wanted,
-                    ).fetchall()
-                )
-        except Exception as exc:
-            _dense_failure(f"db error: {type(exc).__name__}")
-        finally:
-            if conn is not None:
-                conn.close()
-
     results: list[SearchResult] = []
+    query_terms = _tokenize(query)
     with timing_span("result_materialization"):
         for rel_path in top_paths:
-            filepath = _safe_indexed_note_path(vault_dir, rel_path)
-            if filepath is None:
-                continue
             try:
-                content = read_file_content(filepath)
-                metadata = validate_metadata(content)
-                if metadata is None:
-                    continue
-                similarity, chunk_id = doc_best[rel_path]
+                source = _read_indexed_source(vault_dir, rel_path, resolved_db=resolved_db)
+                content = source.content
+                metadata = source.metadata
+                similarity, _chunk_id = doc_best[rel_path]
                 results.append(
                     SearchResult(
                         rel_path=rel_path,
@@ -1217,9 +1316,9 @@ def _semantic_search(
                         description=metadata.description,
                         note_type=metadata.type,
                         score=similarity,
-                        snippet=snippets.get(chunk_id, ""),
+                        snippet=_matched_text(content, query_terms, prefer_last=True),
                         match_count=1,
-                        matched_text=_matched_text(snippets.get(chunk_id, "")),
+                        matched_text=_matched_text(content, query_terms),
                         tags=metadata.tags,
                     )
                 )
@@ -1694,27 +1793,29 @@ def _hybrid_reranked_search(
     rerank_pool = candidates[: min(len(candidates), RERANK_CANDIDATE_LIMIT)]
 
     documents: list[str] = []
+    rerankable: list[SearchResult] = []
     for result in rerank_pool:
-        filepath = vault_dir / result.rel_path
         try:
             # Search snippets may be synthetic, frontmatter-heavy, or chunk
             # headers rather than the note's meaning.  Read the source note so
             # the reranker always sees the same body-centered representation.
-            text = read_file_content(filepath)
+            text = _read_indexed_source(vault_dir, result.rel_path, resolved_db=resolved_db).content
             documents.append(_reranker_document_text(text, result.title)[:RERANK_TEXT_CHARS])
-        except Exception:
-            # Preserve a bounded degraded path for an unreadable source file;
-            # the snippet is still better than dropping the candidate.
-            documents.append(
-                _reranker_document_text(result.snippet, result.title)[:RERANK_TEXT_CHARS]
-            )
+            rerankable.append(result)
+        except (OSError, UnicodeError, RuntimeError, ValueError):
+            # A source that fails the canonical boundary must not be replaced
+            # with index-controlled snippet data.
+            continue
+
+    if not documents:
+        return candidates[:max_results]
 
     with timing_span("reranker_session_startup"):
         reranker = _get_reranker()
     with timing_span("reranker_scoring"):
         reranked_scores = reranker.rerank(query, documents)
 
-    reranked = rerank_pool[:]
+    reranked = rerankable[:]
     for result, score in zip(reranked, reranked_scores, strict=False):
         result.score = score
     reranked.sort(key=lambda r: -r.score)
@@ -1797,12 +1898,10 @@ def _graph_assisted_search(
     for path, boost in graph_boosts.items():
         if path in result_map:
             continue
-        source = vault_dir / path
         try:
-            content = read_file_content(source)
-            metadata = validate_metadata(content)
-            if metadata is None:
-                continue
+            source = _read_indexed_source(vault_dir, path, resolved_db=resolved_db)
+            content = source.content
+            metadata = source.metadata
             result_map[path] = SearchResult(
                 rel_path=path,
                 title=metadata.title,
@@ -1815,7 +1914,7 @@ def _graph_assisted_search(
                 tags=metadata.tags,
                 retrieval_contract="graph_assisted",
             )
-        except Exception:  # noqa: S112
+        except (OSError, UnicodeError, RuntimeError, ValueError):
             continue
 
     return sorted(result_map.values(), key=lambda item: (-item.score, item.title, item.rel_path))[
@@ -1961,10 +2060,8 @@ def format_untrusted_search_envelope(
     for result in results:
         content_hash: str | None = None
         try:
-            source_path = (root / result.rel_path).resolve(strict=True)
-            source_path.relative_to(root)
-            content_hash = hashlib.sha256(source_path.read_bytes()).hexdigest()
-        except (FileNotFoundError, OSError, ValueError):
+            content_hash = _read_indexed_source(root, result.rel_path).sha256
+        except (FileNotFoundError, OSError, RuntimeError, ValueError):
             logger.warning("Unable to create provenance hash for search result %s", result.rel_path)
 
         identifier_input = f"{result.rel_path}\0{content_hash or 'unavailable'}"

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -538,7 +538,6 @@ def _source_read_context(vault_dir: Path) -> SourceReadContext:
     if (
         current is not None
         and current.root == root
-        and current.generation_path is not None
         and resolve_active_generation_path(root) == current.generation_path
     ):
         return current

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -43,6 +43,7 @@ from .models import OKFMetadata  # noqa: TC001
 from .parser import FRONTMATTER_PATTERN, validate_metadata
 from .source_service import (
     SourceReadContext,
+    authorize_current_source,
     create_source_read_context,
     read_source,
     resolve_safe_vault_path,
@@ -534,11 +535,13 @@ def _source_read_context(vault_dir: Path) -> SourceReadContext:
     """Return one request-local canonical source projection for retrieval reads."""
     root = Path(vault_dir).expanduser().resolve()
     current = _SOURCE_READ_CONTEXT.get()
-    if current is not None and current.root == root:
-        if current.generation_path is None:
-            current = None
-        elif resolve_active_generation_path(root) == current.generation_path:
-            return current
+    if (
+        current is not None
+        and current.root == root
+        and current.generation_path is not None
+        and resolve_active_generation_path(root) == current.generation_path
+    ):
+        return current
     context = create_source_read_context(root)
     _SOURCE_READ_CONTEXT.set(context)
     return context
@@ -566,6 +569,11 @@ def _read_generation_source(
     """Read one source from a verified immutable generation projection."""
     if resolved_db.path is None or resolved_db.generation_id is None:
         raise FileNotFoundError("immutable generation identity is missing")
+    authorized_path = authorize_current_source(vault_dir, rel_path)
+    if authorized_path != rel_path:
+        raise FileNotFoundError("immutable generation source path is not canonical")
+    if resolve_active_generation_path(vault_dir) != resolved_db.path:
+        raise ActiveGenerationError("active generation changed during source materialization")
     with contextlib.closing(_open_readonly_db(resolved_db.path)) as conn:
         row = conn.execute(
             """
@@ -582,10 +590,6 @@ def _read_generation_source(
     metadata = validate_metadata(content)
     if metadata is None:
         raise ValueError("immutable source projection metadata is invalid")
-    # The generation stores the raw-byte source hash while text extraction
-    # normalizes CRLF to LF. Keep the authoritative raw-byte digest from the
-    # source projection and validate the decoded snapshot through its own DB
-    # integrity/metadata contract.
     digest = str(row[1])
     if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
         raise ValueError("immutable source projection digest is invalid")
@@ -2041,29 +2045,43 @@ def format_untrusted_search_envelope(
     """
     root = vault_dir.resolve()
     envelope_results: list[dict[str, object]] = []
-    actual_modes = sorted({result.actual_mode or mode for result in results})
-    fallback_reasons = sorted(
-        {result.fallback_reason for result in results if result.fallback_reason}
-    )
-    index_ages = [
-        result.index_age_seconds for result in results if result.index_age_seconds is not None
-    ]
-    actual_mode: str = (
-        actual_modes[0] if actual_modes else getattr(results, "actual_mode", "unknown")
-    )
-    fallback_reason: str | None = (
-        fallback_reasons[0]
-        if len(fallback_reasons) == 1
-        else getattr(results, "fallback_reason", None)
-    )
+    verified_results: list[SearchResult] = []
+    matched_terms = _tokenize(query)
+    active_generation = resolve_active_generation(root)
 
     for result in results:
-        content_hash: str | None = None
+        resolved_db: _ResolvedDb | None = None
+        if result.index_kind == "immutable_generation":
+            if (
+                active_generation is None
+                or result.index_generation_id != active_generation.generation_id
+            ):
+                continue
+            resolved_db = _ResolvedDb(
+                active_generation.path,
+                True,
+                generation_id=active_generation.generation_id,
+                source_snapshot_hash=active_generation.source_snapshot_hash,
+                db_sha256=active_generation.db_sha256,
+            )
+        elif result.index_kind == "legacy_db" and active_generation is not None:
+            continue
         try:
-            content_hash = _read_indexed_source(root, result.rel_path).sha256
+            source = _read_indexed_source(root, result.rel_path, resolved_db=resolved_db)
         except (FileNotFoundError, OSError, RuntimeError, ValueError):
             logger.warning("Unable to create provenance hash for search result %s", result.rel_path)
+            continue
+        active_after_read = resolve_active_generation(root)
+        if result.index_kind == "legacy_db" and active_after_read is not None:
+            continue
+        if result.index_kind == "immutable_generation" and (
+            active_after_read is None
+            or active_after_read.generation_id != result.index_generation_id
+        ):
+            continue
 
+        verified_results.append(result)
+        content_hash = source.sha256
         identifier_input = f"{result.rel_path}\0{content_hash or 'unavailable'}"
         result_id = hashlib.sha256(identifier_input.encode("utf-8")).hexdigest()[:16]
         envelope_results.append(
@@ -2075,10 +2093,10 @@ def format_untrusted_search_envelope(
                     "content_sha256": content_hash,
                 },
                 "metadata": {
-                    "title": result.title,
-                    "description": result.description,
-                    "note_type": result.note_type,
-                    "tags": result.tags,
+                    "title": source.metadata.title,
+                    "description": source.metadata.description,
+                    "note_type": source.metadata.type,
+                    "tags": source.metadata.tags,
                     "retrieval_contract": result.retrieval_contract,
                     "actual_mode": result.actual_mode,
                     "fallback_reason": result.fallback_reason,
@@ -2087,10 +2105,30 @@ def format_untrusted_search_envelope(
                 },
                 "score": result.score,
                 "match_count": result.match_count,
-                "snippet": result.snippet[:MAX_SNIPPET_LENGTH],
-                "matched_text": (result.matched_text or result.snippet)[:MAX_SNIPPET_LENGTH],
+                "snippet": _matched_text(source.content, matched_terms, prefer_last=True)[
+                    :MAX_SNIPPET_LENGTH
+                ],
+                "matched_text": _matched_text(source.content, matched_terms)[:MAX_SNIPPET_LENGTH],
             }
         )
+
+    actual_modes = sorted({result.actual_mode or mode for result in verified_results})
+    fallback_reasons = sorted(
+        {result.fallback_reason for result in verified_results if result.fallback_reason}
+    )
+    index_ages = [
+        result.index_age_seconds
+        for result in verified_results
+        if result.index_age_seconds is not None
+    ]
+    actual_mode: str = (
+        actual_modes[0] if actual_modes else getattr(results, "actual_mode", "unknown")
+    )
+    fallback_reason: str | None = (
+        fallback_reasons[0]
+        if len(fallback_reasons) == 1
+        else getattr(results, "fallback_reason", None)
+    )
 
     envelope = {
         "schema_version": "power.retrieval-envelope.v1",
@@ -2107,7 +2145,7 @@ def format_untrusted_search_envelope(
         "index_age_seconds": max(index_ages) if index_ages else None,
         "temporal_view": temporal_view,
         "as_of": as_of,
-        "index_provenance": _format_index_provenance(results),
+        "index_provenance": _format_index_provenance(verified_results),
         "result_count": len(envelope_results),
         "results": envelope_results,
     }

--- a/src/power_framework/core/source_projection.py
+++ b/src/power_framework/core/source_projection.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from .constants import is_catalog_filename
+from .constants import SKIP_FILES, is_catalog_filename
 from .ignore import should_skip
 from .parser import read_file_content, validate_metadata
 from .utils import iter_vault_markdown_files
@@ -132,7 +132,7 @@ def scan_projection(
 
     for filepath in sorted(iter_vault_markdown_files(root)):
         rel_path = filepath.relative_to(root).as_posix()
-        if filepath.name in {"index.md", "log.md"} or is_catalog_filename(filepath.name):
+        if filepath.name in SKIP_FILES or is_catalog_filename(filepath.name):
             continue
         if should_skip(root, rel_path):
             continue

--- a/src/power_framework/core/source_service.py
+++ b/src/power_framework/core/source_service.py
@@ -9,13 +9,19 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import posixpath
 import sqlite3
+import stat as stat_module
 from collections import deque
 from contextlib import closing
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import BinaryIO
 
 from .application_models import (
     GraphEdgeDTO,
@@ -28,7 +34,7 @@ from .application_models import (
     SourceReadResponse,
     SourceStatsResponse,
 )
-from .constants import is_catalog_filename
+from .constants import SKIP_FILES, is_catalog_filename
 from .generation_index import resolve_active_generation
 from .ignore import should_skip
 from .parser import validate_metadata
@@ -39,7 +45,7 @@ from .source_projection import (
     SourceRecord,
     scan_projection,
 )
-from .utils import iter_vault_markdown_files
+from .utils import is_regular_vault_file, iter_vault_markdown_files
 from .vault_storage import read_vault_identity
 
 # Compatibility name retained for integrations that patched the old helper. It
@@ -48,9 +54,9 @@ ensure_vault_identity = read_vault_identity
 
 ACTIVE_CAPABILITY = "active_source_projection"
 DEGRADED_CAPABILITY = "degraded_bounded_source_scan"
-DIRECT_CAPABILITY = "direct_file_read"
 DEGRADED_SCAN_LIMIT = 5000
 DEGRADED_SOURCE_BYTES = 2_000_000
+CANONICAL_SOURCE_NOT_FOUND = "source not found in canonical source projection"
 
 
 class SourceProjectionError(RuntimeError):
@@ -91,6 +97,15 @@ class _ProjectionData:
     last_indexed_at: str | None
     healthy: bool
     vault_id: str
+
+
+@dataclass(frozen=True)
+class SourceReadContext:
+    """Request-scoped canonical projection used by retrieval materialization."""
+
+    root: Path
+    projection: _ProjectionData
+    generation_path: Path | None
 
 
 def normalize_rel_path(path: str) -> str:
@@ -223,7 +238,7 @@ def _load_active_projection(root: Path) -> _ProjectionData | None:
             for filepath in sorted(iter_vault_markdown_files(root)):
                 rel_path = filepath.relative_to(root).as_posix()
                 if (
-                    filepath.name in {"index.md", "log.md"}
+                    filepath.name in SKIP_FILES
                     or is_catalog_filename(filepath.name)
                     or should_skip(root, rel_path)
                 ):
@@ -308,28 +323,112 @@ def _resolve_projection_path(projection: _ProjectionData, requested: str) -> str
     return candidates[0]
 
 
-def resolve_note_file(vault_dir: Path, rel_path: str) -> tuple[Path, str]:
-    """Resolve an exact path directly or a stem through the source projection."""
-    normalized = normalize_rel_path(rel_path)
+def _validate_source_request_path(requested: str) -> str:
+    """Reject absolute source requests before normalizing their relative form."""
+    raw_path = requested.strip()
+    windows_path = PureWindowsPath(raw_path)
+    if raw_path.startswith(("/", "\\")) or windows_path.is_absolute() or bool(windows_path.drive):
+        raise ValueError("Absolute paths are not allowed")
+    return normalize_rel_path(raw_path)
+
+
+def _reject_ineligible_source_path(root: Path, rel_path: str) -> None:
+    """Reject paths that cannot be canonical sources without touching projection state."""
+    path = Path(rel_path)
+    explicit_file = bool(path.suffix)
+    if (
+        (explicit_file and path.suffix.casefold() != ".md")
+        or path.name in SKIP_FILES
+        or is_catalog_filename(path.name)
+        or (explicit_file and should_skip(root, rel_path))
+    ):
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND)
+
+
+def create_source_read_context(vault_dir: Path) -> SourceReadContext:
+    """Load one canonical projection for a bounded group of source reads."""
+    root = vault_dir.expanduser().resolve()
+    active = resolve_active_generation(root)
+    return SourceReadContext(
+        root=root,
+        projection=_read_projection(root),
+        generation_path=active.path if active is not None else None,
+    )
+
+
+def _resolve_canonical_source(
+    vault_dir: Path, requested: str, projection: _ProjectionData | None = None
+) -> tuple[Path, str, _ProjectionData, SourceRecord]:
+    """Resolve one request to a projected, regular, non-symlink source note."""
+    root = vault_dir.expanduser().resolve()
+    normalized = _validate_source_request_path(requested)
     if not normalized:
         raise ValueError("Relative path cannot be empty")
-    root = vault_dir.expanduser().resolve()
-    target = resolve_safe_vault_path(root, normalized)
-    if target.is_file():
-        return target, target.relative_to(root).as_posix()
-    if target.is_dir():
-        for candidate in (
-            target / f"{target.name}.md",
-            target / "index.md",
-            target / "_index.md",
-        ):
-            if candidate.is_file():
-                return candidate, candidate.relative_to(root).as_posix()
-    if "/" in normalized or normalized.endswith(".md"):
-        raise SourceNotFoundError(f"source file is missing: {normalized}")
-    projection = _read_projection(root)
-    resolved = _resolve_projection_path(projection, normalized)
-    return resolve_safe_vault_path(root, resolved), resolved
+    _reject_ineligible_source_path(root, normalized)
+
+    projection = projection or _read_projection(root)
+    try:
+        rel_norm = _resolve_projection_path(projection, normalized)
+    except SourceNotFoundError as exc:
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND) from exc
+    record = next((source for source in projection.sources if source.rel_path == rel_norm), None)
+    if record is None:
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND)
+
+    raw_target = root / rel_norm
+    if not is_regular_vault_file(root, raw_target):
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND)
+    try:
+        target = resolve_safe_vault_path(root, rel_norm)
+    except (PermissionError, ValueError) as exc:
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND) from exc
+    if not target.is_file():
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND)
+    return target, rel_norm, projection, record
+
+
+def _open_source_file(root: Path, rel_path: str, fallback: Path) -> BinaryIO:
+    """Open a projected source with descriptor-relative no-follow semantics."""
+    if os.name == "nt":  # pragma: no cover - Linux is the supported release platform
+        return fallback.open("rb")
+
+    components = tuple(rel_path.split("/"))
+    if not components or any(not component for component in components):
+        raise OSError("source path has no components")
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    root_fd: int | None = None
+    current_fd: int | None = None
+    file_fd: int | None = None
+    try:
+        root_fd = os.open(root, directory_flags)
+        current_fd = root_fd
+        for component in components[:-1]:
+            assert current_fd is not None
+            next_fd = os.open(component, directory_flags, dir_fd=current_fd)
+            if current_fd != root_fd:
+                os.close(current_fd)
+            current_fd = next_fd
+        assert current_fd is not None
+        file_fd = os.open(components[-1], file_flags, dir_fd=current_fd)
+        if not stat_module.S_ISREG(os.fstat(file_fd).st_mode):
+            raise OSError("source target is not a regular file")
+        handle = os.fdopen(file_fd, "rb", closefd=True)
+        file_fd = None
+        return handle
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        if current_fd is not None and current_fd != root_fd:
+            os.close(current_fd)
+        if root_fd is not None:
+            os.close(root_fd)
+
+
+def resolve_note_file(vault_dir: Path, rel_path: str) -> tuple[Path, str]:
+    """Resolve only a canonical projected source, never an arbitrary file."""
+    target, resolved, _projection, _record = _resolve_canonical_source(vault_dir, rel_path)
+    return target, resolved
 
 
 def list_sources(vault_dir: Path, request: SourceListRequest | None = None) -> SourceListResponse:
@@ -379,53 +478,45 @@ def list_sources(vault_dir: Path, request: SourceListRequest | None = None) -> S
     )
 
 
-def read_source(vault_dir: Path, request: SourceReadRequest) -> SourceReadResponse:
-    """Read a bounded file directly; only stem lookup consults the projection."""
+def read_source(
+    vault_dir: Path,
+    request: SourceReadRequest,
+    *,
+    context: SourceReadContext | None = None,
+) -> SourceReadResponse:
+    """Read a bounded note only after canonical projection and file-policy checks."""
     root = vault_dir.expanduser().resolve()
-    normalized = normalize_rel_path(request.rel_path)
-    if not normalized:
-        raise ValueError("Relative path cannot be empty")
-    exact_target = resolve_safe_vault_path(root, normalized)
-    actual_capability = DIRECT_CAPABILITY
-    degraded_reason: str | None = None
-    source_revision = ""
-    direct_target = exact_target
-    if exact_target.is_dir():
-        direct_candidates = (
-            exact_target / f"{exact_target.name}.md",
-            exact_target / "index.md",
-            exact_target / "_index.md",
-        )
-        direct_target = next(
-            (candidate for candidate in direct_candidates if candidate.is_file()), exact_target
-        )
-    if direct_target.is_file():
-        target_file, rel_norm = direct_target, direct_target.relative_to(root).as_posix()
-    else:
-        if "/" in normalized or normalized.endswith(".md"):
-            raise SourceNotFoundError(f"source file is missing: {normalized}")
-        projection = _read_projection(root)
-        rel_norm = _resolve_projection_path(projection, normalized)
-        target_file = resolve_safe_vault_path(root, rel_norm)
-        if not target_file.is_file():
-            raise SourceNotFoundError(f"source file is missing: {rel_norm}")
-        source_revision = projection.source_revision
-        actual_capability = projection.actual_capability
-        degraded_reason = projection.degraded_reason
+    if context is not None and context.root != root:
+        raise ValueError("source read context does not match the vault")
+    target_file, rel_norm, projection, record = _resolve_canonical_source(
+        root, request.rel_path, context.projection if context is not None else None
+    )
 
-    stat = target_file.stat()
-    if stat.st_size > request.max_bytes:
-        raise ValueError(
-            f"File size {stat.st_size} exceeds requested max_bytes {request.max_bytes}"
-        )
-    with target_file.open("rb") as handle:
+    try:
+        handle = _open_source_file(root, rel_norm, target_file)
+    except OSError as exc:
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND) from exc
+    with handle:
+        stat = os.fstat(handle.fileno())
+        if stat.st_size > request.max_bytes:
+            raise ValueError(
+                f"File size {stat.st_size} exceeds requested max_bytes {request.max_bytes}"
+            )
         raw_content = handle.read(request.max_bytes + 1)
     if len(raw_content) > request.max_bytes:
         raise ValueError(f"File size exceeds requested max_bytes {request.max_bytes}")
     content = raw_content.decode("utf-8", errors="ignore")
     meta = validate_metadata(content)
-    meta_dict = meta.model_dump(mode="json") if meta else {}
     sha256_digest = hashlib.sha256(raw_content).hexdigest()
+    current_modified_at = datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat()
+    if (
+        meta is None
+        or stat.st_size != record.size_bytes
+        or current_modified_at != record.modified_at
+        or sha256_digest != record.content_sha256
+    ):
+        raise SourceProjectionStaleError("source projection is stale; run power sync")
+    meta_dict = meta.model_dump(mode="json") if meta else {}
     return SourceReadResponse(
         rel_path=rel_norm,
         content=content,
@@ -435,9 +526,9 @@ def read_source(vault_dir: Path, request: SourceReadRequest) -> SourceReadRespon
         modified_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat(),
         metadata=meta_dict,
         trust_label="local",
-        source_revision=source_revision,
-        actual_capability=actual_capability,
-        degraded_reason=degraded_reason,
+        source_revision=projection.source_revision,
+        actual_capability=projection.actual_capability,
+        degraded_reason=projection.degraded_reason,
     )
 
 
@@ -554,6 +645,8 @@ __all__ = [
     "SourceNotFoundError",
     "SourceProjectionError",
     "SourceProjectionStaleError",
+    "SourceReadContext",
+    "create_source_read_context",
     "get_graph_projection",
     "get_source_stats",
     "list_sources",

--- a/src/power_framework/core/source_service.py
+++ b/src/power_framework/core/source_service.py
@@ -425,6 +425,40 @@ def _open_source_file(root: Path, rel_path: str, fallback: Path) -> BinaryIO:
             os.close(root_fd)
 
 
+def authorize_current_source(vault_dir: Path, requested: str) -> str:
+    """Authorize a current source path without requiring projection freshness.
+
+    A last-known-good immutable generation may remain searchable while a caller's
+    current edit is being repaired. The path itself must nevertheless still be a
+    safe, eligible Markdown source with valid metadata; this prevents an old
+    generation from re-exposing a newly excluded control file or invalid note.
+    """
+    root = vault_dir.expanduser().resolve()
+    normalized = _validate_source_request_path(requested)
+    if not normalized:
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND)
+    _reject_ineligible_source_path(root, normalized)
+    raw_target = root / normalized
+    if not is_regular_vault_file(root, raw_target):
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND)
+    try:
+        target = resolve_safe_vault_path(root, normalized)
+        if not target.is_file():
+            raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND)
+        handle = _open_source_file(root, normalized, target)
+    except (OSError, ValueError) as exc:
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND) from exc
+    with handle:
+        content = handle.read(10_000_001).decode("utf-8", errors="ignore")
+    try:
+        metadata = validate_metadata(content)
+    except Exception as exc:
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND) from exc
+    if metadata is None:
+        raise SourceNotFoundError(CANONICAL_SOURCE_NOT_FOUND)
+    return normalized
+
+
 def resolve_note_file(vault_dir: Path, rel_path: str) -> tuple[Path, str]:
     """Resolve only a canonical projected source, never an arbitrary file."""
     target, resolved, _projection, _record = _resolve_canonical_source(vault_dir, rel_path)

--- a/src/power_framework/core/task_service.py
+++ b/src/power_framework/core/task_service.py
@@ -27,9 +27,9 @@ logger = logging.getLogger(__name__)
 class TaskService:
     """Canonical domain service managing task lifecycles, revisions, and events."""
 
-    def __init__(self, vault_dir: Path) -> None:
+    def __init__(self, vault_dir: Path, *, create_vault: bool = True) -> None:
         self.vault_dir = Path(vault_dir).expanduser().resolve()
-        self.store = TaskStore(self.vault_dir)
+        self.store = TaskStore(self.vault_dir, create_vault=create_vault)
 
     def create_task(
         self,

--- a/src/power_framework/core/task_store.py
+++ b/src/power_framework/core/task_store.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 class TaskStore:
     """Filesystem-backed durable store for tasks, checkpoints, and event journals."""
 
-    def __init__(self, vault_dir: Path) -> None:
+    def __init__(self, vault_dir: Path, *, create_vault: bool = True) -> None:
         raw_vault_dir = Path(vault_dir).expanduser()
         if raw_vault_dir == raw_vault_dir.parent:
             raise ValueError("Vault path must be a dedicated directory, not the filesystem root")
@@ -45,9 +45,11 @@ class TaskStore:
             if parent.is_symlink():
                 raise ValueError("Vault path symlink ancestors are not followed")
         if not raw_vault_dir.exists():
+            if not create_vault:
+                raise FileNotFoundError(f"Vault path does not exist: {raw_vault_dir}")
             raw_vault_dir.mkdir(parents=True)
         self.vault_dir = raw_vault_dir.resolve()
-        self.power_dir = vault_control_dir(self.vault_dir, create=True)
+        self.power_dir = vault_control_dir(self.vault_dir, create=False)
         self.tasks_dir = self.power_dir / "tasks"
         self.events_dir = self.tasks_dir / "events"
         self.checkpoints_dir = self.tasks_dir / "checkpoints"

--- a/src/power_framework/experimental/colbert_reranker.py
+++ b/src/power_framework/experimental/colbert_reranker.py
@@ -18,6 +18,9 @@ import logging
 import os
 from typing import Any
 
+from power_framework.core.egress import EgressOperation
+from power_framework.core.model_policy import force_model_offline, prepare_external_model
+
 logger = logging.getLogger(__name__)
 
 # Engaged only when POWER_RERANKER == this value.
@@ -60,8 +63,10 @@ class ColBERTLateInteractionReranker:
         rerank(query, documents) -> list[float]  # scores aligned to documents
     """
 
-    def __init__(self, model_name: str = COLBERT_DEFAULT_MODEL) -> None:
-        self.model_name = model_name
+    def __init__(self, model_name: str | None = None) -> None:
+        self.model_name: str = (
+            model_name or os.getenv("POWER_COLBERT_MODEL") or COLBERT_DEFAULT_MODEL
+        )
         self._model: Any | None = None
         if not is_colbert_enabled():
             raise ColBERTUnavailableError(
@@ -76,18 +81,24 @@ class ColBERTLateInteractionReranker:
     def _lazy_init(self) -> None:
         if self._model is not None:
             return
-        try:
-            from colbert.infra import ColBERTConfig  # type: ignore
-            from colbert.modeling.checkpoint import Checkpoint  # type: ignore
-        except ModuleNotFoundError as e:  # pragma: no cover - depends on env
-            raise ColBERTUnavailableError(
-                "The 'colbert' package is not installed. Install with: pip install colbert-ai"
-            ) from e
-        # Late-interaction scoring reuses ColBERT's checkpoint scorer; the heavy
-        # FAISS index build is avoided because we score a small candidate set
-        # directly (reranking already-filtered top-K, not full-corpus search).
-        config = ColBERTConfig()
-        self._model = Checkpoint(self.model_name, colbert_config=config)
+        prepared = prepare_external_model(
+            operation=EgressOperation.RERANKING,
+            provider="colbert-reranker",
+            model_reference=self.model_name,
+        )
+        with force_model_offline():
+            try:
+                from colbert.infra import ColBERTConfig  # type: ignore
+                from colbert.modeling.checkpoint import Checkpoint  # type: ignore
+            except ModuleNotFoundError as e:  # pragma: no cover - depends on env
+                raise ColBERTUnavailableError(
+                    "The 'colbert' package is not installed. Install with: pip install colbert-ai"
+                ) from e
+            # Late-interaction scoring reuses ColBERT's checkpoint scorer; the heavy
+            # FAISS index build is avoided because we score a small candidate set
+            # directly (reranking already-filtered top-K, not full-corpus search).
+            config = ColBERTConfig()
+            self._model = Checkpoint(prepared.local_reference, colbert_config=config)
         logger.info("ColBERT late-interaction reranker loaded: %s", self.model_name)
 
     def rerank(self, query: str, documents: list[str]) -> list[float]:
@@ -99,15 +110,16 @@ class ColBERTLateInteractionReranker:
         """
         self._lazy_init()
         assert self._model is not None
-        q_tokens = self._model.query(query)
-        scores: list[float] = []
-        for doc in documents:
-            d_tokens = self._model.doc(doc)
-            # MaxSim over token embeddings (late interaction).
-            sim = q_tokens @ d_tokens.T if hasattr(q_tokens, "T") else None
-            if sim is None:
-                scores.append(0.0)
-                continue
-            max_sim_per_q = sim.max(dim=1).values
-            scores.append(float(max_sim_per_q.sum()))
-        return scores
+        with force_model_offline():
+            q_tokens = self._model.query(query)
+            scores: list[float] = []
+            for doc in documents:
+                d_tokens = self._model.doc(doc)
+                # MaxSim over token embeddings (late interaction).
+                sim = q_tokens @ d_tokens.T if hasattr(q_tokens, "T") else None
+                if sim is None:
+                    scores.append(0.0)
+                    continue
+                max_sim_per_q = sim.max(dim=1).values
+                scores.append(float(max_sim_per_q.sum()))
+            return scores

--- a/src/power_framework/experimental/colbert_reranker.py
+++ b/src/power_framework/experimental/colbert_reranker.py
@@ -16,10 +16,15 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from typing import Any
 
 from power_framework.core.egress import EgressOperation
-from power_framework.core.model_policy import force_model_offline, prepare_external_model
+from power_framework.core.model_policy import (
+    PreparedModel,
+    force_model_offline,
+    prepare_external_model,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +73,8 @@ class ColBERTLateInteractionReranker:
             model_name or os.getenv("POWER_COLBERT_MODEL") or COLBERT_DEFAULT_MODEL
         )
         self._model: Any | None = None
+        self._prepared_model: PreparedModel | None = None
+        self._init_lock = threading.Lock()
         if not is_colbert_enabled():
             raise ColBERTUnavailableError(
                 "ColBERT backend is opt-in; set POWER_RERANKER=colbert to enable."
@@ -81,25 +88,34 @@ class ColBERTLateInteractionReranker:
     def _lazy_init(self) -> None:
         if self._model is not None:
             return
-        prepared = prepare_external_model(
-            operation=EgressOperation.RERANKING,
-            provider="colbert-reranker",
-            model_reference=self.model_name,
-        )
-        with force_model_offline():
+        with self._init_lock:
+            if self._model is not None:
+                return
+            prepared = prepare_external_model(
+                operation=EgressOperation.RERANKING,
+                provider="colbert-reranker",
+                model_reference=self.model_name,
+            )
             try:
-                from colbert.infra import ColBERTConfig  # type: ignore
-                from colbert.modeling.checkpoint import Checkpoint  # type: ignore
-            except ModuleNotFoundError as e:  # pragma: no cover - depends on env
-                raise ColBERTUnavailableError(
-                    "The 'colbert' package is not installed. Install with: pip install colbert-ai"
-                ) from e
-            # Late-interaction scoring reuses ColBERT's checkpoint scorer; the heavy
-            # FAISS index build is avoided because we score a small candidate set
-            # directly (reranking already-filtered top-K, not full-corpus search).
-            config = ColBERTConfig()
-            self._model = Checkpoint(prepared.local_reference, colbert_config=config)
-        logger.info("ColBERT late-interaction reranker loaded: %s", self.model_name)
+                with force_model_offline():
+                    try:
+                        from colbert.infra import ColBERTConfig  # type: ignore
+                        from colbert.modeling.checkpoint import Checkpoint  # type: ignore
+                    except ModuleNotFoundError as e:  # pragma: no cover - depends on env
+                        raise ColBERTUnavailableError(
+                            "The 'colbert' package is not installed. Install with: pip install colbert-ai"
+                        ) from e
+                    # Late-interaction scoring reuses ColBERT's checkpoint scorer; the heavy
+                    # FAISS index build is avoided because we score a small candidate set
+                    # directly (reranking already-filtered top-K, not full-corpus search).
+                    config = ColBERTConfig()
+                    model = Checkpoint(prepared.local_reference, colbert_config=config)
+            except BaseException:
+                prepared.close()
+                raise
+            self._model = model
+            self._prepared_model = prepared
+            logger.info("ColBERT late-interaction reranker loaded: %s", self.model_name)
 
     def rerank(self, query: str, documents: list[str]) -> list[float]:
         """Score each document against the query via late interaction.
@@ -110,16 +126,29 @@ class ColBERTLateInteractionReranker:
         """
         self._lazy_init()
         assert self._model is not None
-        with force_model_offline():
-            q_tokens = self._model.query(query)
-            scores: list[float] = []
-            for doc in documents:
-                d_tokens = self._model.doc(doc)
-                # MaxSim over token embeddings (late interaction).
-                sim = q_tokens @ d_tokens.T if hasattr(q_tokens, "T") else None
-                if sim is None:
-                    scores.append(0.0)
-                    continue
-                max_sim_per_q = sim.max(dim=1).values
-                scores.append(float(max_sim_per_q.sum()))
-            return scores
+        q_tokens = self._model.query(query)
+        scores: list[float] = []
+        for doc in documents:
+            d_tokens = self._model.doc(doc)
+            # MaxSim over token embeddings (late interaction).
+            sim = q_tokens @ d_tokens.T if hasattr(q_tokens, "T") else None
+            if sim is None:
+                scores.append(0.0)
+                continue
+            max_sim_per_q = sim.max(dim=1).values
+            scores.append(float(max_sim_per_q.sum()))
+        return scores
+
+    def close(self) -> None:
+        """Close the delegated loader and release its owned staging tree."""
+        model = self._model
+        prepared = self._prepared_model
+        self._model = None
+        self._prepared_model = None
+        try:
+            close = getattr(model, "close", None) if model is not None else None
+            if callable(close):
+                close()
+        finally:
+            if prepared is not None:
+                prepared.close()

--- a/src/power_framework/experimental/embeddings.py
+++ b/src/power_framework/experimental/embeddings.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, cast
 from power_framework.core.egress import EgressOperation, validate_local_ollama_endpoint
 from power_framework.core.model_policy import (
     ModelPolicyError,
+    PreparedModel,
     acquire_model_files,
     force_model_offline,
     prepare_external_model,
@@ -83,6 +84,10 @@ BGE_M3_FILE_SHA256 = {
     "tokenizer.json": "6710678b12670bc442b99edc952c4d996ae309a7020c1fa0096dd245c2faf790",
 }
 BGE_M3_DIM = 1024
+
+_FASTEMBED_INIT_LOCK = threading.Lock()
+_QWEN3_INIT_LOCK = threading.Lock()
+_BGE_M3_INIT_LOCK = threading.Lock()
 
 
 def _configured_bge_identity() -> tuple[str, str]:
@@ -489,6 +494,7 @@ class FastEmbedManager:
     def __init__(self, model_name: str | None = None) -> None:
         self.model_name: str = model_name or os.getenv("POWER_EMBEDDING_MODEL") or FASTEMBED_MODEL
         self._model: TextEmbedding | None = None
+        self._prepared_model: PreparedModel | None = None
 
     @property
     def dimension(self) -> int:
@@ -499,8 +505,7 @@ class FastEmbedManager:
             self._lazy_init()
         assert self._model is not None
         try:
-            with force_model_offline():
-                probe = next(iter(self._model.embed(["dim"])))
+            probe = next(iter(self._model.embed(["dim"])))
             return len(probe)
         except Exception:
             return _get_embedding_dim(self.model_name)
@@ -508,13 +513,7 @@ class FastEmbedManager:
     def _lazy_init(self) -> None:
         if self._model is not None:
             return
-        import threading
-
-        _lock = getattr(type(self), "_init_lock", None)
-        if _lock is None:
-            _lock = threading.Lock()
-            type(self)._init_lock = _lock
-        with _lock:
+        with _FASTEMBED_INIT_LOCK:
             if self._model is not None:
                 return
             prepared = prepare_external_model(
@@ -522,24 +521,37 @@ class FastEmbedManager:
                 provider="fastembed-embedding",
                 model_reference=self.model_name,
             )
-            with force_model_offline():
-                try:
-                    os.environ["HF_HUB_DISABLE_SYMLINKS"] = "1"
-                    os.environ["OMP_NUM_THREADS"] = str(EMBED_NUM_THREADS)
-                    os.environ["OPENBLAS_NUM_THREADS"] = str(EMBED_NUM_THREADS)
-                    from fastembed import TextEmbedding
-                except ImportError:
-                    raise ImportError(
-                        "fastembed is required. Install it with: pip install fastembed"
-                    ) from None
-
-        logger.info(
-            "Loading embedding model %s (threads=%d) ...",
-            self.model_name,
-            EMBED_NUM_THREADS,
-        )
-        with force_model_offline():
-            self._model = TextEmbedding(model_name=prepared.local_reference, lazy_load=False)
+            loader_model_name = self.model_name.rsplit("@", 1)[0]
+            try:
+                with force_model_offline(
+                    extra_environment={
+                        "HF_HUB_DISABLE_SYMLINKS": "1",
+                        "OMP_NUM_THREADS": str(EMBED_NUM_THREADS),
+                        "OPENBLAS_NUM_THREADS": str(EMBED_NUM_THREADS),
+                    }
+                ):
+                    try:
+                        from fastembed import TextEmbedding
+                    except ImportError:
+                        raise ImportError(
+                            "fastembed is required. Install it with: pip install fastembed"
+                        ) from None
+                    logger.info(
+                        "Loading embedding model %s (threads=%d) ...",
+                        self.model_name,
+                        EMBED_NUM_THREADS,
+                    )
+                    model = TextEmbedding(
+                        model_name=loader_model_name,
+                        specific_model_path=prepared.local_reference,
+                        threads=EMBED_NUM_THREADS,
+                        lazy_load=False,
+                    )
+            except BaseException:
+                prepared.close()
+                raise
+            self._model = model
+            self._prepared_model = prepared
 
     def embed(self, text: str) -> list[float]:
         self._lazy_init()
@@ -549,8 +561,7 @@ class FastEmbedManager:
         # query embedding spawn many short-lived ONNX subprocesses, adding
         # 10-30s of fork/startup latency to every semantic/hybrid_reranked call.
         parallel = max(1, EMBED_NUM_THREADS)
-        with force_model_offline():
-            return [float(v) for v in next(iter(self._model.embed([text], parallel=parallel)))]
+        return [float(v) for v in next(iter(self._model.embed([text], parallel=parallel)))]
 
     def embed_batch(self, texts: list[str], batch_size: int = 32) -> list[list[float]]:
         self._lazy_init()
@@ -560,11 +571,24 @@ class FastEmbedManager:
         # many-core host (e.g. 20 cores) this balloons RSS to ~30 GB and can
         # trigger OOM on small nodes. Bound it to EMBED_NUM_THREADS instead.
         parallel = max(1, EMBED_NUM_THREADS)
-        with force_model_offline():
-            return [
-                [float(v) for v in vec]
-                for vec in self._model.embed(texts, batch_size=batch_size, parallel=parallel)
-            ]
+        return [
+            [float(v) for v in vec]
+            for vec in self._model.embed(texts, batch_size=batch_size, parallel=parallel)
+        ]
+
+    def close(self) -> None:
+        """Close the delegated loader and release its owned staging tree."""
+        model = self._model
+        prepared = self._prepared_model
+        self._model = None
+        self._prepared_model = None
+        try:
+            close = getattr(model, "close", None) if model is not None else None
+            if callable(close):
+                close()
+        finally:
+            if prepared is not None:
+                prepared.close()
 
 
 class Qwen3EmbeddingManager:
@@ -579,6 +603,7 @@ class Qwen3EmbeddingManager:
             model_name or os.getenv("POWER_QWEN3_EMBED_MODEL") or QWEN3_EMBED_MODEL
         )
         self._model: Any | None = None
+        self._prepared_model: PreparedModel | None = None
         self._dim = 1024
 
     @property
@@ -588,52 +613,67 @@ class Qwen3EmbeddingManager:
     def _lazy_init(self) -> None:
         if self._model is not None:
             return
-        prepared = prepare_external_model(
-            operation=EgressOperation.EMBEDDINGS,
-            provider="qwen3-embedding-onnx",
-            model_reference=self.model_name,
-        )
-        with force_model_offline():
-            try:
-                from qwen3_embed import TextEmbedding as Qwen3TextEmbedding
-            except ImportError:
-                raise ImportError(
-                    "qwen3-embed is required for the qwen3 provider. "
-                    "Install it with: pip install qwen3-embed"
-                ) from None
-            os.environ["OMP_NUM_THREADS"] = str(EMBED_NUM_THREADS)
-            os.environ["OPENBLAS_NUM_THREADS"] = str(EMBED_NUM_THREADS)
-            logger.info(
-                "Loading Qwen3 embedding model %s (ONNX, threads=%d) ...",
-                self.model_name,
-                EMBED_NUM_THREADS,
+        with _QWEN3_INIT_LOCK:
+            if self._model is not None:
+                return
+            prepared = prepare_external_model(
+                operation=EgressOperation.EMBEDDINGS,
+                provider="qwen3-embedding-onnx",
+                model_reference=self.model_name,
             )
-            self._model = Qwen3TextEmbedding(
-                model_name=prepared.local_reference,
-                lazy_load=False,
-            )
-        # Probe: ONNXRuntime's BFCArena can request a multi-GB (or, on some
-        # hosts, tens-of-GB) buffer for a single MatMul node and fail to
-        # allocate even batch_size=1. Detect this eagerly so callers fail
-        # instead of silently returning zero embeddings (FP-7).
-        with force_model_offline():
+            loader_model_name = self.model_name.rsplit("@", 1)[0]
             try:
-                _ = next(iter(self._model.embed(["probe"])))
-            except Exception as e:
-                logger.error(
-                    "Qwen3 ONNX backend failed to allocate on this host (%s).",
-                    type(e).__name__,
-                )
+                with force_model_offline(
+                    extra_environment={
+                        "OMP_NUM_THREADS": str(EMBED_NUM_THREADS),
+                        "OPENBLAS_NUM_THREADS": str(EMBED_NUM_THREADS),
+                    }
+                ):
+                    try:
+                        from qwen3_embed import TextEmbedding as Qwen3TextEmbedding
+                    except ImportError:
+                        raise ImportError(
+                            "qwen3-embed is required for the qwen3 provider. "
+                            "Install it with: pip install qwen3-embed"
+                        ) from None
+                    logger.info(
+                        "Loading Qwen3 embedding model %s (ONNX, threads=%d) ...",
+                        self.model_name,
+                        EMBED_NUM_THREADS,
+                    )
+                    model = Qwen3TextEmbedding(
+                        model_name=loader_model_name,
+                        specific_model_path=prepared.local_reference,
+                        threads=EMBED_NUM_THREADS,
+                        local_files_only=True,
+                        lazy_load=False,
+                    )
+                # Probe: ONNXRuntime's BFCArena can request a multi-GB (or, on
+                # some hosts, tens-of-GB) buffer for a single MatMul node and
+                # fail to allocate even batch_size=1. Detect this eagerly so
+                # callers fail instead of silently returning zero embeddings.
+                try:
+                    _ = next(iter(model.embed(["probe"])))
+                except Exception as exc:
+                    logger.error(
+                        "Qwen3 ONNX backend failed to allocate on this host (%s).",
+                        type(exc).__name__,
+                    )
+                    raise RuntimeError("qwen3_onnx_alloc_failed") from exc
+                self._model = model
+                self._prepared_model = prepared
+            except BaseException:
                 self._model = None
-                raise RuntimeError("qwen3_onnx_alloc_failed") from e
+                self._prepared_model = None
+                prepared.close()
+                raise
 
     def embed(self, text: str) -> list[float]:
         self._lazy_init()
         assert self._model is not None
         if not text or not text.strip():
             return [0.0] * self._dim
-        with force_model_offline():
-            return [float(v) for v in next(iter(self._model.embed([text])))]
+        return [float(v) for v in next(iter(self._model.embed([text])))]
 
     def embed_batch(self, texts: list[str], batch_size: int = 32) -> list[list[float]]:
         self._lazy_init()
@@ -643,14 +683,27 @@ class Qwen3EmbeddingManager:
         # Guard against empty strings which ONNX backends reject; emit a
         # zero vector so callers (e.g. sync) never crash on a blank note.
         cleaned: list[str] = [t if t and t.strip() else " " for t in texts]
-        with force_model_offline():
-            vecs = [
-                [float(v) for v in vec] for vec in self._model.embed(cleaned, batch_size=batch_size)
-            ]
+        vecs = [
+            [float(v) for v in vec] for vec in self._model.embed(cleaned, batch_size=batch_size)
+        ]
         return [
             ([0.0] * self._dim) if not t or not t.strip() else v
             for t, v in zip(texts, vecs, strict=True)
         ]
+
+    def close(self) -> None:
+        """Close the delegated loader and release its owned staging tree."""
+        model = self._model
+        prepared = self._prepared_model
+        self._model = None
+        self._prepared_model = None
+        try:
+            close = getattr(model, "close", None) if model is not None else None
+            if callable(close):
+                close()
+        finally:
+            if prepared is not None:
+                prepared.close()
 
 
 class BGEM3OnnxManager:
@@ -693,13 +746,7 @@ class BGEM3OnnxManager:
     def _lazy_init(self) -> None:
         if self._session is not None:
             return
-        import threading
-
-        _lock = getattr(type(self), "_init_lock", None)
-        if _lock is None:
-            _lock = threading.Lock()
-            type(self)._init_lock = _lock
-        with _lock:
+        with _BGE_M3_INIT_LOCK:
             if self._session is not None:
                 return
             try:
@@ -724,9 +771,6 @@ class BGEM3OnnxManager:
                     "huggingface-hub. Install with: pip install power-framework"
                 ) from e
 
-            os.environ["OMP_NUM_THREADS"] = str(EMBED_NUM_THREADS)
-            os.environ["OPENBLAS_NUM_THREADS"] = str(EMBED_NUM_THREADS)
-
             logger.info(
                 "Loading BGE-M3 ONNX embedder from %s (threads=%d, tamed arena) ...",
                 self.repo,
@@ -745,16 +789,20 @@ class BGEM3OnnxManager:
             active_provider = verify_bound_provider(session, providers, "POWER_EMBED_DEVICE")
             self._session = session
             self.active_provider = active_provider
-            self._tokenizer = Tokenizer.from_file(tok_path)
-            self._tokenizer.enable_truncation(max_length=self._MAX_TOKENS)
-            # Probe: eagerly verify the backend can allocate and produce a
-            # dense vector, so callers fail loudly here rather than silently
-            # returning [] later (FP-7).
-            probe = self._embed_raw(["probe"])
-            if probe is None or len(probe) != 1 or len(probe[0]) != self._dim:
+            try:
+                self._tokenizer = Tokenizer.from_file(tok_path)
+                self._tokenizer.enable_truncation(max_length=self._MAX_TOKENS)
+                # Probe: eagerly verify the backend can allocate and produce a
+                # dense vector, so callers fail loudly here rather than silently
+                # returning [] later (FP-7).
+                probe = self._embed_raw(["probe"])
+                if probe is None or len(probe) != 1 or len(probe[0]) != self._dim:
+                    raise RuntimeError("bge_m3_onnx_probe_failed")
+            except Exception:
                 self._session = None
+                self._tokenizer = None
                 self.active_provider = None
-                raise RuntimeError("bge_m3_onnx_probe_failed")
+                raise
 
     def _embed_raw(self, texts: list[str]) -> list[list[float]] | None:
         import numpy as np
@@ -799,9 +847,18 @@ class BGEM3OnnxManager:
 
 
 _EMBED_MANAGER_CACHE: dict[str, object] = {}
+_EMBED_MANAGER_CACHE_LOCK = threading.Lock()
 
 
 def get_embedding_manager(
+    model_name: str | None = None,
+) -> OllamaEmbeddingManager | FastEmbedManager | Qwen3EmbeddingManager | BGEM3OnnxManager:
+    """Return one cache-owned manager per configured provider/model identity."""
+    with _EMBED_MANAGER_CACHE_LOCK:
+        return _get_embedding_manager_unlocked(model_name)
+
+
+def _get_embedding_manager_unlocked(
     model_name: str | None = None,
 ) -> OllamaEmbeddingManager | FastEmbedManager | Qwen3EmbeddingManager | BGEM3OnnxManager:
     # Respect the module-level default (POWER 3.0: bge-m3) unless explicitly

--- a/src/power_framework/experimental/embeddings.py
+++ b/src/power_framework/experimental/embeddings.py
@@ -9,7 +9,15 @@ import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from power_framework.core.egress import validate_local_ollama_endpoint
+from power_framework.core.egress import EgressOperation, validate_local_ollama_endpoint
+from power_framework.core.model_policy import (
+    ModelPolicyError,
+    acquire_model_files,
+    force_model_offline,
+    prepare_external_model,
+    resolve_model,
+    verify_model_files,
+)
 from power_framework.core.utils import get_cpu_worker_limit
 
 if TYPE_CHECKING:
@@ -37,8 +45,8 @@ logger = logging.getLogger(__name__)
 #     ~1.6 GB — inside the POWER 3.0 <=2 GB contract — and exposes
 #     dense/sparse/colbert vectors for the Phase 3 late-interaction reranker.
 #
-# Legacy providers (fastembed / qwen3 / ollama) remain reachable via
-# POWER_EMBED_PROVIDER for debugging only; none are the default anymore.
+# Legacy providers remain reachable for debugging only when their model identity
+# is explicitly approved; none are the default anymore.
 EMBED_PROVIDER = os.getenv("POWER_EMBED_PROVIDER", "bge-m3").lower()
 
 # Number of threads used by the embedding engine. Strict 50% CPU Throttling Mandate:
@@ -77,6 +85,14 @@ BGE_M3_FILE_SHA256 = {
 BGE_M3_DIM = 1024
 
 
+def _configured_bge_identity() -> tuple[str, str]:
+    """Read the BGE repository and revision at loader/probe time."""
+    return (
+        os.getenv("POWER_BGE_M3_ONNX_REPO", BGE_M3_PINNED_REPO),
+        os.getenv("POWER_BGE_M3_ONNX_REVISION", BGE_M3_PINNED_REVISION),
+    )
+
+
 def dense_embedding_ready() -> tuple[bool, str]:
     """Report whether the canonical dense runtime is locally ready, read-only.
 
@@ -86,6 +102,24 @@ def dense_embedding_ready() -> tuple[bool, str]:
     """
     if os.getenv("POWER_EMBED_PROVIDER", EMBED_PROVIDER).lower() != "bge-m3":
         return False, "non_canonical_provider"
+    repo, revision = _configured_bge_identity()
+    required_files = ("model.onnx", "model.onnx.data", "tokenizer.json")
+    try:
+        spec = resolve_model(
+            operation=EgressOperation.EMBEDDINGS,
+            repo=repo,
+            revision=revision,
+            provider="bge-m3-onnx",
+            required_files=required_files,
+            canonical_repo=BGE_M3_PINNED_REPO,
+            canonical_revision=BGE_M3_PINNED_REVISION,
+            canonical_provider="bge-m3-onnx",
+            canonical_license="MIT",
+            canonical_hashes=BGE_M3_FILE_SHA256,
+            custom_license="MIT",
+        )
+    except ModelPolicyError:
+        return False, "model_approval_required"
     required_modules = ("onnxruntime", "huggingface_hub", "tokenizers", "numpy")
 
     def module_available(name: str) -> bool:
@@ -113,20 +147,18 @@ def dense_embedding_ready() -> tuple[bool, str]:
                 if xdg_cache
                 else Path.home() / ".cache" / "huggingface" / "hub"
             )
-    snapshot = (
-        cache_root
-        / f"models--{BGE_M3_ONNX_REPO.replace('/', '--')}"
-        / "snapshots"
-        / BGE_M3_ONNX_REVISION
-    )
+    snapshot = cache_root / f"models--{repo.replace('/', '--')}" / "snapshots" / revision
     required_files = ("model.onnx", "model.onnx.data", "tokenizer.json")
     if any(not (snapshot / filename).is_file() for filename in required_files):
         return False, "model_snapshot_missing"
+    try:
+        verify_model_files(
+            spec,
+            {filename: str(snapshot / filename) for filename in required_files},
+        )
+    except ModelPolicyError:
+        return False, "model_snapshot_integrity_failed"
     return True, "ready"
-
-
-def _env_flag(name: str) -> bool:
-    return os.getenv(name, "").lower() in {"1", "true", "yes"}
 
 
 def _preload_gpu_runtime(ort: Any) -> None:
@@ -274,12 +306,13 @@ def configured_embedding_identity() -> tuple[str, str]:
     """Return the configured provider/model identity without loading model assets."""
     provider = os.getenv("POWER_EMBED_PROVIDER", EMBED_PROVIDER).lower()
     if provider == "bge-m3":
-        return "BGEM3OnnxManager", f"{BGE_M3_ONNX_REPO}@{BGE_M3_ONNX_REVISION}"
+        repo, revision = _configured_bge_identity()
+        return "BGEM3OnnxManager", f"{repo}@{revision}"
     if provider == "qwen3":
-        return "Qwen3EmbeddingManager", QWEN3_EMBED_MODEL
+        return "Qwen3EmbeddingManager", os.getenv("POWER_QWEN3_EMBED_MODEL", QWEN3_EMBED_MODEL)
     if provider == "ollama":
-        return "OllamaEmbeddingManager", OLLAMA_EMBED_MODEL
-    return "FastEmbedManager", FASTEMBED_MODEL
+        return "OllamaEmbeddingManager", os.getenv("POWER_OLLAMA_EMBED_MODEL", OLLAMA_EMBED_MODEL)
+    return "FastEmbedManager", os.getenv("POWER_EMBEDDING_MODEL", FASTEMBED_MODEL)
 
 
 def _get_embedding_dim(model_name: str) -> int:
@@ -311,14 +344,8 @@ def _get_embedding_dim(model_name: str) -> int:
         except Exception as e:
             logger.debug("Failed to get embedding dim from Ollama: %s", e)
         return 1024
-    try:
-        from fastembed import TextEmbedding
-
-        for m in TextEmbedding.list_supported_models():
-            if m["model"] == model_name:
-                return int(m["dim"])
-    except Exception as e:
-        logger.debug("Failed to list fastembed models: %s", e)
+    # Do not import a delegated model package while this module is initializing:
+    # its registry may perform acquisition work before the model policy runs.
     return 384
 
 
@@ -459,8 +486,8 @@ class OllamaEmbeddingManager:
 
 
 class FastEmbedManager:
-    def __init__(self, model_name: str = FASTEMBED_MODEL) -> None:
-        self.model_name = model_name
+    def __init__(self, model_name: str | None = None) -> None:
+        self.model_name: str = model_name or os.getenv("POWER_EMBEDDING_MODEL") or FASTEMBED_MODEL
         self._model: TextEmbedding | None = None
 
     @property
@@ -472,7 +499,8 @@ class FastEmbedManager:
             self._lazy_init()
         assert self._model is not None
         try:
-            probe = next(iter(self._model.embed(["dim"])))
+            with force_model_offline():
+                probe = next(iter(self._model.embed(["dim"])))
             return len(probe)
         except Exception:
             return _get_embedding_dim(self.model_name)
@@ -489,22 +517,29 @@ class FastEmbedManager:
         with _lock:
             if self._model is not None:
                 return
-            try:
-                os.environ["HF_HUB_DISABLE_SYMLINKS"] = "1"
-                os.environ["OMP_NUM_THREADS"] = str(EMBED_NUM_THREADS)
-                os.environ["OPENBLAS_NUM_THREADS"] = str(EMBED_NUM_THREADS)
-                from fastembed import TextEmbedding
-            except ImportError:
-                raise ImportError(
-                    "fastembed is required. Install it with: pip install fastembed"
-                ) from None
+            prepared = prepare_external_model(
+                operation=EgressOperation.EMBEDDINGS,
+                provider="fastembed-embedding",
+                model_reference=self.model_name,
+            )
+            with force_model_offline():
+                try:
+                    os.environ["HF_HUB_DISABLE_SYMLINKS"] = "1"
+                    os.environ["OMP_NUM_THREADS"] = str(EMBED_NUM_THREADS)
+                    os.environ["OPENBLAS_NUM_THREADS"] = str(EMBED_NUM_THREADS)
+                    from fastembed import TextEmbedding
+                except ImportError:
+                    raise ImportError(
+                        "fastembed is required. Install it with: pip install fastembed"
+                    ) from None
 
         logger.info(
             "Loading embedding model %s (threads=%d) ...",
             self.model_name,
             EMBED_NUM_THREADS,
         )
-        self._model = TextEmbedding(model_name=self.model_name)
+        with force_model_offline():
+            self._model = TextEmbedding(model_name=prepared.local_reference, lazy_load=False)
 
     def embed(self, text: str) -> list[float]:
         self._lazy_init()
@@ -514,7 +549,8 @@ class FastEmbedManager:
         # query embedding spawn many short-lived ONNX subprocesses, adding
         # 10-30s of fork/startup latency to every semantic/hybrid_reranked call.
         parallel = max(1, EMBED_NUM_THREADS)
-        return [float(v) for v in next(iter(self._model.embed([text], parallel=parallel)))]
+        with force_model_offline():
+            return [float(v) for v in next(iter(self._model.embed([text], parallel=parallel)))]
 
     def embed_batch(self, texts: list[str], batch_size: int = 32) -> list[list[float]]:
         self._lazy_init()
@@ -524,10 +560,11 @@ class FastEmbedManager:
         # many-core host (e.g. 20 cores) this balloons RSS to ~30 GB and can
         # trigger OOM on small nodes. Bound it to EMBED_NUM_THREADS instead.
         parallel = max(1, EMBED_NUM_THREADS)
-        return [
-            [float(v) for v in vec]
-            for vec in self._model.embed(texts, batch_size=batch_size, parallel=parallel)
-        ]
+        with force_model_offline():
+            return [
+                [float(v) for v in vec]
+                for vec in self._model.embed(texts, batch_size=batch_size, parallel=parallel)
+            ]
 
 
 class Qwen3EmbeddingManager:
@@ -537,8 +574,10 @@ class Qwen3EmbeddingManager:
     (e.g. i5-5200U / 16GB DDR3). Embedding dim is fixed at 1024 for 0.6B.
     """
 
-    def __init__(self, model_name: str = QWEN3_EMBED_MODEL) -> None:
-        self.model_name = model_name
+    def __init__(self, model_name: str | None = None) -> None:
+        self.model_name: str = (
+            model_name or os.getenv("POWER_QWEN3_EMBED_MODEL") or QWEN3_EMBED_MODEL
+        )
         self._model: Any | None = None
         self._dim = 1024
 
@@ -549,42 +588,52 @@ class Qwen3EmbeddingManager:
     def _lazy_init(self) -> None:
         if self._model is not None:
             return
-        try:
-            from qwen3_embed import TextEmbedding as Qwen3TextEmbedding
-        except ImportError:
-            raise ImportError(
-                "qwen3-embed is required for the qwen3 provider. "
-                "Install it with: pip install qwen3-embed"
-            ) from None
-        os.environ["OMP_NUM_THREADS"] = str(EMBED_NUM_THREADS)
-        os.environ["OPENBLAS_NUM_THREADS"] = str(EMBED_NUM_THREADS)
-        logger.info(
-            "Loading Qwen3 embedding model %s (ONNX, threads=%d) ...",
-            self.model_name,
-            EMBED_NUM_THREADS,
+        prepared = prepare_external_model(
+            operation=EgressOperation.EMBEDDINGS,
+            provider="qwen3-embedding-onnx",
+            model_reference=self.model_name,
         )
-        self._model = Qwen3TextEmbedding(model_name=self.model_name)
+        with force_model_offline():
+            try:
+                from qwen3_embed import TextEmbedding as Qwen3TextEmbedding
+            except ImportError:
+                raise ImportError(
+                    "qwen3-embed is required for the qwen3 provider. "
+                    "Install it with: pip install qwen3-embed"
+                ) from None
+            os.environ["OMP_NUM_THREADS"] = str(EMBED_NUM_THREADS)
+            os.environ["OPENBLAS_NUM_THREADS"] = str(EMBED_NUM_THREADS)
+            logger.info(
+                "Loading Qwen3 embedding model %s (ONNX, threads=%d) ...",
+                self.model_name,
+                EMBED_NUM_THREADS,
+            )
+            self._model = Qwen3TextEmbedding(
+                model_name=prepared.local_reference,
+                lazy_load=False,
+            )
         # Probe: ONNXRuntime's BFCArena can request a multi-GB (or, on some
         # hosts, tens-of-GB) buffer for a single MatMul node and fail to
-        # allocate even batch_size=1. Detect this eagerly so callers can fall
-        # back instead of silently returning zero embeddings (FP-7).
-        try:
-            _ = next(iter(self._model.embed(["probe"])))
-        except Exception as e:
-            logger.error(
-                "Qwen3 ONNX backend failed to allocate on this host (%s). "
-                "Falling back to fastembed for embeddings.",
-                type(e).__name__,
-            )
-            self._model = None
-            raise RuntimeError("qwen3_onnx_alloc_failed") from e
+        # allocate even batch_size=1. Detect this eagerly so callers fail
+        # instead of silently returning zero embeddings (FP-7).
+        with force_model_offline():
+            try:
+                _ = next(iter(self._model.embed(["probe"])))
+            except Exception as e:
+                logger.error(
+                    "Qwen3 ONNX backend failed to allocate on this host (%s).",
+                    type(e).__name__,
+                )
+                self._model = None
+                raise RuntimeError("qwen3_onnx_alloc_failed") from e
 
     def embed(self, text: str) -> list[float]:
         self._lazy_init()
         assert self._model is not None
         if not text or not text.strip():
             return [0.0] * self._dim
-        return [float(v) for v in next(iter(self._model.embed([text])))]
+        with force_model_offline():
+            return [float(v) for v in next(iter(self._model.embed([text])))]
 
     def embed_batch(self, texts: list[str], batch_size: int = 32) -> list[list[float]]:
         self._lazy_init()
@@ -594,9 +643,10 @@ class Qwen3EmbeddingManager:
         # Guard against empty strings which ONNX backends reject; emit a
         # zero vector so callers (e.g. sync) never crash on a blank note.
         cleaned: list[str] = [t if t and t.strip() else " " for t in texts]
-        vecs = [
-            [float(v) for v in vec] for vec in self._model.embed(cleaned, batch_size=batch_size)
-        ]
+        with force_model_offline():
+            vecs = [
+                [float(v) for v in vec] for vec in self._model.embed(cleaned, batch_size=batch_size)
+            ]
         return [
             ([0.0] * self._dim) if not t or not t.strip() else v
             for t, v in zip(texts, vecs, strict=True)
@@ -623,12 +673,14 @@ class BGEM3OnnxManager:
 
     def __init__(
         self,
-        repo: str = BGE_M3_ONNX_REPO,
-        revision: str = BGE_M3_ONNX_REVISION,
+        repo: str | None = None,
+        revision: str | None = None,
     ) -> None:
-        self.repo = repo
-        self.revision = revision
-        self.model_name = f"{repo}@{revision}"
+        self.repo: str = repo or os.getenv("POWER_BGE_M3_ONNX_REPO") or BGE_M3_PINNED_REPO
+        self.revision: str = (
+            revision or os.getenv("POWER_BGE_M3_ONNX_REVISION") or BGE_M3_PINNED_REVISION
+        )
+        self.model_name = f"{self.repo}@{self.revision}"
         self._session: Any | None = None
         self._tokenizer: Any | None = None
         self._dim = BGE_M3_DIM
@@ -651,8 +703,20 @@ class BGEM3OnnxManager:
             if self._session is not None:
                 return
             try:
+                model_files = acquire_model_files(
+                    operation=EgressOperation.EMBEDDINGS,
+                    repo=self.repo,
+                    revision=self.revision,
+                    provider="bge-m3-onnx",
+                    required_files=("model.onnx", "model.onnx.data", "tokenizer.json"),
+                    canonical_repo=BGE_M3_PINNED_REPO,
+                    canonical_revision=BGE_M3_PINNED_REVISION,
+                    canonical_provider="bge-m3-onnx",
+                    canonical_license="MIT",
+                    canonical_hashes=BGE_M3_FILE_SHA256,
+                    custom_license="MIT",
+                )
                 import onnxruntime as ort
-                from huggingface_hub import hf_hub_download
                 from tokenizers import Tokenizer
             except ImportError as e:
                 raise ImportError(
@@ -668,38 +732,8 @@ class BGEM3OnnxManager:
                 self.repo,
                 EMBED_NUM_THREADS,
             )
-            offline = _env_flag("POWER_MODEL_OFFLINE")
-            model_path = hf_hub_download(
-                self.repo,
-                "model.onnx",
-                revision=self.revision,
-                local_files_only=offline,
-            )
-            sidecar_path = hf_hub_download(
-                self.repo,
-                "model.onnx.data",
-                revision=self.revision,
-                local_files_only=offline,
-            )
-            tok_path = hf_hub_download(
-                self.repo,
-                "tokenizer.json",
-                revision=self.revision,
-                local_files_only=offline,
-            )
-
-            if self.repo == BGE_M3_PINNED_REPO and self.revision == BGE_M3_PINNED_REVISION:
-                for filename, path in {
-                    "model.onnx": model_path,
-                    "model.onnx.data": sidecar_path,
-                    "tokenizer.json": tok_path,
-                }.items():
-                    _verify_sha256(path, BGE_M3_FILE_SHA256[filename])
-            elif not _env_flag("POWER_ALLOW_UNVERIFIED_MODELS"):
-                raise RuntimeError(
-                    "unverified_model_revision: set POWER_ALLOW_UNVERIFIED_MODELS=1 "
-                    "only for explicit development overrides"
-                )
+            model_path = model_files["model.onnx"]
+            tok_path = model_files["tokenizer.json"]
 
             so = ort.SessionOptions()
             # R2 arena taming: no persistent CPU mem arena; grow only on demand.
@@ -780,36 +814,24 @@ def get_embedding_manager(
     # cache, or allocation failures are release-contract failures and must not
     # silently switch the retrieval model.
     if effective_provider == "bge-m3":
-        key = f"bge-m3:{BGE_M3_ONNX_REPO}@{BGE_M3_ONNX_REVISION}"
+        repo, revision = _configured_bge_identity()
+        key = f"bge-m3:{repo}@{revision}"
         if key in _EMBED_MANAGER_CACHE:
             return _EMBED_MANAGER_CACHE[key]  # type: ignore[return-value]
         try:
             mgr: (
                 OllamaEmbeddingManager | FastEmbedManager | Qwen3EmbeddingManager | BGEM3OnnxManager
-            ) = BGEM3OnnxManager(BGE_M3_ONNX_REPO, BGE_M3_ONNX_REVISION)
+            ) = BGEM3OnnxManager(repo, revision)
             mgr._lazy_init()  # eager probe: fail loudly, not silently
             _EMBED_MANAGER_CACHE[key] = mgr
             return mgr
+        except ModelPolicyError:
+            raise
         except Exception as e:
             raise RuntimeError(
                 "bge_m3_init_failed: verify release/models.lock.json, prefetch the pinned "
                 "snapshot, and rerun 'power sync'"
             ) from e
-
-    # Graceful fallback: if the qwen3 backend is selected but `qwen3-embed`
-    # is not installed (e.g. minimal install / CI without the extra), fall
-    # back to fastembed instead of raising at import time. This keeps the CLI
-    # and tests working everywhere.
-    if effective_provider == "qwen3":
-        try:
-            import qwen3_embed  # noqa: F401
-        except ImportError:
-            logger.warning(
-                "POWER_EMBED_PROVIDER=qwen3 but `qwen3-embed` is not installed. "
-                "Falling back to fastembed (MiniLM). Install with: pip install "
-                "'power-framework[qwen3]'."
-            )
-            effective_provider = "fastembed"
 
     if effective_provider == "ollama":
         key = f"ollama:{model_name or OLLAMA_EMBED_MODEL}"
@@ -817,22 +839,18 @@ def get_embedding_manager(
             _EMBED_MANAGER_CACHE[key] = OllamaEmbeddingManager(model_name or OLLAMA_EMBED_MODEL)
         return _EMBED_MANAGER_CACHE[key]  # type: ignore[return-value]
     if effective_provider == "qwen3":
-        key = f"qwen3:{model_name or QWEN3_EMBED_MODEL}"
+        configured_model = model_name or os.getenv("POWER_QWEN3_EMBED_MODEL") or QWEN3_EMBED_MODEL
+        key = f"qwen3:{configured_model}"
         if key not in _EMBED_MANAGER_CACHE:
-            try:
-                mgr = Qwen3EmbeddingManager(model_name or QWEN3_EMBED_MODEL)
-                mgr._lazy_init()  # probe allocation eagerly
-                _EMBED_MANAGER_CACHE[key] = mgr
-            except RuntimeError as e:
-                if "qwen3_onnx_alloc_failed" in str(e):
-                    logger.warning("Qwen3 ONNX allocation failed; falling back to fastembed.")
-                    effective_provider = "fastembed"
-                else:
-                    raise
+            mgr = Qwen3EmbeddingManager(configured_model)
+            mgr._lazy_init()  # probe allocation eagerly
+            _EMBED_MANAGER_CACHE[key] = mgr
+        return _EMBED_MANAGER_CACHE[key]  # type: ignore[return-value]
     if effective_provider == "fastembed":
-        key = f"fastembed:{model_name or FASTEMBED_MODEL}"
+        configured_model = model_name or os.getenv("POWER_EMBEDDING_MODEL") or FASTEMBED_MODEL
+        key = f"fastembed:{configured_model}"
         if key not in _EMBED_MANAGER_CACHE:
-            _EMBED_MANAGER_CACHE[key] = FastEmbedManager(model_name or FASTEMBED_MODEL)
+            _EMBED_MANAGER_CACHE[key] = FastEmbedManager(configured_model)
         return _EMBED_MANAGER_CACHE[key]  # type: ignore[return-value]
 
     # WTF #3 remediation: never silently fall back to an unintended embedding

--- a/src/power_framework/experimental/reranker.py
+++ b/src/power_framework/experimental/reranker.py
@@ -4,11 +4,13 @@ import hashlib
 import logging
 import math
 import os
+import threading
 import time
 from typing import Protocol
 
 from power_framework.core.egress import EgressOperation
 from power_framework.core.model_policy import (
+    PreparedModel,
     acquire_model_files,
     force_model_offline,
     prepare_external_model,
@@ -45,6 +47,7 @@ QWEN3_RERANKER_MODEL = os.getenv("POWER_QWEN3_RERANKER_MODEL", "n24q02m/Qwen3-Re
 # Jina remains a documented opt-in only (CC-BY-NC-4.0).
 JINA_RERANKER_MODEL = "jinaai/jina-reranker-v2-base-multilingual"
 JINA_RERANKER_REVISION = "9cfeff2df7d40d1b78e75e5e9cebec92a99813c9"
+_BGE_RERANKER_INIT_LOCK = threading.Lock()
 
 
 class RerankerProtocol(Protocol):
@@ -85,11 +88,20 @@ class RerankerManager:
             model_name or os.getenv("POWER_JINA_RERANKER_MODEL") or JINA_RERANKER_MODEL
         )
         self._model: object | None = None
+        self._prepared_model: PreparedModel | None = None
+        self._init_lock = threading.Lock()
         self._use_qwen3 = os.getenv("POWER_EMBED_PROVIDER", "").lower() == "qwen3"
 
     def _lazy_init(self) -> None:
         if self._model is not None:
             return
+        with self._init_lock:
+            if self._model is not None:
+                return
+            self._initialize_model()
+
+    def _initialize_model(self) -> None:
+        """Construct a delegated model while the caller holds the init lock."""
         if os.getenv("POWER_RERANKER", "").lower() != "jina" or not _env_flag(
             ALLOW_NONCOMMERCIAL_MODELS_ENV
         ):
@@ -104,18 +116,30 @@ class RerankerManager:
                 provider="qwen3-reranker-onnx",
                 model_reference=os.getenv("POWER_QWEN3_RERANKER_MODEL", QWEN3_RERANKER_MODEL),
             )
-            with force_model_offline():
-                try:
-                    from qwen3_embed import TextCrossEncoder as Qwen3TextCrossEncoder
-                except ImportError as e:
-                    raise ImportError(
-                        "qwen3-embed is required for Qwen3 reranking. "
-                        "Install it with: pip install qwen3-embed"
-                    ) from e
-                self._model = Qwen3TextCrossEncoder(
-                    model_name=prepared.local_reference,
-                    lazy_load=False,
-                )
+            loader_model_name = os.getenv(
+                "POWER_QWEN3_RERANKER_MODEL", QWEN3_RERANKER_MODEL
+            ).rsplit("@", 1)[0]
+            try:
+                with force_model_offline():
+                    try:
+                        from qwen3_embed import TextCrossEncoder as Qwen3TextCrossEncoder
+                    except ImportError as e:
+                        raise ImportError(
+                            "qwen3-embed is required for Qwen3 reranking. "
+                            "Install it with: pip install qwen3-embed"
+                        ) from e
+                    model = Qwen3TextCrossEncoder(
+                        model_name=loader_model_name,
+                        specific_model_path=prepared.local_reference,
+                        threads=get_cpu_worker_limit(),
+                        local_files_only=True,
+                        lazy_load=False,
+                    )
+            except BaseException:
+                prepared.close()
+                raise
+            self._model = model
+            self._prepared_model = prepared
             return
         model_reference = self.model_name
         if "@" not in model_reference:
@@ -126,24 +150,46 @@ class RerankerManager:
             model_reference=model_reference,
             expected_license="CC-BY-NC-4.0",
         )
+        loader_model_name = model_reference.rsplit("@", 1)[0]
         with force_model_offline():
             try:
                 from fastembed.rerank.cross_encoder import TextCrossEncoder
-            except ImportError as e:
+            except Exception as e:
+                prepared.close()
                 raise ImportError(
                     "fastembed is required. Install it with: pip install fastembed"
                 ) from e
-            self._model = TextCrossEncoder(
-                model_name=prepared.local_reference,
-                lazy_load=False,
-            )
+            try:
+                model = TextCrossEncoder(
+                    model_name=loader_model_name,
+                    specific_model_path=prepared.local_reference,
+                    lazy_load=False,
+                )
+            except BaseException:
+                prepared.close()
+                raise
+        self._model = model
+        self._prepared_model = prepared
 
     def rerank(self, query: str, documents: list[str]) -> list[float]:
         self._lazy_init()
         assert self._model is not None
-        with force_model_offline():
-            scores = self._model.rerank(query, documents)
+        scores = self._model.rerank(query, documents)
         return [float(s) for s in scores]
+
+    def close(self) -> None:
+        """Close the delegated loader and release its owned staging tree."""
+        model = self._model
+        prepared = self._prepared_model
+        self._model = None
+        self._prepared_model = None
+        try:
+            close = getattr(model, "close", None) if model is not None else None
+            if callable(close):
+                close()
+        finally:
+            if prepared is not None:
+                prepared.close()
 
 
 class BGEM3Reranker:
@@ -179,13 +225,7 @@ class BGEM3Reranker:
     def _lazy_init(self) -> None:
         if self._session is not None:
             return
-        import threading
-
-        _lock = getattr(type(self), "_init_lock", None)
-        if _lock is None:
-            _lock = threading.Lock()
-            type(self)._init_lock = _lock
-        with _lock:
+        with _BGE_RERANKER_INIT_LOCK:
             if self._session is not None:
                 return
             model_files = acquire_model_files(
@@ -230,15 +270,19 @@ class BGEM3Reranker:
             active_provider = verify_bound_provider(session, providers, "POWER_RERANKER_DEVICE")
             self._session = session
             self.active_provider = active_provider
-            self._tokenizer = Tokenizer.from_file(tok_path)
-            self._tokenizer.enable_truncation(max_length=self._MAX_TOKENS)
+            try:
+                self._tokenizer = Tokenizer.from_file(tok_path)
+                self._tokenizer.enable_truncation(max_length=self._MAX_TOKENS)
 
-            # Probe: eagerly verify the backend can allocate and produce a score.
-            probe = self._rerank_raw("probe query", "probe passage")
-            if probe is None or len(probe) != 1:
+                # Probe: eagerly verify the backend can allocate and produce a score.
+                probe = self._rerank_raw("probe query", "probe passage")
+                if probe is None or len(probe) != 1:
+                    raise RuntimeError("bge_reranker_onnx_probe_failed")
+            except Exception:
                 self._session = None
+                self._tokenizer = None
                 self.active_provider = None
-                raise RuntimeError("bge_reranker_onnx_probe_failed")
+                raise
 
     def _rerank_batch(self, query: str, documents: list[str]) -> list[float] | None:
         import numpy as np

--- a/src/power_framework/experimental/reranker.py
+++ b/src/power_framework/experimental/reranker.py
@@ -7,6 +7,12 @@ import os
 import time
 from typing import Protocol
 
+from power_framework.core.egress import EgressOperation
+from power_framework.core.model_policy import (
+    acquire_model_files,
+    force_model_offline,
+    prepare_external_model,
+)
 from power_framework.core.utils import get_cpu_worker_limit
 from power_framework.experimental.embeddings import select_onnx_providers, verify_bound_provider
 
@@ -38,6 +44,7 @@ QWEN3_RERANKER_MODEL = os.getenv("POWER_QWEN3_RERANKER_MODEL", "n24q02m/Qwen3-Re
 
 # Jina remains a documented opt-in only (CC-BY-NC-4.0).
 JINA_RERANKER_MODEL = "jinaai/jina-reranker-v2-base-multilingual"
+JINA_RERANKER_REVISION = "9cfeff2df7d40d1b78e75e5e9cebec92a99813c9"
 
 
 class RerankerProtocol(Protocol):
@@ -73,8 +80,10 @@ class RerankerManager:
     license violations when POWER is used under a GPLv3/commercial context.
     """
 
-    def __init__(self, model_name: str = JINA_RERANKER_MODEL) -> None:
-        self.model_name = model_name
+    def __init__(self, model_name: str | None = None) -> None:
+        self.model_name: str = (
+            model_name or os.getenv("POWER_JINA_RERANKER_MODEL") or JINA_RERANKER_MODEL
+        )
         self._model: object | None = None
         self._use_qwen3 = os.getenv("POWER_EMBED_PROVIDER", "").lower() == "qwen3"
 
@@ -90,27 +99,50 @@ class RerankerManager:
                 f"permitted non-commercial use, or rely on the MIT/Apache BGE reranker default."
             )
         if self._use_qwen3:
+            prepared = prepare_external_model(
+                operation=EgressOperation.RERANKING,
+                provider="qwen3-reranker-onnx",
+                model_reference=os.getenv("POWER_QWEN3_RERANKER_MODEL", QWEN3_RERANKER_MODEL),
+            )
+            with force_model_offline():
+                try:
+                    from qwen3_embed import TextCrossEncoder as Qwen3TextCrossEncoder
+                except ImportError as e:
+                    raise ImportError(
+                        "qwen3-embed is required for Qwen3 reranking. "
+                        "Install it with: pip install qwen3-embed"
+                    ) from e
+                self._model = Qwen3TextCrossEncoder(
+                    model_name=prepared.local_reference,
+                    lazy_load=False,
+                )
+            return
+        model_reference = self.model_name
+        if "@" not in model_reference:
+            model_reference = f"{model_reference}@{JINA_RERANKER_REVISION}"
+        prepared = prepare_external_model(
+            operation=EgressOperation.RERANKING,
+            provider="jina-reranker",
+            model_reference=model_reference,
+            expected_license="CC-BY-NC-4.0",
+        )
+        with force_model_offline():
             try:
-                from qwen3_embed import TextCrossEncoder as Qwen3TextCrossEncoder
+                from fastembed.rerank.cross_encoder import TextCrossEncoder
             except ImportError as e:
                 raise ImportError(
-                    "qwen3-embed is required for Qwen3 reranking. "
-                    "Install it with: pip install qwen3-embed"
+                    "fastembed is required. Install it with: pip install fastembed"
                 ) from e
-            self._model = Qwen3TextCrossEncoder(model_name=QWEN3_RERANKER_MODEL)
-            return
-        try:
-            from fastembed.rerank.cross_encoder import TextCrossEncoder
-        except ImportError as e:
-            raise ImportError(
-                "fastembed is required. Install it with: pip install fastembed"
-            ) from e
-        self._model = TextCrossEncoder(model_name=self.model_name)
+            self._model = TextCrossEncoder(
+                model_name=prepared.local_reference,
+                lazy_load=False,
+            )
 
     def rerank(self, query: str, documents: list[str]) -> list[float]:
         self._lazy_init()
         assert self._model is not None
-        scores = self._model.rerank(query, documents)
+        with force_model_offline():
+            scores = self._model.rerank(query, documents)
         return [float(s) for s in scores]
 
 
@@ -128,12 +160,18 @@ class BGEM3Reranker:
 
     def __init__(
         self,
-        repo: str = BGE_RERANKER_ONNX_REPO,
-        revision: str = BGE_RERANKER_ONNX_REVISION,
+        repo: str | None = None,
+        revision: str | None = None,
     ) -> None:
-        self.repo = repo
-        self.revision = revision
-        self.model_name = f"{repo}@{revision}"
+        self.repo: str = (
+            repo or os.getenv("POWER_BGE_RERANKER_ONNX_REPO") or BGE_RERANKER_PINNED_REPO
+        )
+        self.revision: str = (
+            revision
+            or os.getenv("POWER_BGE_RERANKER_ONNX_REVISION")
+            or BGE_RERANKER_PINNED_REVISION
+        )
+        self.model_name = f"{self.repo}@{self.revision}"
         self._session: object | None = None
         self._tokenizer: object | None = None
         self.active_provider: str | None = None
@@ -150,9 +188,25 @@ class BGEM3Reranker:
         with _lock:
             if self._session is not None:
                 return
+            model_files = acquire_model_files(
+                operation=EgressOperation.RERANKING,
+                repo=self.repo,
+                revision=self.revision,
+                provider="bge-reranker-v2-m3-onnx",
+                required_files=("onnx/model.onnx", "onnx/model.onnx_data", "tokenizer.json"),
+                canonical_repo=BGE_RERANKER_PINNED_REPO,
+                canonical_revision=BGE_RERANKER_PINNED_REVISION,
+                canonical_provider="bge-reranker-v2-m3-onnx",
+                canonical_license="Apache-2.0",
+                canonical_hashes={
+                    "onnx/model.onnx": BGE_RERANKER_FILE_SHA256["model.onnx"],
+                    "onnx/model.onnx_data": BGE_RERANKER_FILE_SHA256["model.onnx_data"],
+                    "tokenizer.json": BGE_RERANKER_FILE_SHA256["tokenizer.json"],
+                },
+                custom_license="Apache-2.0",
+            )
             try:
                 import onnxruntime as ort
-                from huggingface_hub import hf_hub_download
                 from tokenizers import Tokenizer
             except ImportError as e:
                 raise ImportError(
@@ -160,66 +214,8 @@ class BGEM3Reranker:
                     "Install with: pip install power-framework"
                 ) from e
 
-            offline = (
-                os.getenv("HF_HUB_OFFLINE", "0") == "1"
-                or os.getenv("TRANSFORMERS_OFFLINE", "0") == "1"
-            )
-            local_only = offline
-            try:
-                model_path = hf_hub_download(
-                    self.repo,
-                    "onnx/model.onnx",
-                    revision=self.revision,
-                    local_files_only=local_only,
-                )
-                data_path = hf_hub_download(
-                    self.repo,
-                    "onnx/model.onnx_data",
-                    revision=self.revision,
-                    local_files_only=local_only,
-                )
-                tok_path = hf_hub_download(
-                    self.repo,
-                    "tokenizer.json",
-                    revision=self.revision,
-                    local_files_only=local_only,
-                )
-            except Exception:
-                model_path = hf_hub_download(
-                    self.repo,
-                    "onnx/model.onnx",
-                    revision=self.revision,
-                    local_files_only=True,
-                )
-                data_path = hf_hub_download(
-                    self.repo,
-                    "onnx/model.onnx_data",
-                    revision=self.revision,
-                    local_files_only=True,
-                )
-                tok_path = hf_hub_download(
-                    self.repo,
-                    "tokenizer.json",
-                    revision=self.revision,
-                    local_files_only=True,
-                )
-
-            if (
-                self.repo == BGE_RERANKER_PINNED_REPO
-                and self.revision == BGE_RERANKER_PINNED_REVISION
-            ):
-                for filename, path in {
-                    "model.onnx": model_path,
-                    "model.onnx_data": data_path,
-                    "tokenizer.json": tok_path,
-                }.items():
-                    expected = BGE_RERANKER_FILE_SHA256.get(filename)
-                    if expected:
-                        _verify_sha256(path, expected)
-                    else:
-                        raise RuntimeError(
-                            f"missing_reranker_sha256_pin:{filename}; release defaults require pins"
-                        )
+            model_path = model_files["onnx/model.onnx"]
+            tok_path = model_files["tokenizer.json"]
 
             so = ort.SessionOptions()
             so.enable_cpu_mem_arena = False

--- a/src/power_framework/experimental/reranker.py
+++ b/src/power_framework/experimental/reranker.py
@@ -6,6 +6,7 @@ import math
 import os
 import threading
 import time
+from contextlib import contextmanager
 from typing import Protocol
 
 from power_framework.core.egress import EgressOperation
@@ -73,6 +74,17 @@ def _verify_sha256(path: str, expected: str) -> None:
     actual = digest.hexdigest()
     if actual != expected:
         raise RuntimeError(f"model_sha256_mismatch:{os.path.basename(path)}")
+
+
+@contextmanager
+def _prepared_model_constructor_environment(prepared: PreparedModel):
+    """Protect a delegated constructor and release staging on any failure."""
+    try:
+        with force_model_offline():
+            yield
+    except BaseException:
+        prepared.close()
+        raise
 
 
 class RerankerManager:
@@ -151,23 +163,18 @@ class RerankerManager:
             expected_license="CC-BY-NC-4.0",
         )
         loader_model_name = model_reference.rsplit("@", 1)[0]
-        with force_model_offline():
+        with _prepared_model_constructor_environment(prepared):
             try:
                 from fastembed.rerank.cross_encoder import TextCrossEncoder
             except Exception as e:
-                prepared.close()
                 raise ImportError(
                     "fastembed is required. Install it with: pip install fastembed"
                 ) from e
-            try:
-                model = TextCrossEncoder(
-                    model_name=loader_model_name,
-                    specific_model_path=prepared.local_reference,
-                    lazy_load=False,
-                )
-            except BaseException:
-                prepared.close()
-                raise
+            model = TextCrossEncoder(
+                model_name=loader_model_name,
+                specific_model_path=prepared.local_reference,
+                lazy_load=False,
+            )
         self._model = model
         self._prepared_model = prepared
 

--- a/src/power_framework/web/clients/power.py
+++ b/src/power_framework/web/clients/power.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,7 @@ from power_framework.core.application_models import (
     TaskDTO,
     TaskEventDTO,
 )
+from power_framework.core.searcher import search_vault
 
 
 class PowerClient:
@@ -22,7 +24,10 @@ class PowerClient:
 
     def __init__(self, vault_path: Path) -> None:
         self.vault_path = Path(vault_path).expanduser().resolve()
-        self._service = ApplicationService(self.vault_path)
+        self._service = ApplicationService(
+            self.vault_path,
+            search_fn=partial(search_vault, allow_search_db_override=False),
+        )
 
     def discover(self, actor: str = "web") -> ApplicationEnvelope:
         """Fetch system capability manifest."""

--- a/tests/test_application_v2.py
+++ b/tests/test_application_v2.py
@@ -89,6 +89,38 @@ def test_read_only_application_service_does_not_create_task_namespace(temp_vault
     assert not tasks_dir.exists()
 
 
+def test_read_only_application_service_does_not_create_control_directory(tmp_path: Path) -> None:
+    """Constructing the application boundary remains side-effect free for a new vault."""
+    vault = tmp_path / "new-vault"
+    vault.mkdir()
+
+    ApplicationService(vault)
+
+    assert not (vault / ".power").exists()
+
+
+def test_application_service_does_not_create_missing_vault(tmp_path: Path) -> None:
+    """A read-boundary construction must fail closed instead of creating a root."""
+    vault = tmp_path / "missing-vault"
+
+    with pytest.raises(FileNotFoundError, match="Vault path does not exist"):
+        ApplicationService(vault)
+
+    assert not vault.exists()
+
+
+def test_application_source_read_rejects_control_files(temp_vault: Path) -> None:
+    """ApplicationService inherits the core canonical source boundary."""
+    control_file = temp_vault / ".power" / "events.jsonl"
+    control_file.write_text("synthetic internal event", encoding="utf-8")
+    service = ApplicationService(temp_vault)
+
+    with pytest.raises(source_service.SourceNotFoundError) as exc_info:
+        service.source_read(".power/events.jsonl")
+
+    assert str(exc_info.value) == "source not found in canonical source projection"
+
+
 def test_source_list_and_pagination(temp_vault: Path) -> None:
     """Test listing sources with filters and pagination."""
     service = ApplicationService(temp_vault)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -345,13 +345,13 @@ class TestEmbeddingManager:
 
         manager = embeddings.FastEmbedManager("custom/model@" + "a" * 40)
         start_barrier = threading.Barrier(2)
-        errors: list[BaseException] = []
+        errors: list[Exception] = []
 
         def initialize() -> None:
             try:
                 start_barrier.wait(timeout=5)
                 manager._lazy_init()
-            except BaseException as exc:  # pragma: no cover - assertion below reports the failure
+            except Exception as exc:  # pragma: no cover - assertion below reports the failure
                 errors.append(exc)
 
         workers = [threading.Thread(target=initialize) for _ in range(2)]
@@ -685,8 +685,8 @@ class TestEmbeddingManager:
                     raise RuntimeError("synthetic BGE tokenizer failure")
                 return FakeTokenizer()
 
-            def enable_truncation(self, max_length: int) -> None:
-                del max_length
+            def enable_truncation(self, **_kwargs: int) -> None:
+                return None
 
         tokenizers = ModuleType("tokenizers")
         tokenizers.Tokenizer = FakeTokenizer  # type: ignore[attr-defined]

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -21,6 +21,9 @@ class TestEmbeddingManager:
     def test_dense_readiness_is_read_only_and_reports_missing_snapshot(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.setenv("POWER_EMBED_PROVIDER", "bge-m3")
+        monkeypatch.setenv("POWER_BGE_M3_ONNX_REPO", embeddings.BGE_M3_PINNED_REPO)
+        monkeypatch.setenv("POWER_BGE_M3_ONNX_REVISION", embeddings.BGE_M3_PINNED_REVISION)
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "cache"))
 
         ready, reason = embeddings.dense_embedding_ready()
@@ -32,8 +35,14 @@ class TestEmbeddingManager:
     def test_dense_readiness_accepts_complete_local_snapshot(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.setenv("POWER_EMBED_PROVIDER", "bge-m3")
+        monkeypatch.setenv("POWER_BGE_M3_ONNX_REPO", embeddings.BGE_M3_PINNED_REPO)
+        monkeypatch.setenv("POWER_BGE_M3_ONNX_REVISION", embeddings.BGE_M3_PINNED_REVISION)
         snapshot = (
-            tmp_path / "models--aapot--bge-m3-onnx" / "snapshots" / embeddings.BGE_M3_ONNX_REVISION
+            tmp_path
+            / "models--aapot--bge-m3-onnx"
+            / "snapshots"
+            / embeddings.BGE_M3_PINNED_REVISION
         )
         snapshot.mkdir(parents=True)
         expected_hashes: dict[str, str] = {}
@@ -52,6 +61,7 @@ class TestEmbeddingManager:
     def test_dense_readiness_rejects_unapproved_model_override(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.setenv("POWER_EMBED_PROVIDER", "bge-m3")
         monkeypatch.setenv("POWER_BGE_M3_ONNX_REPO", "custom/model")
         monkeypatch.setenv("POWER_BGE_M3_ONNX_REVISION", "b" * 40)
         monkeypatch.delenv("POWER_ALLOW_CUSTOM_MODELS", raising=False)
@@ -320,6 +330,10 @@ class TestEmbeddingManager:
     ):
         from power_framework.core import model_policy
 
+        for name in model_policy.MODEL_OFFLINE_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.delenv("HF_ENDPOINT", raising=False)
+
         class FakeOptions:
             pass
 
@@ -345,8 +359,10 @@ class TestEmbeddingManager:
         monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
         monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
         monkeypatch.setitem(sys.modules, "tokenizers", fake_tokenizers)
+        monkeypatch.setenv("POWER_EMBED_PROVIDER", "bge-m3")
         monkeypatch.setenv("POWER_EMBED_DEVICE", "cuda")
         monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+        monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
         monkeypatch.setattr(
             model_policy,
             "_verify_model_files",

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import inspect
 import signal
 import sys
@@ -35,14 +36,31 @@ class TestEmbeddingManager:
             tmp_path / "models--aapot--bge-m3-onnx" / "snapshots" / embeddings.BGE_M3_ONNX_REVISION
         )
         snapshot.mkdir(parents=True)
+        expected_hashes: dict[str, str] = {}
         for filename in ("model.onnx", "model.onnx.data", "tokenizer.json"):
-            (snapshot / filename).write_bytes(b"cached")
+            content = f"cached:{filename}".encode()
+            (snapshot / filename).write_bytes(content)
+            expected_hashes[filename] = hashlib.sha256(content).hexdigest()
+        monkeypatch.setattr(embeddings, "BGE_M3_FILE_SHA256", expected_hashes)
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
 
         ready, reason = embeddings.dense_embedding_ready()
 
         assert ready is True
         assert reason == "ready"
+
+    def test_dense_readiness_rejects_unapproved_model_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("POWER_BGE_M3_ONNX_REPO", "custom/model")
+        monkeypatch.setenv("POWER_BGE_M3_ONNX_REVISION", "b" * 40)
+        monkeypatch.delenv("POWER_ALLOW_CUSTOM_MODELS", raising=False)
+        monkeypatch.delenv("POWER_MODEL_APPROVAL", raising=False)
+
+        ready, reason = embeddings.dense_embedding_ready()
+
+        assert ready is False
+        assert reason == "model_approval_required"
 
     def test_auto_device_prefers_cuda_and_keeps_cpu_fallback(self, monkeypatch: pytest.MonkeyPatch):
         class FakeOrt:
@@ -300,6 +318,8 @@ class TestEmbeddingManager:
     def test_failed_binding_does_not_retain_an_unsafe_embedder_session(
         self, monkeypatch: pytest.MonkeyPatch
     ):
+        from power_framework.core import model_policy
+
         class FakeOptions:
             pass
 
@@ -326,9 +346,17 @@ class TestEmbeddingManager:
         monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
         monkeypatch.setitem(sys.modules, "tokenizers", fake_tokenizers)
         monkeypatch.setenv("POWER_EMBED_DEVICE", "cuda")
-        monkeypatch.setenv("POWER_ALLOW_UNVERIFIED_MODELS", "1")
+        monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+        monkeypatch.setattr(
+            model_policy,
+            "_verify_model_files",
+            lambda _spec, paths: dict(paths),
+        )
 
-        manager = embeddings.BGEM3OnnxManager(repo="example/repo", revision="dev")
+        manager = embeddings.BGEM3OnnxManager(
+            repo=embeddings.BGE_M3_PINNED_REPO,
+            revision=embeddings.BGE_M3_PINNED_REVISION,
+        )
         with pytest.raises(RuntimeError, match="requested_onnx_provider_not_bound"):
             manager.embed("provider probe")
         assert manager._session is None

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import os
 import signal
 import sys
+import threading
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from typing import TYPE_CHECKING
 
 import pytest
 
 import power_framework.core.embeddings as embeddings
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 class TestEmbeddingManager:
@@ -225,11 +224,278 @@ class TestEmbeddingManager:
         vec2 = manager.embed("Rocket science")
         assert vec1 != vec2
 
+    def test_fastembed_inference_does_not_set_process_offline_flags(self, monkeypatch):
+        """A local model must not change the process policy while embedding."""
+        observed_flags: list[tuple[str | None, ...]] = []
+
+        class FakeModel:
+            def embed(self, texts, **_kwargs):
+                observed_flags.append(
+                    tuple(os.getenv(name) for name in ("POWER_MODEL_OFFLINE", "HF_HUB_OFFLINE"))
+                )
+                return iter([[float(len(text))] for text in texts])
+
+        for name in ("POWER_MODEL_OFFLINE", "HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"):
+            monkeypatch.delenv(name, raising=False)
+        manager = embeddings.FastEmbedManager()
+        manager._model = FakeModel()
+
+        assert manager.embed("text") == [4.0]
+        assert manager.embed_batch(["a", "bb"]) == [[1.0], [2.0]]
+        assert observed_flags == [(None, None), (None, None)]
+
+    def test_fastembed_uses_registered_name_and_specific_local_snapshot_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FastEmbed receives a supported identity plus the verified local directory."""
+        from power_framework.core import model_policy
+
+        root = tmp_path / "power-model-fastembed-api"
+        root.mkdir()
+        spec = model_policy.ApprovedModel(
+            repo="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+            revision="a" * 40,
+            provider="fastembed-embedding",
+            license="MIT",
+            files=(),
+            canonical=False,
+        )
+        prepared = model_policy.PreparedModel(spec, {}, str(root))
+        monkeypatch.setattr(embeddings, "prepare_external_model", lambda **_kwargs: prepared)
+        captured: dict[str, object] = {}
+
+        class FakeEmbedding:
+            def __init__(self, **kwargs: object) -> None:
+                captured.update(kwargs)
+
+        fastembed = ModuleType("fastembed")
+        fastembed.TextEmbedding = FakeEmbedding  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "fastembed", fastembed)
+
+        manager = embeddings.FastEmbedManager(
+            "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2@" + "a" * 40
+        )
+        manager._lazy_init()
+
+        assert (
+            captured["model_name"] == "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+        )
+        assert captured["specific_model_path"] == str(root)
+        manager.close()
+        assert not root.exists()
+
+    def test_installed_fastembed_accepts_specific_local_snapshot_path(self, tmp_path: Path) -> None:
+        """The real FastEmbed API accepts a registered name plus local path."""
+        from fastembed import TextEmbedding
+
+        from power_framework.core.model_policy import force_model_offline
+
+        with force_model_offline():
+            loader = TextEmbedding(
+                model_name=embeddings.FASTEMBED_MODEL,
+                specific_model_path=str(tmp_path),
+                lazy_load=True,
+            )
+
+        assert loader.model_name == embeddings.FASTEMBED_MODEL
+
+    def test_fastembed_lazy_init_is_single_flight_and_owns_one_staging_tree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Concurrent initialization prepares and constructs exactly one model."""
+        from power_framework.core import model_policy
+
+        prepared_models: list[model_policy.PreparedModel] = []
+        prepare_calls = 0
+
+        def prepare(**_kwargs: object) -> model_policy.PreparedModel:
+            nonlocal prepare_calls
+            prepare_calls += 1
+            root = tmp_path / f"power-model-fastembed-{prepare_calls}"
+            root.mkdir()
+            spec = model_policy.ApprovedModel(
+                repo="custom/model",
+                revision="a" * 40,
+                provider="fastembed-embedding",
+                license="MIT",
+                files=(),
+                canonical=False,
+            )
+            prepared = model_policy.PreparedModel(spec, {}, str(root))
+            prepared_models.append(prepared)
+            return prepared
+
+        constructor_started = threading.Event()
+        release_constructor = threading.Event()
+        constructor_calls = 0
+
+        class BlockingEmbedding:
+            def __init__(self, **_kwargs: object) -> None:
+                nonlocal constructor_calls
+                constructor_calls += 1
+                if constructor_calls == 1:
+                    constructor_started.set()
+                    if not release_constructor.wait(5):
+                        raise AssertionError("constructor release was not signalled")
+
+        fastembed = ModuleType("fastembed")
+        fastembed.TextEmbedding = BlockingEmbedding  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "fastembed", fastembed)
+        monkeypatch.setattr(embeddings, "prepare_external_model", prepare)
+
+        manager = embeddings.FastEmbedManager("custom/model@" + "a" * 40)
+        start_barrier = threading.Barrier(2)
+        errors: list[BaseException] = []
+
+        def initialize() -> None:
+            try:
+                start_barrier.wait(timeout=5)
+                manager._lazy_init()
+            except BaseException as exc:  # pragma: no cover - assertion below reports the failure
+                errors.append(exc)
+
+        workers = [threading.Thread(target=initialize) for _ in range(2)]
+        for worker in workers:
+            worker.start()
+        assert constructor_started.wait(5)
+        release_constructor.set()
+        for worker in workers:
+            worker.join(timeout=5)
+
+        assert all(not worker.is_alive() for worker in workers)
+        assert not errors
+        assert prepare_calls == 1
+        assert constructor_calls == 1
+        assert len(prepared_models) == 1
+        assert Path(prepared_models[0].local_reference).is_dir()
+
+        manager.close()
+        assert not Path(prepared_models[0].local_reference).exists()
+
+    def test_fastembed_constructor_failure_releases_staging_and_retry_is_fresh(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed constructor cannot poison retry state or retain its staging tree."""
+        from power_framework.core import model_policy
+
+        prepared_models: list[model_policy.PreparedModel] = []
+
+        def prepare(**_kwargs: object) -> model_policy.PreparedModel:
+            root = tmp_path / f"power-model-retry-{len(prepared_models) + 1}"
+            root.mkdir()
+            spec = model_policy.ApprovedModel(
+                repo="custom/model",
+                revision="a" * 40,
+                provider="fastembed-embedding",
+                license="MIT",
+                files=(),
+                canonical=False,
+            )
+            prepared = model_policy.PreparedModel(spec, {}, str(root))
+            prepared_models.append(prepared)
+            return prepared
+
+        constructor_calls = 0
+
+        class RetryEmbedding:
+            def __init__(self, **_kwargs: object) -> None:
+                nonlocal constructor_calls
+                constructor_calls += 1
+                if constructor_calls == 1:
+                    raise RuntimeError("synthetic constructor failure")
+
+        fastembed = ModuleType("fastembed")
+        fastembed.TextEmbedding = RetryEmbedding  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "fastembed", fastembed)
+        monkeypatch.setattr(embeddings, "prepare_external_model", prepare)
+
+        manager = embeddings.FastEmbedManager("custom/model@" + "a" * 40)
+        with pytest.raises(RuntimeError, match="synthetic constructor failure"):
+            manager._lazy_init()
+
+        assert manager._model is None
+        assert not Path(prepared_models[0].local_reference).exists()
+
+        manager._lazy_init()
+        assert manager._model is not None
+        assert len(prepared_models) == 2
+        assert not Path(prepared_models[0].local_reference).exists()
+        assert Path(prepared_models[1].local_reference).is_dir()
+
+        manager.close()
+        manager.close()
+        assert not Path(prepared_models[1].local_reference).exists()
+
+    def test_qwen_probe_failure_releases_staging_and_retry_is_fresh(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed eager probe releases its tree and permits one clean retry."""
+        from power_framework.core import model_policy
+
+        prepared_models: list[model_policy.PreparedModel] = []
+
+        def prepare(**_kwargs: object) -> model_policy.PreparedModel:
+            root = tmp_path / f"power-model-qwen-retry-{len(prepared_models) + 1}"
+            root.mkdir()
+            spec = model_policy.ApprovedModel(
+                repo="custom/model",
+                revision="a" * 40,
+                provider="qwen3-embedding-onnx",
+                license="MIT",
+                files=(),
+                canonical=False,
+            )
+            prepared = model_policy.PreparedModel(spec, {}, str(root))
+            prepared_models.append(prepared)
+            return prepared
+
+        instances = 0
+        constructor_kwargs: dict[str, object] = {}
+
+        class RetryQwenEmbedding:
+            def __init__(self, **_kwargs: object) -> None:
+                nonlocal instances
+                instances += 1
+                self.instance = instances
+                constructor_kwargs.update(_kwargs)
+
+            def embed(self, _texts, **_kwargs: object):
+                if self.instance == 1:
+                    raise RuntimeError("synthetic probe failure")
+                return iter([[0.0] * 1024])
+
+        qwen = ModuleType("qwen3_embed")
+        qwen.TextEmbedding = RetryQwenEmbedding  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "qwen3_embed", qwen)
+        monkeypatch.setattr(embeddings, "prepare_external_model", prepare)
+
+        manager = embeddings.Qwen3EmbeddingManager("custom/model@" + "a" * 40)
+        with pytest.raises(RuntimeError, match="qwen3_onnx_alloc_failed"):
+            manager._lazy_init()
+
+        assert manager._model is None
+        assert not Path(prepared_models[0].local_reference).exists()
+
+        manager._lazy_init()
+        assert manager._model is not None
+        assert len(prepared_models) == 2
+        assert not Path(prepared_models[0].local_reference).exists()
+        assert Path(prepared_models[1].local_reference).is_dir()
+        assert constructor_kwargs["model_name"] == "custom/model"
+        assert constructor_kwargs["specific_model_path"] == prepared_models[1].local_reference
+        assert constructor_kwargs["local_files_only"] is True
+
+        manager.close()
+        manager.close()
+        assert not Path(prepared_models[1].local_reference).exists()
+
     def test_canonical_identity_contains_immutable_revision(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("POWER_EMBED_PROVIDER", "bge-m3")
+        monkeypatch.setenv("POWER_BGE_M3_ONNX_REPO", embeddings.BGE_M3_PINNED_REPO)
+        monkeypatch.setenv("POWER_BGE_M3_ONNX_REVISION", embeddings.BGE_M3_PINNED_REVISION)
         provider, model = embeddings.configured_embedding_identity()
         assert provider == "BGEM3OnnxManager"
-        assert model == f"{embeddings.BGE_M3_PINNED_REPO}@{embeddings.BGE_M3_ONNX_REVISION}"
+        assert model == f"{embeddings.BGE_M3_PINNED_REPO}@{embeddings.BGE_M3_PINNED_REVISION}"
 
     def test_sha256_verification_fails_closed(self, tmp_path: Path):
         artifact = tmp_path / "model.onnx"
@@ -377,3 +643,81 @@ class TestEmbeddingManager:
             manager.embed("provider probe")
         assert manager._session is None
         assert manager.active_provider is None
+
+    @pytest.mark.parametrize("failure_stage", ["tokenizer", "probe"])
+    def test_bge_probe_failure_clears_session_and_allows_clean_retry(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, failure_stage: str
+    ) -> None:
+        """Direct BGE probe failures must not poison the manager's retry state."""
+        model_files = {
+            "model.onnx": str(tmp_path / "model.onnx"),
+            "model.onnx.data": str(tmp_path / "model.onnx.data"),
+            "tokenizer.json": str(tmp_path / "tokenizer.json"),
+        }
+        monkeypatch.setattr(embeddings, "acquire_model_files", lambda **_kwargs: model_files)
+
+        class FakeOptions:
+            enable_cpu_mem_arena = True
+            intra_op_num_threads = 0
+            inter_op_num_threads = 0
+
+        class FakeSession:
+            @staticmethod
+            def get_providers() -> list[str]:
+                return ["CPUExecutionProvider"]
+
+        class FakeOrt:
+            SessionOptions = FakeOptions
+            InferenceSession = staticmethod(lambda *_args, **_kwargs: FakeSession())
+
+            @staticmethod
+            def get_available_providers() -> list[str]:
+                return ["CPUExecutionProvider"]
+
+        tokenizer_calls = 0
+
+        class FakeTokenizer:
+            @staticmethod
+            def from_file(_path: str) -> FakeTokenizer:
+                nonlocal tokenizer_calls
+                tokenizer_calls += 1
+                if failure_stage == "tokenizer" and tokenizer_calls == 1:
+                    raise RuntimeError("synthetic BGE tokenizer failure")
+                return FakeTokenizer()
+
+            def enable_truncation(self, max_length: int) -> None:
+                del max_length
+
+        tokenizers = ModuleType("tokenizers")
+        tokenizers.Tokenizer = FakeTokenizer  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "onnxruntime", FakeOrt)
+        monkeypatch.setitem(sys.modules, "tokenizers", tokenizers)
+        monkeypatch.setenv("POWER_EMBED_DEVICE", "cpu")
+
+        manager = embeddings.BGEM3OnnxManager(
+            repo=embeddings.BGE_M3_PINNED_REPO,
+            revision=embeddings.BGE_M3_PINNED_REVISION,
+        )
+        should_fail = True
+
+        def probe(_texts: list[str]) -> list[list[float]]:
+            if should_fail:
+                raise RuntimeError("synthetic BGE probe failure")
+            return [[0.0] * embeddings.BGE_M3_DIM]
+
+        monkeypatch.setattr(manager, "_embed_raw", probe)
+        expected_error = (
+            "synthetic BGE tokenizer failure"
+            if failure_stage == "tokenizer"
+            else "synthetic BGE probe failure"
+        )
+        with pytest.raises(RuntimeError, match=expected_error):
+            manager._lazy_init()
+        assert manager._session is None
+        assert manager._tokenizer is None
+        assert manager.active_provider is None
+
+        should_fail = False
+        manager._lazy_init()
+        assert manager._session is not None
+        assert manager._tokenizer is not None

--- a/tests/test_generation_index.py
+++ b/tests/test_generation_index.py
@@ -711,8 +711,10 @@ def test_empty_legacy_dense_migration_writes_zero_count_manifest(
         conn.commit()
 
     class EmptyDenseManager:
-        dimension = 3
         model_name = "empty-migration"
+
+        def dimension(self) -> int:
+            return 3
 
         def embed_batch(self, texts: list[str], batch_size: int = 32) -> list[list[float]]:
             del batch_size

--- a/tests/test_generation_index.py
+++ b/tests/test_generation_index.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from power_framework.core import generation_index
+from power_framework.core import generation_index, index_sync
+from power_framework.core.constants import DENSE_INDEX_SCHEMA_VERSION
 from power_framework.core.db import _init_db
 from power_framework.core.generation_index import (
     ActiveGeneration,
@@ -679,3 +680,120 @@ def test_legacy_dense_state_is_also_fail_closed(
     assert active_dense_chunk_count(vault) == 1
     with pytest.raises(IndexGenerationError, match=r"Refusing --fts-only.*1 chunks"):
         sync_vault_atomically(vault, sync_embeddings=False)
+
+
+def test_empty_legacy_dense_migration_writes_zero_count_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty forced rebuild must not inherit a legacy dense identity."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    vault = tmp_path / "empty-legacy-dense"
+    vault.mkdir()
+    legacy = vault_db_path(vault)
+    with closing(sqlite3.connect(legacy)) as conn:
+        _init_db(conn)
+        conn.execute(
+            "INSERT INTO chunk_embeddings(chunk_id, rel_path, embedding, content, mtime) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("legacy", "01_Projects/Removed.md", b"old", "old", 0.0),
+        )
+        conn.executemany(
+            "INSERT INTO dense_index_manifest(manifest_key, manifest_value) VALUES (?, ?)",
+            [
+                ("schema_version", DENSE_INDEX_SCHEMA_VERSION),
+                ("embedding_dimension", "3"),
+                ("chunk_count", "1"),
+                ("embedding_provider", "legacy-provider"),
+                ("embedding_model", "legacy-model"),
+            ],
+        )
+        conn.commit()
+
+    class EmptyDenseManager:
+        dimension = 3
+        model_name = "empty-migration"
+
+        def embed_batch(self, texts: list[str], batch_size: int = 32) -> list[list[float]]:
+            del batch_size
+            return [[0.0, 0.0, 0.0] for _ in texts]
+
+    monkeypatch.setattr(index_sync, "_get_embedding_manager", lambda: EmptyDenseManager())
+
+    report = sync_vault_atomically(vault, sync_embeddings=True, force_rebuild=True)
+
+    assert report.actual_chunks == 0
+    active = _active_db(vault)
+    with closing(sqlite3.connect(active)) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM chunk_embeddings").fetchone()[0] == 0
+        manifest = dict(
+            conn.execute("SELECT manifest_key, manifest_value FROM dense_index_manifest")
+        )
+        validated = generation_index._validate_staging(
+            conn,
+            set(),
+            True,
+            expected_source_revision=report.source_snapshot_hash,
+        )
+
+    assert manifest == {
+        "schema_version": DENSE_INDEX_SCHEMA_VERSION,
+        "embedding_dimension": "3",
+        "chunk_count": "0",
+        "embedding_provider": "EmptyDenseManager",
+        "embedding_model": "empty-migration",
+    }
+    assert validated[1:] == (0, "EmptyDenseManager", "empty-migration")
+
+
+def test_nonempty_legacy_dense_migration_rewrites_manifest_from_new_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-empty forced migration keeps the regular manifest contract."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    vault = _vault(tmp_path, "nonempty-legacy-dense", "current-token")
+    legacy = vault_db_path(vault)
+    with closing(sqlite3.connect(legacy)) as conn:
+        _init_db(conn)
+        conn.execute(
+            "INSERT INTO chunk_embeddings(chunk_id, rel_path, embedding, content, mtime) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("legacy", "01_Projects/Test.md", b"old", "old", 0.0),
+        )
+        conn.executemany(
+            "INSERT INTO dense_index_manifest(manifest_key, manifest_value) VALUES (?, ?)",
+            [
+                ("schema_version", DENSE_INDEX_SCHEMA_VERSION),
+                ("embedding_dimension", "99"),
+                ("chunk_count", "1"),
+                ("embedding_provider", "legacy-provider"),
+                ("embedding_model", "legacy-model"),
+            ],
+        )
+        conn.commit()
+
+    class DenseMigrationManager:
+        dimension = 3
+        model_name = "nonempty-migration"
+
+        def embed_batch(self, texts: list[str], batch_size: int = 32) -> list[list[float]]:
+            del batch_size
+            return [[float(index), 1.0, 0.0] for index, _ in enumerate(texts)]
+
+    monkeypatch.setattr(index_sync, "_get_embedding_manager", lambda: DenseMigrationManager())
+
+    report = sync_vault_atomically(vault, sync_embeddings=True, force_rebuild=True)
+
+    assert report.actual_chunks > 0
+    with closing(sqlite3.connect(_active_db(vault))) as conn:
+        chunk_count = conn.execute("SELECT COUNT(*) FROM chunk_embeddings").fetchone()[0]
+        manifest = dict(
+            conn.execute("SELECT manifest_key, manifest_value FROM dense_index_manifest")
+        )
+
+    assert manifest["schema_version"] == DENSE_INDEX_SCHEMA_VERSION
+    assert manifest["embedding_dimension"] == "3"
+    assert manifest["chunk_count"] == str(chunk_count)
+    assert manifest["embedding_provider"] == "DenseMigrationManager"
+    assert manifest["embedding_model"] == "nonempty-migration"

--- a/tests/test_generation_index.py
+++ b/tests/test_generation_index.py
@@ -472,6 +472,29 @@ def test_legacy_search_database_is_imported_before_removal(
     assert search_vault(vault, "legacy-token", mode="fts")
 
 
+def test_legacy_migration_rebuilds_content_for_changed_source_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legacy derived row must not be paired with a newer source projection."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    vault = _vault(tmp_path, "legacy-rewrite", "old-token")
+    legacy_path = vault_db_path(vault)
+    with closing(sqlite3.connect(legacy_path)) as conn:
+        _init_db(conn)
+        _sync_vault_to_db(vault, conn, sync_embeddings=False)
+
+    note = vault / "01_Projects" / "Test.md"
+    note.write_text(
+        note.read_text(encoding="utf-8").replace("old-token", "new-token"), encoding="utf-8"
+    )
+
+    report = sync_vault_atomically(vault, sync_embeddings=False)
+
+    assert report.actual_files == 1
+    assert search_vault(vault, "new-token", mode="fts")
+    assert not search_vault(vault, "old-token", mode="fts")
+
+
 def test_stale_legacy_database_falls_back_to_source_rebuild(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -727,8 +727,7 @@ def test_prepare_external_model_releases_staging_when_copy_fails(
 
     staging = tmp_path / "power-model-copy-failure"
 
-    def make_staging(*, prefix: str) -> str:
-        del prefix
+    def make_staging(**_kwargs: str) -> str:
         staging.mkdir()
         return str(staging)
 
@@ -750,6 +749,64 @@ def test_prepare_external_model_releases_staging_when_copy_fails(
         )
 
     assert not staging.exists()
+
+
+def test_prepare_external_model_preserves_staging_cleanup_failure_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A staging tamper error remains visible and retains the preparation cause."""
+    paths, hashes = _files(tmp_path / "snapshot")
+    repo = "custom/model"
+    revision = "b" * 40
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "deny")
+    monkeypatch.setenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, "1")
+    monkeypatch.setenv(
+        model_policy.MODEL_APPROVAL_ENV,
+        json.dumps(
+            {
+                "operation": "embeddings",
+                "provider": "test-external",
+                "license": "MIT",
+                "repo": repo,
+                "revision": revision,
+                "files": hashes,
+            }
+        ),
+    )
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: paths)
+
+    staging = tmp_path / "power-model-tampered"
+
+    def make_staging(**_kwargs: str) -> str:
+        staging.mkdir()
+        return str(staging)
+
+    def fail_link(_source: Path, _destination: Path) -> None:
+        raise OSError("synthetic preparation failure")
+
+    def fail_copy(_source: Path, _destination: Path) -> None:
+        raise OSError("synthetic copy failure")
+
+    def fail_release(_prepared: model_policy.PreparedModel) -> None:
+        raise model_policy.ModelIntegrityError("synthetic staging tamper")
+
+    monkeypatch.setattr(model_policy.tempfile, "mkdtemp", make_staging)
+    monkeypatch.setattr(model_policy.os, "link", fail_link)
+    monkeypatch.setattr(model_policy.shutil, "copyfile", fail_copy)
+    monkeypatch.setattr(model_policy.PreparedModel, "release", fail_release)
+
+    with pytest.raises(
+        model_policy.ModelIntegrityError, match="synthetic staging tamper"
+    ) as exc_info:
+        model_policy.prepare_external_model(
+            operation=EgressOperation.EMBEDDINGS,
+            provider="test-external",
+            model_reference=f"{repo}@{revision}",
+        )
+
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert str(exc_info.value.__cause__) == "synthetic copy failure"
+    assert staging.exists()
 
 
 def test_prepare_external_model_releases_staging_when_staged_hash_fails(
@@ -779,8 +836,7 @@ def test_prepare_external_model_releases_staging_when_staged_hash_fails(
 
     staging = tmp_path / "power-model-hash-failure"
 
-    def make_staging(*, prefix: str) -> str:
-        del prefix
+    def make_staging(**_kwargs: str) -> str:
         staging.mkdir()
         return str(staging)
 

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -206,7 +206,7 @@ def test_model_acquisition_cannot_be_interleaved_by_constructor_environment(
     release_download = threading.Event()
     constructor_entered = threading.Event()
     observed_flags: list[tuple[str | None, ...]] = []
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
     monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
     monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
 
@@ -230,7 +230,7 @@ def test_model_acquisition_cannot_be_interleaved_by_constructor_environment(
     def acquire() -> None:
         try:
             model_policy.acquire_model_files(**_acquire_kwargs("org/model", "a" * 40, hashes))
-        except BaseException as exc:  # pragma: no cover - assertion below reports the failure
+        except Exception as exc:  # pragma: no cover - assertion below reports the failure
             errors.append(exc)
 
     acquisition_thread = threading.Thread(target=acquire)
@@ -847,8 +847,8 @@ def test_constructor_local_offline_state_does_not_block_concurrent_acquisition(
     acquisition_started = threading.Event()
     acquisition_checked = threading.Event()
     offline_check_started = threading.Event()
-    constructor_errors: list[BaseException] = []
-    acquisition_errors: list[BaseException] = []
+    constructor_errors: list[Exception] = []
+    acquisition_errors: list[Exception] = []
     acquisition_result: list[dict[str, str]] = []
 
     class BlockingEmbedding:
@@ -873,7 +873,7 @@ def test_constructor_local_offline_state_does_not_block_concurrent_acquisition(
     def construct_delegated() -> None:
         try:
             manager._lazy_init()
-        except BaseException as exc:  # pragma: no cover - assertion below reports the failure
+        except Exception as exc:  # pragma: no cover - assertion below reports the failure
             constructor_errors.append(exc)
 
     def acquire_remote() -> None:
@@ -893,7 +893,7 @@ def test_constructor_local_offline_state_does_not_block_concurrent_acquisition(
                     canonical_hashes=remote_hashes,
                 )
             )
-        except BaseException as exc:  # pragma: no cover - assertion below reports the failure
+        except Exception as exc:  # pragma: no cover - assertion below reports the failure
             acquisition_errors.append(exc)
 
     constructor_thread = threading.Thread(target=construct_delegated)

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sys
+import threading
 from pathlib import Path
 from types import ModuleType
 
@@ -67,6 +69,7 @@ def isolate_model_policy_environment(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _files(tmp_path: Path, *, mismatch: bool = False) -> tuple[dict[str, str], dict[str, str]]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
     paths: dict[str, str] = {}
     hashes: dict[str, str] = {}
     for filename, content in (
@@ -157,6 +160,100 @@ def test_unapproved_hf_endpoint_is_rejected_before_network(
     with pytest.raises(model_policy.ModelApprovalError, match="model_endpoint_not_approved"):
         model_policy.acquire_model_files(**_acquire_kwargs("org/model", "a" * 40, hashes))
     assert calls == []
+
+
+def test_hf_acquisition_binds_the_validated_endpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The downloader must receive the same endpoint that policy validated."""
+    paths, hashes = _files(tmp_path)
+    calls: list[dict[str, object]] = []
+    module = ModuleType("huggingface_hub")
+
+    def download(_repo: str, filename: str, **kwargs: object) -> str:
+        calls.append(kwargs)
+        return paths[filename]
+
+    module.hf_hub_download = download  # type: ignore[attr-defined]
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv("HF_ENDPOINT", "https://huggingface.co")
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", module)
+
+    result = model_policy.acquire_model_files(**_acquire_kwargs("org/model", "a" * 40, hashes))
+
+    assert result == paths
+    assert calls == [
+        {
+            "revision": "a" * 40,
+            "local_files_only": False,
+            "endpoint": "https://huggingface.co",
+        },
+        {
+            "revision": "a" * 40,
+            "local_files_only": False,
+            "endpoint": "https://huggingface.co",
+        },
+    ]
+
+
+def test_model_acquisition_cannot_be_interleaved_by_constructor_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A constructor-local environment window cannot contaminate an active download."""
+    paths, hashes = _files(tmp_path)
+    download_started = threading.Event()
+    release_download = threading.Event()
+    constructor_entered = threading.Event()
+    observed_flags: list[tuple[str | None, ...]] = []
+    errors: list[BaseException] = []
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+
+    module = ModuleType("huggingface_hub")
+
+    def download(_repo: str, filename: str, **_kwargs: object) -> str:
+        download_started.set()
+        if not release_download.wait(5):
+            raise AssertionError("download release was not signalled")
+        observed_flags.append(
+            tuple(
+                os.getenv(name)
+                for name in ("POWER_MODEL_OFFLINE", "HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE")
+            )
+        )
+        return paths[filename]
+
+    module.hf_hub_download = download  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "huggingface_hub", module)
+
+    def acquire() -> None:
+        try:
+            model_policy.acquire_model_files(**_acquire_kwargs("org/model", "a" * 40, hashes))
+        except BaseException as exc:  # pragma: no cover - assertion below reports the failure
+            errors.append(exc)
+
+    acquisition_thread = threading.Thread(target=acquire)
+    acquisition_thread.start()
+    assert download_started.wait(5)
+
+    def enter_constructor_window() -> None:
+        with model_policy.force_model_offline():
+            constructor_entered.set()
+
+    constructor_thread = threading.Thread(target=enter_constructor_window)
+    constructor_thread.start()
+    assert not constructor_entered.wait(0.1)
+
+    release_download.set()
+    acquisition_thread.join(timeout=5)
+    constructor_thread.join(timeout=5)
+
+    assert not acquisition_thread.is_alive()
+    assert not constructor_thread.is_alive()
+    assert not errors
+    assert observed_flags == [(None, None, None), (None, None, None)]
+    assert constructor_entered.is_set()
 
 
 def test_complete_cached_canonical_model_works_under_deny_without_hf_call(
@@ -597,3 +694,252 @@ def test_approved_external_loader_receives_verified_local_snapshot(
         paths
     )
     assert not (staging / "unapproved-config.py").exists()
+
+    prepared.release()
+    assert not staging.exists()
+    prepared.close()
+
+
+def test_prepare_external_model_releases_staging_when_copy_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed hardlink and copy fallback must not leave a staging tree behind."""
+    snapshot = tmp_path / "snapshot"
+    paths, hashes = _files(snapshot)
+    repo = "custom/model"
+    revision = "b" * 40
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "deny")
+    monkeypatch.setenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, "1")
+    monkeypatch.setenv(
+        model_policy.MODEL_APPROVAL_ENV,
+        json.dumps(
+            {
+                "operation": "embeddings",
+                "provider": "test-external",
+                "license": "MIT",
+                "repo": repo,
+                "revision": revision,
+                "files": hashes,
+            }
+        ),
+    )
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: paths)
+
+    staging = tmp_path / "power-model-copy-failure"
+
+    def make_staging(*, prefix: str) -> str:
+        del prefix
+        staging.mkdir()
+        return str(staging)
+
+    def fail_link(_source: Path, _destination: Path) -> None:
+        raise OSError("synthetic hardlink failure")
+
+    def fail_copy(_source: Path, _destination: Path) -> None:
+        raise OSError("synthetic copy failure")
+
+    monkeypatch.setattr(model_policy.tempfile, "mkdtemp", make_staging)
+    monkeypatch.setattr(model_policy.os, "link", fail_link)
+    monkeypatch.setattr(model_policy.shutil, "copyfile", fail_copy)
+
+    with pytest.raises(model_policy.ModelIntegrityError, match="isolated_model_snapshot_failed"):
+        model_policy.prepare_external_model(
+            operation=EgressOperation.EMBEDDINGS,
+            provider="test-external",
+            model_reference=f"{repo}@{revision}",
+        )
+
+    assert not staging.exists()
+
+
+def test_prepare_external_model_releases_staging_when_staged_hash_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A post-copy verification failure must release the owned staging tree."""
+    snapshot = tmp_path / "snapshot"
+    paths, hashes = _files(snapshot)
+    repo = "custom/model"
+    revision = "b" * 40
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "deny")
+    monkeypatch.setenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, "1")
+    monkeypatch.setenv(
+        model_policy.MODEL_APPROVAL_ENV,
+        json.dumps(
+            {
+                "operation": "embeddings",
+                "provider": "test-external",
+                "license": "MIT",
+                "repo": repo,
+                "revision": revision,
+                "files": hashes,
+            }
+        ),
+    )
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: paths)
+
+    staging = tmp_path / "power-model-hash-failure"
+
+    def make_staging(*, prefix: str) -> str:
+        del prefix
+        staging.mkdir()
+        return str(staging)
+
+    original_verify = model_policy.verify_model_files
+    verify_calls = 0
+
+    def fail_staged_verify(spec: model_policy.ApprovedModel, candidate: dict[str, str]):
+        nonlocal verify_calls
+        verify_calls += 1
+        if verify_calls == 2:
+            raise model_policy.ModelIntegrityError("synthetic staged hash failure")
+        return original_verify(spec, candidate)
+
+    monkeypatch.setattr(model_policy.tempfile, "mkdtemp", make_staging)
+    monkeypatch.setattr(model_policy, "verify_model_files", fail_staged_verify)
+
+    with pytest.raises(model_policy.ModelIntegrityError, match="isolated_model_snapshot_failed"):
+        model_policy.prepare_external_model(
+            operation=EgressOperation.EMBEDDINGS,
+            provider="test-external",
+            model_reference=f"{repo}@{revision}",
+        )
+
+    assert verify_calls == 2
+    assert not staging.exists()
+
+
+def test_constructor_local_offline_state_does_not_block_concurrent_acquisition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A delegated constructor's temporary flags cannot become another request's policy."""
+    delegated_snapshot = tmp_path / "delegated-snapshot"
+    delegated_paths, delegated_hashes = _files(delegated_snapshot)
+    delegated_repo = "custom/delegated"
+    delegated_revision = "b" * 40
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, "1")
+    monkeypatch.setenv(
+        model_policy.MODEL_APPROVAL_ENV,
+        json.dumps(
+            {
+                "operation": "embeddings",
+                "provider": "fastembed-embedding",
+                "license": "MIT",
+                "repo": delegated_repo,
+                "revision": delegated_revision,
+                "files": delegated_hashes,
+            }
+        ),
+    )
+
+    remote_snapshot = tmp_path / "remote-snapshot"
+    remote_paths, remote_hashes = _files(remote_snapshot)
+    remote_calls: list[str] = []
+    monkeypatch.setattr(
+        model_policy,
+        "_cached_model_files",
+        lambda spec: delegated_paths if spec.repo == delegated_repo else {},
+    )
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(remote_calls, remote_paths))
+
+    constructor_started = threading.Event()
+    release_constructor = threading.Event()
+    acquisition_started = threading.Event()
+    acquisition_checked = threading.Event()
+    offline_check_started = threading.Event()
+    constructor_errors: list[BaseException] = []
+    acquisition_errors: list[BaseException] = []
+    acquisition_result: list[dict[str, str]] = []
+
+    class BlockingEmbedding:
+        def __init__(self, **_kwargs: object) -> None:
+            constructor_started.set()
+            if not release_constructor.wait(5):
+                raise AssertionError("constructor release was not signalled")
+
+    fastembed = ModuleType("fastembed")
+    fastembed.TextEmbedding = BlockingEmbedding  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "fastembed", fastembed)
+
+    original_model_offline = model_policy.model_offline
+
+    def observe_model_offline() -> bool:
+        offline_check_started.set()
+        return original_model_offline()
+
+    monkeypatch.setattr(model_policy, "model_offline", observe_model_offline)
+    manager = embeddings.FastEmbedManager(f"{delegated_repo}@{delegated_revision}")
+
+    def construct_delegated() -> None:
+        try:
+            manager._lazy_init()
+        except BaseException as exc:  # pragma: no cover - assertion below reports the failure
+            constructor_errors.append(exc)
+
+    def acquire_remote() -> None:
+        acquisition_started.set()
+        try:
+            acquisition_result.append(
+                model_policy.acquire_model_files(
+                    operation=EgressOperation.EMBEDDINGS,
+                    repo="remote/model",
+                    revision="a" * 40,
+                    provider="bge-m3-onnx",
+                    required_files=("model.onnx", "tokenizer.json"),
+                    canonical_repo="remote/model",
+                    canonical_revision="a" * 40,
+                    canonical_provider="bge-m3-onnx",
+                    canonical_license="MIT",
+                    canonical_hashes=remote_hashes,
+                )
+            )
+        except BaseException as exc:  # pragma: no cover - assertion below reports the failure
+            acquisition_errors.append(exc)
+
+    constructor_thread = threading.Thread(target=construct_delegated)
+    constructor_thread.start()
+    assert constructor_started.wait(5)
+
+    original_cached = model_policy._cached_model_files
+
+    def observe_acquisition_cache(spec: model_policy.ApprovedModel) -> dict[str, str]:
+        if spec.repo != delegated_repo:
+            acquisition_checked.set()
+        return original_cached(spec) if spec.repo == delegated_repo else {}
+
+    monkeypatch.setattr(model_policy, "_cached_model_files", observe_acquisition_cache)
+    acquisition_thread = threading.Thread(target=acquire_remote)
+    acquisition_thread.start()
+    assert acquisition_started.wait(5)
+    assert not acquisition_errors
+    assert acquisition_thread.is_alive()
+    assert not acquisition_checked.is_set()
+    assert not offline_check_started.is_set()
+
+    release_constructor.set()
+    constructor_thread.join(timeout=5)
+    acquisition_thread.join(timeout=5)
+
+    assert not constructor_thread.is_alive()
+    assert not acquisition_thread.is_alive()
+    assert not constructor_errors
+    assert not acquisition_errors
+    assert acquisition_result == [remote_paths]
+    assert remote_calls == ["model.onnx", "tokenizer.json"]
+
+    monkeypatch.setenv("POWER_MODEL_OFFLINE", "1")
+    with pytest.raises(model_policy.ModelOfflineError, match="model_offline_cache_missing"):
+        model_policy.acquire_model_files(
+            operation=EgressOperation.EMBEDDINGS,
+            repo="remote/model",
+            revision="a" * 40,
+            provider="bge-m3-onnx",
+            required_files=("model.onnx", "tokenizer.json"),
+            canonical_repo="remote/model",
+            canonical_revision="a" * 40,
+            canonical_provider="bge-m3-onnx",
+            canonical_license="MIT",
+            canonical_hashes=remote_hashes,
+        )
+    assert remote_calls == ["model.onnx", "tokenizer.json"]
+    manager.close()

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -1,0 +1,548 @@
+"""Adversarial regression tests for the centralized model egress boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from power_framework.core import model_policy
+from power_framework.core.egress import EgressDeniedError, EgressOperation
+from power_framework.experimental import embeddings, reranker
+
+
+def _files(tmp_path: Path, *, mismatch: bool = False) -> tuple[dict[str, str], dict[str, str]]:
+    paths: dict[str, str] = {}
+    hashes: dict[str, str] = {}
+    for filename, content in (
+        ("model.onnx", b"synthetic model"),
+        ("tokenizer.json", b'{"synthetic":true}'),
+    ):
+        path = tmp_path / filename
+        path.write_bytes(b"tampered" if mismatch and filename == "model.onnx" else content)
+        paths[filename] = str(path)
+        hashes[filename] = hashlib.sha256(content).hexdigest()
+    return paths, hashes
+
+
+def _acquire_kwargs(repo: str, revision: str, hashes: dict[str, str]) -> dict[str, object]:
+    return {
+        "operation": EgressOperation.EMBEDDINGS,
+        "repo": repo,
+        "revision": revision,
+        "provider": "bge-m3-onnx",
+        "required_files": ("model.onnx", "tokenizer.json"),
+        "canonical_repo": repo,
+        "canonical_revision": revision,
+        "canonical_provider": "bge-m3-onnx",
+        "canonical_license": "MIT",
+        "canonical_hashes": hashes,
+    }
+
+
+def _fake_hub(calls: list[str], paths: dict[str, str], *, failure: bool = False) -> ModuleType:
+    module = ModuleType("huggingface_hub")
+
+    def download(_repo: str, filename: str, **_kwargs: object) -> str:
+        calls.append(filename)
+        if failure:
+            raise RuntimeError("synthetic download failure")
+        return paths[filename]
+
+    module.hf_hub_download = download  # type: ignore[attr-defined]
+    return module
+
+
+@pytest.mark.parametrize("policy", [None, "deny"])
+def test_default_or_explicit_deny_rejects_before_hf_network(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, policy: str | None
+) -> None:
+    """No HF network-capable function is called when the cache is incomplete."""
+    _paths, hashes = _files(tmp_path)
+    calls: list[str] = []
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, _paths))
+    if policy is None:
+        monkeypatch.delenv("POWER_EGRESS_POLICY", raising=False)
+    else:
+        monkeypatch.setenv("POWER_EGRESS_POLICY", policy)
+
+    with pytest.raises(EgressDeniedError, match="POWER_EGRESS_POLICY=deny"):
+        model_policy.acquire_model_files(**_acquire_kwargs("org/model", "a" * 40, hashes))
+    assert calls == []
+
+
+@pytest.mark.parametrize("offline_name", model_policy.MODEL_OFFLINE_ENV_VARS)
+def test_any_offline_flag_wins_over_allow_public_before_hf_network(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, offline_name: str
+) -> None:
+    """POWER and maintained HF offline flags all force deterministic cache-only behavior."""
+    _paths, hashes = _files(tmp_path)
+    calls: list[str] = []
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv(offline_name, "1")
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, _paths))
+
+    with pytest.raises(model_policy.ModelOfflineError, match="model_offline_cache_missing"):
+        model_policy.acquire_model_files(**_acquire_kwargs("org/model", "a" * 40, hashes))
+    assert calls == []
+
+
+def test_unapproved_hf_endpoint_is_rejected_before_network(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _paths, hashes = _files(tmp_path)
+    calls: list[str] = []
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv("HF_ENDPOINT", "https://attacker.example")
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, _paths))
+
+    with pytest.raises(model_policy.ModelApprovalError, match="model_endpoint_not_approved"):
+        model_policy.acquire_model_files(**_acquire_kwargs("org/model", "a" * 40, hashes))
+    assert calls == []
+
+
+def test_complete_cached_canonical_model_works_under_deny_without_hf_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A verified local canonical snapshot does not need egress authorization."""
+    paths, hashes = _files(tmp_path)
+    calls: list[str] = []
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "deny")
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: paths)
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, paths))
+
+    result = model_policy.acquire_model_files(**_acquire_kwargs("org/model", "a" * 40, hashes))
+
+    assert result == paths
+    assert calls == []
+
+
+def test_custom_model_requires_explicit_approval_and_old_bypass_is_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legacy boolean cannot authorize an unpinned custom model."""
+    paths, hashes = _files(tmp_path)
+    calls: list[str] = []
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv("POWER_ALLOW_UNVERIFIED_MODELS", "1")
+    monkeypatch.delenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, raising=False)
+    monkeypatch.delenv(model_policy.MODEL_APPROVAL_ENV, raising=False)
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, paths))
+
+    with pytest.raises(model_policy.ModelApprovalError, match="custom_model_requires_approval"):
+        model_policy.acquire_model_files(
+            operation=EgressOperation.EMBEDDINGS,
+            repo="custom/model",
+            revision="b" * 40,
+            provider="bge-m3-onnx",
+            required_files=("model.onnx", "tokenizer.json"),
+            canonical_repo="org/canonical",
+            canonical_revision="a" * 40,
+            canonical_provider="bge-m3-onnx",
+            canonical_license="MIT",
+            canonical_hashes=hashes,
+        )
+    assert calls == []
+
+
+def test_custom_model_without_immutable_revision_is_rejected_before_network(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, hashes = _files(tmp_path)
+    calls: list[str] = []
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, "1")
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, paths))
+
+    with pytest.raises(model_policy.ModelApprovalError, match="immutable_model_revision_required"):
+        model_policy.acquire_model_files(
+            operation=EgressOperation.EMBEDDINGS,
+            repo="custom/model",
+            revision="main",
+            provider="bge-m3-onnx",
+            required_files=("model.onnx", "tokenizer.json"),
+            canonical_repo="org/canonical",
+            canonical_revision="a" * 40,
+            canonical_provider="bge-m3-onnx",
+            canonical_license="MIT",
+            canonical_hashes=hashes,
+        )
+    assert calls == []
+
+
+def test_custom_model_without_complete_hash_manifest_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, hashes = _files(tmp_path)
+    calls: list[str] = []
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, "1")
+    monkeypatch.setenv(
+        model_policy.MODEL_APPROVAL_ENV,
+        json.dumps(
+            {
+                "repo": "custom/model",
+                "revision": "b" * 40,
+                "operation": "embeddings",
+                "provider": "bge-m3-onnx",
+                "license": "MIT",
+                "files": {"model.onnx": hashes["model.onnx"]},
+            }
+        ),
+    )
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, paths))
+
+    with pytest.raises(model_policy.ModelIntegrityError, match="complete_model_file_manifest"):
+        model_policy.acquire_model_files(
+            operation=EgressOperation.EMBEDDINGS,
+            repo="custom/model",
+            revision="b" * 40,
+            provider="bge-m3-onnx",
+            required_files=("model.onnx", "tokenizer.json"),
+            canonical_repo="org/canonical",
+            canonical_revision="a" * 40,
+            canonical_provider="bge-m3-onnx",
+            canonical_license="MIT",
+            canonical_hashes=hashes,
+        )
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("operation", "reranking", "custom_model_operation_not_approved"),
+        ("provider", "other-loader", "custom_model_provider_not_approved"),
+        ("license", "", "model_license_required"),
+        ("license", "Apache-2.0", "custom_model_license_not_approved"),
+    ],
+)
+def test_custom_approval_is_bound_to_operation_provider_and_license(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: str,
+    error: str,
+) -> None:
+    paths, hashes = _files(tmp_path)
+    calls: list[str] = []
+    repo = "custom/model"
+    revision = "b" * 40
+    approval: dict[str, object] = {
+        "operation": "embeddings",
+        "provider": "bge-m3-onnx",
+        "license": "MIT",
+        "repo": repo,
+        "revision": revision,
+        "files": hashes,
+    }
+    approval[field] = value
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, "1")
+    monkeypatch.setenv(model_policy.MODEL_APPROVAL_ENV, json.dumps(approval))
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, paths))
+
+    with pytest.raises(model_policy.ModelApprovalError, match=error):
+        model_policy.acquire_model_files(
+            operation=EgressOperation.EMBEDDINGS,
+            repo=repo,
+            revision=revision,
+            provider="bge-m3-onnx",
+            required_files=("model.onnx", "tokenizer.json"),
+            canonical_repo="org/canonical",
+            canonical_revision="a" * 40,
+            canonical_provider="bge-m3-onnx",
+            canonical_license="MIT",
+            canonical_hashes=hashes,
+        )
+    assert calls == []
+
+
+def test_approved_immutable_custom_model_downloads_and_verifies_all_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, hashes = _files(tmp_path)
+    calls: list[str] = []
+    repo = "custom/model"
+    revision = "b" * 40
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, "1")
+    monkeypatch.setenv(
+        model_policy.MODEL_APPROVAL_ENV,
+        json.dumps(
+            {
+                "operation": "embeddings",
+                "provider": "bge-m3-onnx",
+                "license": "MIT",
+                "repo": repo,
+                "revision": revision,
+                "files": hashes,
+            }
+        ),
+    )
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, paths))
+
+    result = model_policy.acquire_model_files(
+        operation=EgressOperation.EMBEDDINGS,
+        repo=repo,
+        revision=revision,
+        provider="bge-m3-onnx",
+        required_files=("model.onnx", "tokenizer.json"),
+        canonical_repo="org/canonical",
+        canonical_revision="a" * 40,
+        canonical_provider="bge-m3-onnx",
+        canonical_license="MIT",
+        canonical_hashes=hashes,
+    )
+
+    assert result == paths
+    assert calls == ["model.onnx", "tokenizer.json"]
+
+
+def test_custom_model_hash_mismatch_fails_closed_before_returning_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, hashes = _files(tmp_path, mismatch=True)
+    calls: list[str] = []
+    repo = "custom/model"
+    revision = "b" * 40
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, "1")
+    monkeypatch.setenv(
+        model_policy.MODEL_APPROVAL_ENV,
+        json.dumps(
+            {
+                "operation": "embeddings",
+                "provider": "bge-m3-onnx",
+                "license": "MIT",
+                "repo": repo,
+                "revision": revision,
+                "files": hashes,
+            }
+        ),
+    )
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, paths))
+
+    with pytest.raises(
+        model_policy.ModelIntegrityError, match=r"model_sha256_mismatch:model\.onnx"
+    ):
+        model_policy.acquire_model_files(
+            operation=EgressOperation.EMBEDDINGS,
+            repo=repo,
+            revision=revision,
+            provider="bge-m3-onnx",
+            required_files=("model.onnx", "tokenizer.json"),
+            canonical_repo="org/canonical",
+            canonical_revision="a" * 40,
+            canonical_provider="bge-m3-onnx",
+            canonical_license="MIT",
+            canonical_hashes=hashes,
+        )
+    assert calls == ["model.onnx", "tokenizer.json"]
+
+
+def test_download_exception_does_not_trigger_a_second_network_attempt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _paths, hashes = _files(tmp_path)
+    calls: list[str] = []
+    repo = "custom/model"
+    revision = "b" * 40
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, "1")
+    monkeypatch.setenv(
+        model_policy.MODEL_APPROVAL_ENV,
+        json.dumps(
+            {
+                "operation": "embeddings",
+                "provider": "bge-m3-onnx",
+                "license": "MIT",
+                "repo": repo,
+                "revision": revision,
+                "files": hashes,
+            }
+        ),
+    )
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, {}, failure=True))
+
+    with pytest.raises(RuntimeError, match="synthetic download failure"):
+        model_policy.acquire_model_files(
+            operation=EgressOperation.EMBEDDINGS,
+            repo=repo,
+            revision=revision,
+            provider="bge-m3-onnx",
+            required_files=("model.onnx", "tokenizer.json"),
+            canonical_repo="org/canonical",
+            canonical_revision="a" * 40,
+            canonical_provider="bge-m3-onnx",
+            canonical_license="MIT",
+            canonical_hashes=hashes,
+        )
+    assert calls == ["model.onnx"]
+
+
+def test_complete_cached_canonical_reranker_works_under_deny_without_hf_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    files = {
+        "onnx/model.onnx": b"synthetic reranker model",
+        "onnx/model.onnx_data": b"synthetic reranker sidecar",
+        "tokenizer.json": b'{"synthetic":true}',
+    }
+    paths: dict[str, str] = {}
+    hashes: dict[str, str] = {}
+    for filename, content in files.items():
+        path = tmp_path / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        paths[filename] = str(path)
+        hashes[filename] = hashlib.sha256(content).hexdigest()
+    calls: list[str] = []
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "deny")
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: paths)
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, paths))
+
+    result = model_policy.acquire_model_files(
+        operation=EgressOperation.RERANKING,
+        repo="org/reranker",
+        revision="c" * 40,
+        provider="bge-reranker-v2-m3-onnx",
+        required_files=tuple(files),
+        canonical_repo="org/reranker",
+        canonical_revision="c" * 40,
+        canonical_provider="bge-reranker-v2-m3-onnx",
+        canonical_license="Apache-2.0",
+        canonical_hashes=hashes,
+    )
+
+    assert result == paths
+    assert calls == []
+
+
+def test_direct_embedding_and_reranker_loaders_honor_default_deny_before_hf(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    monkeypatch.delenv("POWER_EGRESS_POLICY", raising=False)
+    monkeypatch.delenv("POWER_MODEL_OFFLINE", raising=False)
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, {}))
+
+    with pytest.raises(EgressDeniedError):
+        embeddings.BGEM3OnnxManager().embed("synthetic query")
+    with pytest.raises(EgressDeniedError):
+        reranker.BGEM3Reranker().rerank("synthetic query", ["synthetic document"])
+    assert calls == []
+
+
+def test_reranker_honors_power_model_offline_even_with_allow_public(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+    monkeypatch.setenv("POWER_MODEL_OFFLINE", "1")
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(calls, {}))
+
+    with pytest.raises(model_policy.ModelOfflineError):
+        reranker.BGEM3Reranker().rerank("synthetic query", ["synthetic document"])
+    assert calls == []
+
+
+def test_fastembed_and_qwen_constructors_cannot_bypass_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructor_calls: list[str] = []
+
+    class FakeEmbedding:
+        def __init__(self, **_kwargs: object) -> None:
+            constructor_calls.append("embedding")
+
+    fastembed = ModuleType("fastembed")
+    fastembed.TextEmbedding = FakeEmbedding  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "fastembed", fastembed)
+
+    with pytest.raises(model_policy.ModelApprovalError, match="immutable_model_revision_required"):
+        embeddings.FastEmbedManager(model_name="custom/model")._lazy_init()
+
+    qwen = ModuleType("qwen3_embed")
+    qwen.TextEmbedding = FakeEmbedding  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "qwen3_embed", qwen)
+    with pytest.raises(model_policy.ModelApprovalError, match="immutable_model_revision_required"):
+        embeddings.Qwen3EmbeddingManager(model_name="custom/qwen-model")._lazy_init()
+
+    assert constructor_calls == []
+
+
+def test_colbert_constructor_cannot_bypass_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from power_framework.experimental.colbert_reranker import ColBERTLateInteractionReranker
+
+    monkeypatch.setenv("POWER_RERANKER", "colbert")
+    monkeypatch.setattr(
+        "power_framework.experimental.colbert_reranker._available_ram_gb", lambda: 16.0
+    )
+    reranker_instance = ColBERTLateInteractionReranker(model_name="custom/colbert-model")
+
+    with pytest.raises(model_policy.ModelApprovalError, match="immutable_model_revision_required"):
+        reranker_instance._lazy_init()
+
+
+def test_approved_external_loader_receives_verified_local_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    paths, hashes = _files(snapshot)
+    (snapshot / "unapproved-config.py").write_text(
+        "synthetic unapproved material", encoding="utf-8"
+    )
+    repo = "custom/model"
+    revision = "b" * 40
+    monkeypatch.setenv("POWER_EGRESS_POLICY", "deny")
+    monkeypatch.setenv(model_policy.ALLOW_CUSTOM_MODELS_ENV, "1")
+    monkeypatch.setenv(
+        model_policy.MODEL_APPROVAL_ENV,
+        json.dumps(
+            {
+                "operation": "embeddings",
+                "provider": "test-external",
+                "license": "MIT",
+                "repo": repo,
+                "revision": revision,
+                "files": hashes,
+            }
+        ),
+    )
+    monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: paths)
+
+    prepared = model_policy.prepare_external_model(
+        operation=EgressOperation.EMBEDDINGS,
+        provider="test-external",
+        model_reference=f"{repo}@{revision}",
+    )
+
+    staging = Path(prepared.local_reference)
+    assert staging != snapshot
+    assert staging.is_dir()
+    assert set(prepared.files) == set(paths)
+    assert all(Path(path).is_relative_to(staging) for path in prepared.files.values())
+    assert {Path(path).relative_to(staging).as_posix() for path in prepared.files.values()} == set(
+        paths
+    )
+    assert not (staging / "unapproved-config.py").exists()

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -15,6 +15,57 @@ from power_framework.core.egress import EgressDeniedError, EgressOperation
 from power_framework.experimental import embeddings, reranker
 
 
+@pytest.fixture(autouse=True)
+def isolate_model_policy_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep model-policy assertions independent of shell and CI environment state."""
+    assert model_policy.MODEL_OFFLINE_ENV_VARS == (
+        "POWER_MODEL_OFFLINE",
+        "HF_HUB_OFFLINE",
+        "TRANSFORMERS_OFFLINE",
+    )
+    for name in model_policy.MODEL_OFFLINE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    for name in (
+        "HF_ENDPOINT",
+        "POWER_EGRESS_POLICY",
+        "POWER_ALLOW_UNVERIFIED_MODELS",
+        "POWER_ALLOW_NONCOMMERCIAL_MODELS",
+        "POWER_EMBED_PROVIDER",
+        "POWER_RERANKER",
+        "POWER_BGE_M3_ONNX_REPO",
+        "POWER_BGE_M3_ONNX_REVISION",
+        "POWER_BGE_RERANKER_ONNX_REPO",
+        "POWER_BGE_RERANKER_ONNX_REVISION",
+        "POWER_QWEN3_RERANKER_MODEL",
+        "POWER_JINA_RERANKER_MODEL",
+        "POWER_QWEN3_EMBED_MODEL",
+        "POWER_OLLAMA_EMBED_MODEL",
+        "POWER_EMBEDDING_MODEL",
+        "POWER_COLBERT_MODEL",
+        model_policy.ALLOW_CUSTOM_MODELS_ENV,
+        model_policy.MODEL_APPROVAL_ENV,
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(embeddings, "EMBED_PROVIDER", "bge-m3")
+    monkeypatch.setattr(embeddings, "QWEN3_EMBED_MODEL", "n24q02m/Qwen3-Embedding-0.6B-ONNX")
+    monkeypatch.setattr(embeddings, "OLLAMA_EMBED_MODEL", "qwen3-embedding:0.6b")
+    monkeypatch.setattr(
+        embeddings,
+        "FASTEMBED_MODEL",
+        "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+    )
+    monkeypatch.setattr(embeddings, "BGE_M3_ONNX_REPO", embeddings.BGE_M3_PINNED_REPO)
+    monkeypatch.setattr(embeddings, "BGE_M3_ONNX_REVISION", embeddings.BGE_M3_PINNED_REVISION)
+    monkeypatch.setattr(reranker, "BGE_RERANKER_ONNX_REPO", reranker.BGE_RERANKER_PINNED_REPO)
+    monkeypatch.setattr(
+        reranker, "BGE_RERANKER_ONNX_REVISION", reranker.BGE_RERANKER_PINNED_REVISION
+    )
+    monkeypatch.setattr(reranker, "QWEN3_RERANKER_MODEL", "n24q02m/Qwen3-Reranker-0.6B-ONNX")
+    from power_framework.experimental import colbert_reranker
+
+    monkeypatch.setattr(colbert_reranker, "COLBERT_DEFAULT_MODEL", "colbert-ir/colbertv2.0")
+
+
 def _files(tmp_path: Path, *, mismatch: bool = False) -> tuple[dict[str, str], dict[str, str]]:
     paths: dict[str, str] = {}
     hashes: dict[str, str] = {}

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -23,6 +24,23 @@ from power_framework.core.reranker import (
     get_reranker,
 )
 from power_framework.experimental import reranker as reranker_module
+
+
+def _prepared_stub(tmp_path: Path, index: int, provider: str):
+    """Create a real owned staging stub for delegated-loader lifecycle tests."""
+    from power_framework.core.model_policy import ApprovedModel, PreparedModel
+
+    root = tmp_path / f"power-model-reranker-{index}"
+    root.mkdir()
+    spec = ApprovedModel(
+        repo="custom/model",
+        revision="a" * 40,
+        provider=provider,
+        license="MIT",
+        files=(),
+        canonical=False,
+    )
+    return PreparedModel(spec, {}, str(root))
 
 
 def _bge_reranker_available() -> bool:
@@ -116,6 +134,172 @@ class TestRerankerManager:
 
         manager.rerank("query", ["doc a", "doc b"])
         mock_model.rerank.assert_called_once_with("query", ["doc a", "doc b"])
+
+    def test_delegated_rerank_inference_does_not_set_process_offline_flags(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A constructed delegated reranker must run without global policy mutation."""
+        observed_flags: list[tuple[str | None, ...]] = []
+
+        class FakeModel:
+            def rerank(self, _query: str, _documents: list[str]) -> list[float]:
+                observed_flags.append(
+                    tuple(
+                        os.getenv(name)
+                        for name in (
+                            "POWER_MODEL_OFFLINE",
+                            "HF_HUB_OFFLINE",
+                            "TRANSFORMERS_OFFLINE",
+                        )
+                    )
+                )
+                return [0.5]
+
+        for name in ("POWER_MODEL_OFFLINE", "HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"):
+            monkeypatch.delenv(name, raising=False)
+        manager = RerankerManager()
+        manager._model = FakeModel()
+
+        assert manager.rerank("query", ["document"]) == [0.5]
+        assert observed_flags == [(None, None, None)]
+
+    def test_jina_constructor_failure_releases_owned_staging(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Jina import/constructor failure must not leak its prepared snapshot."""
+        prepared_models = []
+
+        def prepare(**_kwargs: object):
+            prepared = _prepared_stub(tmp_path, len(prepared_models) + 1, "jina-reranker")
+            prepared_models.append(prepared)
+            return prepared
+
+        constructor_args: dict[str, object] = {}
+
+        class FailingCrossEncoder:
+            def __init__(self, **_kwargs: object) -> None:
+                constructor_args.update(_kwargs)
+                raise RuntimeError("synthetic Jina constructor failure")
+
+        cross_encoder = ModuleType("fastembed.rerank.cross_encoder")
+        cross_encoder.TextCrossEncoder = FailingCrossEncoder  # type: ignore[attr-defined]
+        rerank_package = ModuleType("fastembed.rerank")
+        fastembed_package = ModuleType("fastembed")
+        rerank_package.cross_encoder = cross_encoder  # type: ignore[attr-defined]
+        fastembed_package.rerank = rerank_package  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "fastembed", fastembed_package)
+        monkeypatch.setitem(sys.modules, "fastembed.rerank", rerank_package)
+        monkeypatch.setitem(sys.modules, "fastembed.rerank.cross_encoder", cross_encoder)
+        monkeypatch.setattr(reranker_module, "prepare_external_model", prepare)
+        monkeypatch.setenv("POWER_RERANKER", "jina")
+        monkeypatch.setenv(ALLOW_NONCOMMERCIAL_MODELS_ENV, "1")
+        monkeypatch.setenv("POWER_EMBED_PROVIDER", "bge-m3")
+
+        manager = RerankerManager("custom/model@" + "a" * 40)
+        with pytest.raises(RuntimeError, match="synthetic Jina constructor failure"):
+            manager._lazy_init()
+
+        assert manager._model is None
+        assert not Path(prepared_models[0].local_reference).exists()
+        assert constructor_args["specific_model_path"] == prepared_models[0].local_reference
+
+    def test_installed_fastembed_cross_encoder_accepts_specific_local_snapshot_path(
+        self, tmp_path: Path
+    ) -> None:
+        """The real FastEmbed cross-encoder accepts the verified local path seam."""
+        from fastembed.rerank.cross_encoder import TextCrossEncoder
+
+        from power_framework.core.model_policy import force_model_offline
+
+        with force_model_offline():
+            loader = TextCrossEncoder(
+                model_name="jinaai/jina-reranker-v2-base-multilingual",
+                specific_model_path=str(tmp_path),
+                lazy_load=True,
+            )
+
+        assert loader.model_name == "jinaai/jina-reranker-v2-base-multilingual"
+
+    def test_qwen_reranker_constructor_failure_releases_owned_staging(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Qwen3 reranker constructor failure must release the local snapshot."""
+        prepared_models = []
+
+        def prepare(**_kwargs: object):
+            prepared = _prepared_stub(tmp_path, len(prepared_models) + 1, "qwen3-reranker-onnx")
+            prepared_models.append(prepared)
+            return prepared
+
+        constructor_args: dict[str, object] = {}
+
+        class FailingCrossEncoder:
+            def __init__(self, **_kwargs: object) -> None:
+                constructor_args.update(_kwargs)
+                raise RuntimeError("synthetic Qwen reranker failure")
+
+        qwen = ModuleType("qwen3_embed")
+        qwen.TextCrossEncoder = FailingCrossEncoder  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "qwen3_embed", qwen)
+        monkeypatch.setattr(reranker_module, "prepare_external_model", prepare)
+        monkeypatch.setenv("POWER_RERANKER", "jina")
+        monkeypatch.setenv(ALLOW_NONCOMMERCIAL_MODELS_ENV, "1")
+        monkeypatch.setenv("POWER_EMBED_PROVIDER", "qwen3")
+        monkeypatch.setenv("POWER_QWEN3_RERANKER_MODEL", "custom/model@" + "a" * 40)
+
+        manager = RerankerManager("custom/model@" + "a" * 40)
+        with pytest.raises(RuntimeError, match="synthetic Qwen reranker failure"):
+            manager._lazy_init()
+
+        assert manager._model is None
+        assert not Path(prepared_models[0].local_reference).exists()
+        assert constructor_args["model_name"] == "custom/model"
+        assert constructor_args["specific_model_path"] == prepared_models[0].local_reference
+        assert constructor_args["local_files_only"] is True
+
+    def test_colbert_constructor_failure_releases_owned_staging(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ColBERT constructor failure must release its prepared snapshot."""
+        from power_framework.experimental import colbert_reranker as colbert_module
+
+        prepared_models = []
+
+        def prepare(**_kwargs: object):
+            prepared = _prepared_stub(tmp_path, len(prepared_models) + 1, "colbert-reranker")
+            prepared_models.append(prepared)
+            return prepared
+
+        class FakeConfig:
+            pass
+
+        class FailingCheckpoint:
+            def __init__(self, *_args: object, **_kwargs: object) -> None:
+                raise RuntimeError("synthetic ColBERT constructor failure")
+
+        infra = ModuleType("colbert.infra")
+        infra.ColBERTConfig = FakeConfig  # type: ignore[attr-defined]
+        checkpoint = ModuleType("colbert.modeling.checkpoint")
+        checkpoint.Checkpoint = FailingCheckpoint  # type: ignore[attr-defined]
+        modeling = ModuleType("colbert.modeling")
+        modeling.checkpoint = checkpoint  # type: ignore[attr-defined]
+        colbert = ModuleType("colbert")
+        colbert.infra = infra  # type: ignore[attr-defined]
+        colbert.modeling = modeling  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "colbert", colbert)
+        monkeypatch.setitem(sys.modules, "colbert.infra", infra)
+        monkeypatch.setitem(sys.modules, "colbert.modeling", modeling)
+        monkeypatch.setitem(sys.modules, "colbert.modeling.checkpoint", checkpoint)
+        monkeypatch.setattr(colbert_module, "prepare_external_model", prepare)
+        monkeypatch.setattr(colbert_module, "_available_ram_gb", lambda: 16.0)
+        monkeypatch.setenv("POWER_RERANKER", "colbert")
+
+        manager = colbert_module.ColBERTLateInteractionReranker("custom/model@" + "a" * 40)
+        with pytest.raises(RuntimeError, match="synthetic ColBERT constructor failure"):
+            manager._lazy_init()
+
+        assert manager._model is None
+        assert not Path(prepared_models[0].local_reference).exists()
 
     def test_colbert_helpers(self):
         from unittest.mock import patch
@@ -368,6 +552,73 @@ class TestRerankerManager:
 
             scores = reranker.rerank("q", ["doc1"])
             assert scores == [2.5]
+
+
+def test_bge_reranker_probe_failure_clears_session_and_allows_clean_retry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Direct BGE reranker probe failures must leave retryable state."""
+    model_files = {
+        "onnx/model.onnx": str(tmp_path / "model.onnx"),
+        "onnx/model.onnx_data": str(tmp_path / "model.onnx_data"),
+        "tokenizer.json": str(tmp_path / "tokenizer.json"),
+    }
+    monkeypatch.setattr(reranker_module, "acquire_model_files", lambda **_kwargs: model_files)
+
+    class FakeOptions:
+        enable_cpu_mem_arena = True
+        intra_op_num_threads = 0
+        inter_op_num_threads = 0
+
+    class FakeSession:
+        @staticmethod
+        def get_providers() -> list[str]:
+            return ["CPUExecutionProvider"]
+
+    class FakeOrt:
+        SessionOptions = FakeOptions
+        InferenceSession = staticmethod(lambda *_args, **_kwargs: FakeSession())
+
+        @staticmethod
+        def get_available_providers() -> list[str]:
+            return ["CPUExecutionProvider"]
+
+    class FakeTokenizer:
+        @staticmethod
+        def from_file(_path: str) -> FakeTokenizer:
+            return FakeTokenizer()
+
+        def enable_truncation(self, max_length: int) -> None:
+            del max_length
+
+    tokenizers = ModuleType("tokenizers")
+    tokenizers.Tokenizer = FakeTokenizer  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "onnxruntime", FakeOrt)
+    monkeypatch.setitem(sys.modules, "tokenizers", tokenizers)
+    monkeypatch.setenv("POWER_RERANKER_DEVICE", "cpu")
+
+    manager = BGEM3Reranker(
+        repo=BGE_RERANKER_PINNED_REPO,
+        revision=BGE_RERANKER_PINNED_REVISION,
+    )
+    should_fail = True
+
+    def probe(_query: str, _document: str) -> list[float] | None:
+        if should_fail:
+            raise RuntimeError("synthetic BGE reranker probe failure")
+        return [0.5]
+
+    monkeypatch.setattr(manager, "_rerank_raw", probe)
+    with pytest.raises(RuntimeError, match="synthetic BGE reranker probe failure"):
+        manager._lazy_init()
+    assert manager._session is None
+    assert manager._tokenizer is None
+    assert manager.active_provider is None
+
+    should_fail = False
+    manager._lazy_init()
+    assert manager._session is not None
+    assert manager._tokenizer is not None
 
 
 def test_bge_reranker_omits_token_type_ids_when_model_does_not_accept_it():

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -203,6 +203,37 @@ class TestRerankerManager:
         assert not Path(prepared_models[0].local_reference).exists()
         assert constructor_args["specific_model_path"] == prepared_models[0].local_reference
 
+    def test_jina_force_environment_entry_failure_releases_owned_staging(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Failure entering the constructor environment must still release staging."""
+        prepared_models = []
+
+        def prepare(**_kwargs: object):
+            prepared = _prepared_stub(tmp_path, len(prepared_models) + 1, "jina-reranker")
+            prepared_models.append(prepared)
+            return prepared
+
+        class FailingEnvironment:
+            def __enter__(self):
+                raise RuntimeError("synthetic force environment failure")
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+        monkeypatch.setattr(reranker_module, "prepare_external_model", prepare)
+        monkeypatch.setattr(reranker_module, "force_model_offline", FailingEnvironment)
+        monkeypatch.setenv("POWER_RERANKER", "jina")
+        monkeypatch.setenv(ALLOW_NONCOMMERCIAL_MODELS_ENV, "1")
+        monkeypatch.setenv("POWER_EMBED_PROVIDER", "bge-m3")
+
+        manager = RerankerManager("custom/model@" + "a" * 40)
+        with pytest.raises(RuntimeError, match="synthetic force environment failure"):
+            manager._lazy_init()
+
+        assert manager._model is None
+        assert not Path(prepared_models[0].local_reference).exists()
+
     def test_installed_fastembed_cross_encoder_accepts_specific_local_snapshot_path(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from huggingface_hub import try_to_load_from_cache
 
+from power_framework.core.model_policy import ModelApprovalError
 from power_framework.core.reranker import (
     ALLOW_NONCOMMERCIAL_MODELS_ENV,
     BGE_RERANKER_FILE_SHA256,
@@ -234,7 +235,7 @@ class TestRerankerManager:
         # The UA↔EN semantic query should favor the knowledge-base passages.
         assert scores[0] > scores[1]
 
-    def test_qwen3_reranker_import_error(self):
+    def test_qwen3_reranker_requires_model_policy_before_import(self):
         import sys
         from unittest.mock import patch
 
@@ -254,10 +255,10 @@ class TestRerankerManager:
             patch.dict(sys.modules, {"qwen3_embed": None}),
         ):
             mgr = RerankerManager()
-            with pytest.raises(ImportError, match="qwen3-embed is required"):
+            with pytest.raises(ModelApprovalError, match="immutable_model_revision_required"):
                 mgr._lazy_init()
 
-    def test_fastembed_reranker_import_error(self):
+    def test_fastembed_reranker_requires_model_policy_before_import(self):
         import sys
         from unittest.mock import patch
 
@@ -276,7 +277,7 @@ class TestRerankerManager:
             patch.dict(sys.modules, {"fastembed.rerank.cross_encoder": None}),
         ):
             mgr = RerankerManager()
-            with pytest.raises(ImportError, match="fastembed is required"):
+            with pytest.raises(ModelApprovalError, match="custom_model_requires_approval"):
                 mgr._lazy_init()
 
     def test_colbert_rerank_with_mock_model(self):

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -588,8 +588,8 @@ def test_bge_reranker_probe_failure_clears_session_and_allows_clean_retry(
         def from_file(_path: str) -> FakeTokenizer:
             return FakeTokenizer()
 
-        def enable_truncation(self, max_length: int) -> None:
-            del max_length
+        def enable_truncation(self, **_kwargs: int) -> None:
+            return None
 
     tokenizers = ModuleType("tokenizers")
     tokenizers.Tokenizer = FakeTokenizer  # type: ignore[attr-defined]

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest
 from huggingface_hub import try_to_load_from_cache
 
-from power_framework.core.model_policy import ModelApprovalError
+from power_framework.core.model_policy import MODEL_OFFLINE_ENV_VARS, ModelApprovalError
 from power_framework.core.reranker import (
     ALLOW_NONCOMMERCIAL_MODELS_ENV,
     BGE_RERANKER_FILE_SHA256,
@@ -20,6 +22,7 @@ from power_framework.core.reranker import (
     RerankerManager,
     get_reranker,
 )
+from power_framework.experimental import reranker as reranker_module
 
 
 def _bge_reranker_available() -> bool:
@@ -36,6 +39,20 @@ def _bge_reranker_available() -> bool:
         and Path(cached).is_file()
         for filename in ("onnx/model.onnx", "onnx/model.onnx_data", "tokenizer.json")
     )
+
+
+def _install_hf_download_spy(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Install a local HF double so policy tests cannot perform real egress."""
+    calls: list[str] = []
+    module = ModuleType("huggingface_hub")
+
+    def download(_repo: str, filename: str, **_kwargs: object) -> str:
+        calls.append(filename)
+        return "unexpected-model-file"
+
+    module.hf_hub_download = download  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "huggingface_hub", module)
+    return calls
 
 
 class TestRerankerManager:
@@ -235,13 +252,32 @@ class TestRerankerManager:
         # The UA↔EN semantic query should favor the knowledge-base passages.
         assert scores[0] > scores[1]
 
-    def test_qwen3_reranker_requires_model_policy_before_import(self):
-        import sys
+    def test_qwen3_reranker_requires_model_policy_before_import(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         from unittest.mock import patch
 
         import pytest
 
+        from power_framework.core import model_policy
         from power_framework.core.reranker import RerankerManager
+
+        for name in MODEL_OFFLINE_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+        for name in (
+            "HF_ENDPOINT",
+            "POWER_EGRESS_POLICY",
+            "POWER_ALLOW_CUSTOM_MODELS",
+            "POWER_MODEL_APPROVAL",
+            "POWER_QWEN3_RERANKER_MODEL",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+        monkeypatch.setattr(
+            reranker_module, "QWEN3_RERANKER_MODEL", "n24q02m/Qwen3-Reranker-0.6B-ONNX"
+        )
+        monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+        calls = _install_hf_download_spy(monkeypatch)
 
         with (
             patch.dict(
@@ -257,28 +293,50 @@ class TestRerankerManager:
             mgr = RerankerManager()
             with pytest.raises(ModelApprovalError, match="immutable_model_revision_required"):
                 mgr._lazy_init()
+        assert calls == []
 
-    def test_fastembed_reranker_requires_model_policy_before_import(self):
-        import sys
+    def test_fastembed_reranker_requires_model_policy_before_import(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         from unittest.mock import patch
 
         import pytest
 
+        from power_framework.core import model_policy
         from power_framework.core.reranker import (
             ALLOW_NONCOMMERCIAL_MODELS_ENV,
             RerankerManager,
         )
 
+        for name in MODEL_OFFLINE_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+        for name in (
+            "HF_ENDPOINT",
+            "POWER_EGRESS_POLICY",
+            "POWER_ALLOW_CUSTOM_MODELS",
+            "POWER_MODEL_APPROVAL",
+            "POWER_JINA_RERANKER_MODEL",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("POWER_EGRESS_POLICY", "allow-public")
+        monkeypatch.setattr(model_policy, "_cached_model_files", lambda _spec: {})
+        calls = _install_hf_download_spy(monkeypatch)
+
         with (
             patch.dict(
                 "os.environ",
-                {ALLOW_NONCOMMERCIAL_MODELS_ENV: "1", "POWER_RERANKER": "jina"},
+                {
+                    ALLOW_NONCOMMERCIAL_MODELS_ENV: "1",
+                    "POWER_EMBED_PROVIDER": "bge-m3",
+                    "POWER_RERANKER": "jina",
+                },
             ),
             patch.dict(sys.modules, {"fastembed.rerank.cross_encoder": None}),
         ):
             mgr = RerankerManager()
             with pytest.raises(ModelApprovalError, match="custom_model_requires_approval"):
                 mgr._lazy_init()
+        assert calls == []
 
     def test_colbert_rerank_with_mock_model(self):
         from unittest.mock import MagicMock, patch

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -560,8 +560,10 @@ class TestSearchModeContract:
             "power_framework.core.searcher.get_embedding_manager", lambda: _Embedder()
         )
 
+        source_dir = tmp_path / "03_Resources"
+        source_dir.mkdir()
         for name in ("near.md", "far.md", "orthogonal.md"):
-            (tmp_path / name).write_text(
+            (source_dir / name).write_text(
                 "---\n"
                 "type: Resource\n"
                 f'title: "{name}"\n'
@@ -579,9 +581,15 @@ class TestSearchModeContract:
             conn.executemany(
                 "INSERT INTO chunk_embeddings VALUES (?, ?, ?, ?, ?)",
                 [
-                    ("c1", "near.md", vec(1.0, 0.0, 0.0, 0.0), "near", 0.0),
-                    ("c2", "far.md", vec(0.3, 0.95, 0.0, 0.0), "far", 0.0),
-                    ("c3", "orthogonal.md", vec(0.0, 0.0, 1.0, 0.0), "orth", 0.0),
+                    ("c1", "03_Resources/near.md", vec(1.0, 0.0, 0.0, 0.0), "near", 0.0),
+                    ("c2", "03_Resources/far.md", vec(0.3, 0.95, 0.0, 0.0), "far", 0.0),
+                    (
+                        "c3",
+                        "03_Resources/orthogonal.md",
+                        vec(0.0, 0.0, 1.0, 0.0),
+                        "orth",
+                        0.0,
+                    ),
                 ],
             )
             conn.executemany(
@@ -598,9 +606,12 @@ class TestSearchModeContract:
 
         results = _semantic_search(tmp_path, "query", max_results=5)
 
-        assert [result.rel_path for result in results] == ["near.md", "far.md"]
+        assert [result.rel_path for result in results] == [
+            "03_Resources/near.md",
+            "03_Resources/far.md",
+        ]
         assert results[0].score > results[1].score
-        assert [result.snippet for result in results] == ["near", "far"]
+        assert [result.snippet for result in results] == ["body", "body"]
 
     def test_dense_index_validation_requires_matching_manifest(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1037,6 +1048,32 @@ class TestSearchVault:
         assert "body-only phrase" in results[0].matched_text
         assert "metadata-only phrase" not in results[0].matched_text
         assert "description:" not in results[0].matched_text
+
+    def test_fts_search_rejects_control_file_from_crafted_index(
+        self, sample_vault: Path, tmp_path: Path
+    ) -> None:
+        """DB-derived result paths cannot bypass the canonical source projection."""
+        control = sample_vault / ".power" / "events.jsonl"
+        control.parent.mkdir(parents=True, exist_ok=True)
+        control.write_text("internal secret event", encoding="utf-8")
+        database = tmp_path / "crafted-fts.db"
+        with closing(sqlite3.connect(database)) as conn:
+            _init_db(conn)
+            conn.execute(
+                "INSERT INTO fts_notes(title, tags, description, content, rel_path, note_type) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("Internal", "", "", "internal secret event", ".power/events.jsonl", "Resource"),
+            )
+            conn.commit()
+
+        results = _fts_search(
+            sample_vault,
+            "secret",
+            max_results=5,
+            resolved_db=searcher._ResolvedDb(database, False),
+        )
+
+        assert results == []
 
     def test_auto_domain_policy_scopes_results(self, sample_vault: Path):
         (sample_vault / ".power").mkdir(exist_ok=True)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -976,6 +976,27 @@ class TestFormatSearchResults:
         assert envelope["index_provenance"] == _format_index_provenance([])
         assert calls == 2
 
+    def test_source_read_context_caches_bounded_scan_without_generation(
+        self, sample_vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A no-generation context is reusable while the active identity stays absent."""
+        searcher._SOURCE_READ_CONTEXT.set(None)
+        original_create = searcher.create_source_read_context
+        create_calls = 0
+
+        def counted_create(root: Path):
+            nonlocal create_calls
+            create_calls += 1
+            return original_create(root)
+
+        monkeypatch.setattr(searcher, "create_source_read_context", counted_create)
+        first = searcher._source_read_context(sample_vault)
+        second = searcher._source_read_context(sample_vault)
+
+        assert first is second
+        assert first.generation_path is None
+        assert create_calls == 1
+
     def test_untrusted_envelope_marks_manual_results_without_request_provenance(
         self, sample_vault: Path
     ) -> None:

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -852,6 +852,130 @@ class TestFormatSearchResults:
             "source_snapshot_hash": report.source_snapshot_hash,
         }
 
+    def test_active_generation_cannot_materialize_stale_current_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Search and envelopes must reject old generation data after source drift."""
+        monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+        vault = tmp_path / "stale-generation-source"
+        note = vault / "01_Projects" / "Current.md"
+        note.parent.mkdir(parents=True)
+        note.write_text(
+            "---\n"
+            "type: Project\n"
+            "title: Current\n"
+            "description: source drift regression\n"
+            "timestamp: 2026-07-27T00:00:00Z\n"
+            "---\n\nold-generation-token\n",
+            encoding="utf-8",
+        )
+        sync_vault_atomically(vault, sync_embeddings=False)
+        original_results = search_vault(vault, "old-generation-token", mode="fts")
+        assert original_results
+
+        note.write_text("# invalidated source\n", encoding="utf-8")
+
+        assert search_vault(vault, "old-generation-token", mode="fts") == []
+        envelope = json.loads(
+            format_untrusted_search_envelope(
+                original_results,
+                "old-generation-token",
+                mode="fts",
+                vault_dir=vault,
+            )
+        )
+        assert envelope["result_count"] == 0
+
+    def test_untrusted_envelope_drops_results_from_a_replaced_generation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Envelope content and provenance must come from one active generation."""
+        monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+        vault = tmp_path / "replaced-generation-envelope"
+        note = vault / "01_Projects" / "Current.md"
+        note.parent.mkdir(parents=True)
+        note.write_text(
+            "---\n"
+            "type: Project\n"
+            "title: Current\n"
+            "description: generation replacement regression\n"
+            "timestamp: 2026-07-27T00:00:00Z\n"
+            "---\n\nold-envelope-token\n",
+            encoding="utf-8",
+        )
+        first = sync_vault_atomically(vault, sync_embeddings=False)
+        old_results = search_vault(vault, "old-envelope-token", mode="fts")
+        assert old_results
+        assert old_results[0].index_generation_id == first.generation_id
+
+        note.write_text(
+            note.read_text(encoding="utf-8").replace("old-envelope-token", "new-envelope-token"),
+            encoding="utf-8",
+        )
+        second = sync_vault_atomically(vault, sync_embeddings=False)
+        assert second.generation_id != first.generation_id
+
+        envelope = json.loads(
+            format_untrusted_search_envelope(
+                old_results,
+                "old-envelope-token",
+                mode="fts",
+                vault_dir=vault,
+            )
+        )
+
+        assert envelope["result_count"] == 0
+        assert envelope["index_provenance"] == {"kind": "unavailable"}
+
+    def test_untrusted_envelope_drops_legacy_result_when_generation_appears_mid_read(
+        self, sample_vault: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A legacy result cannot be paired with a generation published mid-request."""
+        from power_framework.core.searcher import _format_index_provenance
+
+        result = SearchResult(
+            rel_path="01_Projects/TestProject.md",
+            title="Test Project",
+            description="A sample project note for testing",
+            note_type="Project",
+            score=1.0,
+            snippet="legacy result",
+            match_count=1,
+            index_kind="legacy_db",
+        )
+        fake_active = ActiveGeneration(
+            path=tmp_path / "new-generation.db",
+            generation_id="new-generation",
+            source_snapshot_hash="a" * 64,
+            db_sha256="b" * 64,
+            db_size=1,
+            completed_at="2026-09-07T00:00:00Z",
+            activated_at="2026-09-07T00:00:01Z",
+        )
+        calls = 0
+
+        def resolve(_vault: Path) -> ActiveGeneration | None:
+            nonlocal calls
+            calls += 1
+            return None if calls == 1 else fake_active
+
+        monkeypatch.setattr(searcher, "resolve_active_generation", resolve)
+
+        envelope = json.loads(
+            format_untrusted_search_envelope(
+                [result],
+                "test",
+                mode="fts",
+                vault_dir=sample_vault,
+            )
+        )
+
+        assert envelope["result_count"] == 0
+        assert envelope["index_provenance"] == _format_index_provenance([])
+        assert calls == 2
+
     def test_untrusted_envelope_marks_manual_results_without_request_provenance(
         self, sample_vault: Path
     ) -> None:

--- a/tests/test_source_projection.py
+++ b/tests/test_source_projection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import sqlite3
 from contextlib import closing
 from typing import TYPE_CHECKING
@@ -80,7 +81,7 @@ def test_sync_builds_rebuildable_source_projection_and_truthful_stats(
         assert conn.execute("SELECT COUNT(*) FROM source_links").fetchone()[0] == 2
 
 
-def test_active_reads_use_projection_and_exact_read_is_direct(
+def test_active_reads_use_projection_for_exact_and_stem_reads(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Active list/stats/graph/stem reads do not rescan source files."""
@@ -104,8 +105,9 @@ def test_active_reads_use_projection_and_exact_read_is_direct(
     assert stats.actual_capability == "active_source_projection"
     assert graph.actual_capability == "active_source_projection"
     assert stem.actual_capability == "active_source_projection"
-    assert exact.actual_capability == "direct_file_read"
+    assert exact.actual_capability == "active_source_projection"
     assert exact.degraded_reason is None
+    assert exact.source_revision == listed.source_revision
     assert exact.content.endswith("[[B]]\n")
 
 
@@ -222,3 +224,130 @@ def test_active_projection_staleness_fails_closed_after_source_edit(
 
     with pytest.raises(source_service.SourceProjectionStaleError, match="run power sync"):
         source_service.get_source_stats(vault)
+
+
+def test_source_read_rejects_internal_and_arbitrary_in_vault_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Projection membership, not filesystem containment, authorizes source reads."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    vault = _projection_vault(tmp_path)
+    sync_vault_atomically(vault, sync_embeddings=False)
+
+    control_files = {
+        ".power/events.jsonl": b"private event ledger",
+        ".power/tasks/task.json": b"private task state",
+        ".power/projects/project.json": b"private project state",
+        ".power/proposals/proposal.json": b"private proposal state",
+        ".power/state.json": b"private control state",
+        ".env": b"SECRET=synthetic",
+        ".env.local": b"LOCAL_SECRET=synthetic",
+        "credentials.json": b'{"token":"synthetic"}',
+        "events.jsonl": b'{"event":"synthetic"}\n',
+        "cache.sqlite": b"SQLite synthetic",
+        "cache.db": b"database synthetic",
+        "payload.bin": bytes(range(16)),
+        "arbitrary.txt": b"arbitrary regular file",
+        "01_Projects/POWER_STATUS.md": b"internal status material",
+        "README.md": b"repository instructions are not a source note",
+        "05_Templates/template.md": b"template control material",
+        ".power/internal.md": b"internal markdown control material",
+    }
+    for rel_path, content in control_files.items():
+        target = vault / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+    for rel_path in control_files:
+        with pytest.raises(source_service.SourceNotFoundError) as exc_info:
+            source_service.read_source(vault, SourceReadRequest(rel_path=rel_path))
+        assert str(exc_info.value) == "source not found in canonical source projection"
+
+
+def test_source_read_rejects_invalid_markdown_outside_projection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Markdown file without valid OKF metadata is not a readable source."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    vault = _projection_vault(tmp_path)
+    invalid = vault / "01_Projects" / "Invalid.md"
+    invalid.write_text("not an OKF note", encoding="utf-8")
+
+    with pytest.raises(source_service.SourceNotFoundError) as exc_info:
+        source_service.read_source(vault, SourceReadRequest(rel_path="01_Projects/Invalid.md"))
+    assert str(exc_info.value) == "source not found in canonical source projection"
+
+
+def test_source_read_rejects_absolute_traversal_and_symlink_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Containment and non-symlink policy are enforced before source bytes are opened."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    vault = _projection_vault(tmp_path)
+    sync_vault_atomically(vault, sync_embeddings=False)
+
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("outside synthetic secret", encoding="utf-8")
+    escaped = vault / "01_Projects" / "escaped.md"
+    escaped.symlink_to(outside)
+    directory_alias = vault / "01_Projects" / "index.md"
+    directory_alias.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="Absolute paths"):
+        source_service.read_source(vault, SourceReadRequest(rel_path="/01_Projects/A.md"))
+    with pytest.raises(ValueError, match="Absolute paths"):
+        source_service.read_source(vault, SourceReadRequest(rel_path="C:\\outside-secret.md"))
+    with pytest.raises(PermissionError, match="Path traversal"):
+        source_service.read_source(vault, SourceReadRequest(rel_path="../outside-secret.txt"))
+    with pytest.raises(PermissionError, match="Path traversal"):
+        source_service.read_source(
+            vault, SourceReadRequest(rel_path="01_Projects/../../etc/passwd")
+        )
+
+    for rel_path in ("01_Projects/escaped.md", "01_Projects"):
+        with pytest.raises(source_service.SourceNotFoundError) as exc_info:
+            source_service.read_source(vault, SourceReadRequest(rel_path=rel_path))
+        assert str(exc_info.value) == "source not found in canonical source projection"
+    if os.name != "nt":
+        with pytest.raises(OSError, match="Too many levels"):
+            source_service._open_source_file(vault, "01_Projects/escaped.md", escaped)
+        outside_dir = tmp_path / "outside-dir"
+        outside_dir.mkdir()
+        (outside_dir / "secret.md").write_text("parent secret", encoding="utf-8")
+        parent_alias = vault / "alias"
+        parent_alias.symlink_to(outside_dir, target_is_directory=True)
+        with pytest.raises(OSError, match=r"Too many levels|Not a directory"):
+            source_service._open_source_file(vault, "alias/secret.md", parent_alias / "secret.md")
+    assert outside.read_text(encoding="utf-8") == "outside synthetic secret"
+
+
+def test_source_read_preserves_valid_unicode_nested_and_bounded_contracts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Canonical notes remain readable with Unicode names, stems, ETags, and byte bounds."""
+    monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    vault = _projection_vault(tmp_path)
+    unicode_note = vault / "02_Areas" / "Внутрішня нотатка.md"
+    _note(unicode_note, "Unicode note", "nested valid source")
+    sync_vault_atomically(vault, sync_embeddings=False)
+
+    response = source_service.read_source(
+        vault, SourceReadRequest(rel_path="02_Areas/Внутрішня нотатка.md")
+    )
+    stem_response = source_service.read_source(
+        vault, SourceReadRequest(rel_path="Внутрішня нотатка")
+    )
+
+    assert response.rel_path == "02_Areas/Внутрішня нотатка.md"
+    assert response.content == stem_response.content
+    assert response.actual_capability == "active_source_projection"
+    assert response.source_revision
+    assert response.etag.startswith('"')
+    with pytest.raises(ValueError, match="max_bytes"):
+        source_service.read_source(
+            vault, SourceReadRequest(rel_path="02_Areas/Внутрішня нотатка.md", max_bytes=1)
+        )

--- a/tests/web/contract/test_app_routes.py
+++ b/tests/web/contract/test_app_routes.py
@@ -119,6 +119,39 @@ def test_notes_listing_and_read(client: TestClient) -> None:
     assert 'class="wikilink"' in resp_read.text
 
 
+def test_notes_read_rejects_control_files_without_disclosure(
+    client: TestClient, test_vault: Path
+) -> None:
+    """The Web route exposes only the core source projection and redacted errors."""
+    (test_vault / ".power" / "events.jsonl").write_text(
+        "synthetic internal event secret", encoding="utf-8"
+    )
+    (test_vault / ".env").write_text("SECRET=synthetic", encoding="utf-8")
+
+    for rel_path in (".power/events.jsonl", ".env", "missing.json"):
+        response = client.get("/notes/read", params={"path": rel_path})
+        assert response.status_code == 404
+        assert "requested resource was not found" in response.text.lower()
+        assert "synthetic" not in response.text
+        assert "events.jsonl" not in response.text
+
+
+def test_web_client_disables_legacy_search_db_override(
+    test_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Web read cannot create or use a caller-selected external SQLite DB."""
+    from power_framework.web.clients.power import PowerClient
+
+    database = tmp_path / "external-search.db"
+    monkeypatch.setenv("POWER_SEARCH_DB", str(database))
+    power_client = PowerClient(test_vault)
+
+    assert not database.exists()
+    power_client.search("Alpha", mode="fts")
+    assert not database.exists()
+    assert not (test_vault / ".power" / "tasks").exists()
+
+
 def test_notes_edit_and_proposal_flow(client: TestClient) -> None:
     """Test transactional note edit and proposal review."""
     resp_edit = client.get("/notes/edit?path=01_Projects/Project_Alpha.md")


### PR DESCRIPTION
## Scope

Full PR scope: WEB-01 + WEB-05 production remediation across 27 files. This correction round advances the historical failed-admission head `1fa23817bbe3ad6234003c5f526cd17f4f64f797` with signed head `a2ba3000c6bc1c3c470b47a0e784ff3c10c51c0b`.

Review rounds:

- Round 1 — WEB-01 / WEB-05 implementation.
- Round 2 — CI environment isolation.
- Round 3 — concurrency / lifecycle / integrity closure.

## Root cause

Canonical CI intentionally sets `POWER_MODEL_OFFLINE=1` and `HF_HUB_OFFLINE=1`. WEB-05 tests that intentionally exercise egress, approval, immutable revision, and hash-integrity branches inherited those defaults and stopped at `model_offline_cache_missing` before reaching the branch under test.

## Repair

- Isolate all maintained offline authorities (`POWER_MODEL_OFFLINE`, `HF_HUB_OFFLINE`, `TRANSFORMERS_OFFLINE`) and relevant model/policy overrides with pytest monkeypatches.
- Bind embedding readiness/binding tests to the canonical provider, pinned identity, and empty cache.
- Add delegated-loader HF call spies and assert zero calls before approval/revision rejection.
- Round 3 changes production model/source/index boundaries and regression tests; CI workflows, dependencies, POWER version, tags, releases, and Phase 5 remain unchanged.

## Local evidence on exact head

- WEB-05 focused security matrix: 96 passed, 10 marker-deselected.
- New concurrency, lifecycle, manifest, endpoint, loader-API, and generation-consistency regressions pass.
- PSE/TASK/DECISION: 348 passed.
- Crash recovery: 11 passed.
- Combined PSE/TASK/DECISION/crash: 359 passed.
- Canonical CI-equivalent command (both interpreters): `uv run pytest tests/ -v --tb=short -m "not real_neural and not bench" --cov=src/power_framework/ --cov-report=term-missing --cov-fail-under=70 -W error::ResourceWarning -W error::pytest.PytestUnraisableExceptionWarning`.
- Python 3.13 exact-head: 1775 passed, 4 skipped, 17 deselected; coverage 83.06% (fresh local run, Python 3.13.5).
- Python 3.14 exact-head: 1775 passed, 4 skipped, 17 deselected; coverage 83.06% (CI run 34145750465, Python 3.14.7).
- Canonical skips: 1 release-tag baseline and 3 unavailable live Web E2E tests.
- Ruff, format, MyPy, pip-audit, uv lock, doc drift, strict MkDocs, verify.sh, neural contract, complexity, release contract, and maintenance rollback: passed.
- Local commit and GitHub commit verification: good signature from the pinned maintainer key.

HF #404, Actions #396, controlled dependency refresh, and Phase 5 remain on hold by design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Source reads now use the canonical projection and reject control files, symlinks, invalid Markdown, traversal, and stale content without exposing sensitive details.
  * Optional embedding and reranking models require pinned revisions, verified hashes, approved providers/licenses, and controlled offline loading.

* **Bug Fixes**
  * Search results consistently use validated source content and metadata.
  * Index migrations rebuild stale derived data and honor shared skip-file rules.
  * Application startup no longer creates missing vaults or control directories unexpectedly.

* **Documentation**
  * Updated API and threat-model documentation describes the new source-reading and model-acquisition protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->