### PR TITLE
docs: publish post-governance HF state

### DIFF
--- a/artifacts/project-state/handoffs/2026-09-08T091401Z_governance-post-merge_pre-hf.md
+++ b/artifacts/project-state/handoffs/2026-09-08T091401Z_governance-post-merge_pre-hf.md
@@ -1,0 +1,214 @@
+# POWER 3.8 Governance Post-Merge — HF Refresh Handoff
+
+> Append-only handoff. Governance is canonical on `main` after PR #408; HF
+> admission is not merged and must be rebuilt against the new main.
+
+## STAGE
+
+Pre-HF controlled dependency refresh after canonical governance merge.
+
+## PUBLIC_VERSION
+
+`3.7.11` — public stable and frozen.
+
+## STARTING_MAIN
+
+`119d5c39aa2c22734ca72c351f8a70790371678f`
+
+## ENDING_MAIN
+
+`4b49e00c75866fa57f71e7bef61547915f7e01db`
+
+## STATE_BASE_SHA
+
+`4b49e00c75866fa57f71e7bef61547915f7e01db`
+
+## PR
+
+- Governance PR [#408](https://github.com/weby-homelab/power-framework/pull/408):
+  `MERGED`.
+- HF PR [#406](https://github.com/weby-homelab/power-framework/pull/406):
+  `OPEN / NOT MERGED`; its base remains the pre-governance main.
+- Provisional evidence PR [#407](https://github.com/weby-homelab/power-framework/pull/407):
+  retained, open, and marked `SUPERSEDED BY #408`.
+- Actions PR #396: `HOLD / NOT STARTED`.
+
+## BASE_SHA
+
+HF #406 original base: `119d5c39aa2c22734ca72c351f8a70790371678f`.
+
+## HEAD_SHA
+
+HF #406 retained head: `201da2e0e78d1bbf860c98dc653008c0fb4984cd`.
+
+## HEAD_TREE
+
+HF #406 retained tree: `c8d66c9bf65c54b09bb9990380313737af63c932`.
+
+## HEAD_PARENT
+
+HF #406 retained parent: `119d5c39aa2c22734ca72c351f8a70790371678f`.
+
+## OBSERVED_AT_UTC
+
+`2026-09-08T09:14:03Z` — post-merge REST and Git verification.
+
+## CANDIDATE_EPOCH
+
+```text
+GOVERNANCE_MERGE_EPOCH: governance-408-4
+GOVERNANCE_PR: 408
+GOVERNANCE_HEAD: b6f54b0c04da545ba1fe3cd9fa932638d2ff8815
+GOVERNANCE_TREE: da33bef8fd4ecd5eafa68e04bb7db21246fb42b4
+MERGE_SHA: 4b49e00c75866fa57f71e7bef61547915f7e01db
+MERGE_PARENTS: 119d5c39aa2c22734ca72c351f8a70790371678f, b6f54b0c04da545ba1fe3cd9fa932638d2ff8815
+
+HF_EPOCH: hf-406-1-stale-after-governance-merge
+HF_BASE: 119d5c39aa2c22734ca72c351f8a70790371678f
+HF_HEAD: 201da2e0e78d1bbf860c98dc653008c0fb4984cd
+HF_TREE: c8d66c9bf65c54b09bb9990380313737af63c932
+HF_PARENT: 119d5c39aa2c22734ca72c351f8a70790371678f
+INVALIDATED_BY: main advanced to 4b49e00c75866fa57f71e7bef61547915f7e01db
+```
+
+The HF epoch is retained for provenance but cannot authorize a merge. Merge
+current `main` into the HF branch or create a replacement, then record the new
+base/head/tree/parent, recompute the three-file diff and all evidence. A SHA
+change starts a new epoch and does not terminate the work.
+
+## GPG
+
+- Governance head `b6f54b0c04da545ba1fe3cd9fa932638d2ff8815`: local and GitHub
+  `verified=true`, `reason=valid`.
+- Normal merge commit `4b49e00c75866fa57f71e7bef61547915f7e01db`: GitHub
+  `verified=true`, `reason=valid`.
+- Protected merge method: normal `merge`; no bypass or force operation.
+
+## MERGE_STATUS
+
+```text
+GOVERNANCE_PR_408: MERGED
+GOVERNANCE_MERGE: ACCEPTED BY PROTECTED NORMAL MERGE
+HF_PR_406: OPEN / NOT MERGED / STALE BASE
+HF_NORMAL_MERGE: NOT ATTEMPTED
+```
+
+## MERGE_SHA
+
+`4b49e00c75866fa57f71e7bef61547915f7e01db`
+
+## MERGE_PARENTS
+
+- `119d5c39aa2c22734ca72c351f8a70790371678f`
+- `b6f54b0c04da545ba1fe3cd9fa932638d2ff8815`
+
+## TESTS
+
+- PR #408 required checks: `11/11 success` before merge.
+- Post-merge `main` had 10 direct required workflow check-runs observed as
+  `success`, including Python 3.13/3.14, security, package smoke, upgrade
+  matrix, benchmark integrity, Python analysis, build, base runtime, and
+  aggregate. CodeQL was `success` on the exact governance PR head before merge;
+  no separate push CodeQL run appeared in the observed main check-run set.
+- Local governance docs: `.venv/bin/mkdocs build --strict` `PASS` and
+  workspace `./verify.sh` `PASS` before merge.
+- HF exact-head local evidence: lock/export/pip-check, deterministic HF tests,
+  core security matrix, Ruff, format, MyPy, and pip-audit `PASS`; full suite
+  `1774 passed, 4 skipped, 17 deselected, 83.05%`, with one timing assertion
+  failure at `5.107s` that passed isolated at `4.14s` and is pre-existing
+  performance variance, not a dependency failure.
+
+## SECURITY
+
+- WEB-01: `CLOSED / PASS` through merged PR #405.
+- WEB-05: `CLOSED / PASS` through merged PR #405.
+- Governance merge changed only docs/handoff files and introduced no executable
+  network, loader, provider, approval, or path-traversal surface.
+- HF security matrix remains exact-head evidence and must be rerun after the
+  new HF candidate is based on current `main`.
+
+## CI / CODEQL / DOCS
+
+- Governance PR #408 required contexts were successful before its merge.
+- Main merge commit `4b49e00c75866fa57f71e7bef61547915f7e01db` had successful
+  post-merge CI required contexts in the observed check set.
+- CodeQL and Docs were successful on the exact governance head before merge;
+  `deploy` behavior remains workflow-defined and is not the HF admission gate.
+- No HF check run was started by this handoff after the main advance.
+
+## REVIEW_THREADS
+
+- Governance #408 merged after required-policy diagnosis; branch protection
+  required zero approvals and required conversation resolution was disabled.
+- #408 retained CodeRabbit findings were repaired or explicitly bounded in the
+  PR body and review-disposition comment.
+- #406 has zero submitted reviews, zero requested reviewers, and zero inline
+  comments in the authenticated observation; its old check evidence is stale
+  for the new base.
+
+## WORKTREE
+
+- Repository: `/root/geminicli/projects/power-framework`.
+- Current local branch: `docs/power-3.8-post-governance-state`.
+- Base commit: `4b49e00c75866fa57f71e7bef61547915f7e01db`.
+- State update branch is provisional until its normal protected PR merge.
+
+## COMPLETED
+
+- Fresh-fetch verified governance PR #408 merge, merge SHA, tree, parents, and
+  current `main` ref.
+- Proved the signed governance head is an ancestor of `main` through the
+  protected merge graph.
+- Verified post-merge required checks and retained HF exact-head evidence.
+- Classified #406 as a repairable stale-base candidate, not a terminal stop.
+
+## OPEN_BLOCKERS
+
+- Current-state files on `main` still describe the pre-merge governance snapshot
+  until this post-governance state update is normally merged.
+- HF #406 requires a new candidate epoch against current `main`; no HF merge
+  attempt is authorized under the old base.
+- Actions #396 and Phase 5 remain intentionally untouched.
+
+## NEXT_GATE
+
+Publish this post-governance state update in one normal protected PR. Then merge
+current `main` into the HF branch or create a replacement, compute the new exact
+tuple and three-file diff, rerun the full HF dependency/security/CI matrix, and
+make one normal protected HF merge attempt only when policy accepts the exact
+head. Do not start Actions #396 or Phase 5.
+
+## AUTHORIZED
+
+- Post-governance state publication: `YES`.
+- HF branch refresh/replacement as a new candidate epoch: `YES`.
+- One normal HF merge attempt after fresh exact admission: `YES`.
+
+## NOT_AUTHORIZED
+
+- Admin/protection bypass, fake approval, force push, force merge, auto-merge,
+  merge queue override, or weakening required checks.
+- Starting Actions #396, Phase 5–9, version bump, tag, release, or POWER 3.8.0.
+- Rewriting historical handoffs or promoting old HF evidence to current main.
+
+## PUBLICATION
+
+- Canonical merged main:
+  [4b49e00](https://github.com/weby-homelab/power-framework/commit/4b49e00c75866fa57f71e7bef61547915f7e01db).
+- Governance PR:
+  [#408](https://github.com/weby-homelab/power-framework/pull/408).
+- Active HF gate:
+  [#406](https://github.com/weby-homelab/power-framework/pull/406).
+- Current state: `docs/plans/POWER_3.8_CURRENT_STATE.md`.
+- Roadmap: `docs/plans/POWER_3.8_EXECUTION_ROADMAP.md`.
+- Protocol: `docs/plans/POWER_3.8_DEVELOPMENT_PROTOCOL.md`.
+- This packet is provisional until its state-update PR merges; later changes
+  append a new handoff.
+
+## POWER VERSION
+
+`3.7.11`
+
+## POWER 3.8.0
+
+`NO-GO`

--- a/docs/plans/POWER_3.8_CURRENT_STATE.md
+++ b/docs/plans/POWER_3.8_CURRENT_STATE.md
@@ -18,25 +18,25 @@ DEVELOPMENT_TARGET:
 3.8.0
 
 STATE_STATUS:
-PRE-HF GOVERNANCE CANDIDATE / HF BLOCKED
+GOVERNANCE CANONICAL / HF REFRESH REQUIRED
 
 STATE_BASE_SHA:
-119d5c39aa2c22734ca72c351f8a70790371678f
+4b49e00c75866fa57f71e7bef61547915f7e01db
 
 CURRENT_MAIN_SHA:
-119d5c39aa2c22734ca72c351f8a70790371678f
+4b49e00c75866fa57f71e7bef61547915f7e01db
 
 ACTIVE_GATE:
-Controlled Dependency Refresh — HF #406 exact-head admission
+Controlled Dependency Refresh — HF #406 new candidate epoch
 
 LAST_CLOSED_GATE:
-Controlled Dependency Refresh — WEB-01 / WEB-05 security closure
+Pre-HF Governance Snapshot — PR #408 protected merge
 
 LAST_MERGED_PR:
-405
+408
 
 HF_PR:
-406 OPEN / NOT MERGED
+406 OPEN / STALE BASE / REFRESH REQUIRED
 
 PHASE_5:
 BLOCKED / NOT STARTED
@@ -45,16 +45,16 @@ RELEASE_3_8_0:
 NO-GO
 
 CANONICAL_GOVERNANCE_BRANCH:
-docs/power-3.8-governance-bootstrap
+docs/power-3.8-governance-bootstrap (merged; remote ref auto-deleted)
 
 CANONICAL_GOVERNANCE_COMMIT:
-98f90b36e73e0e43ac77dce3dcf895c9caec1ef9 (signed candidate; canonical after protected merge)
+4b49e00c75866fa57f71e7bef61547915f7e01db (protected merge; GitHub-verified)
 
 CANONICAL_GOVERNANCE_PR:
-408 OPEN / PROVISIONAL
+408 MERGED
 
 LATEST_HANDOFF:
-artifacts/project-state/handoffs/2026-09-08T084501Z_governance-bootstrap_epoch-3.md
+artifacts/project-state/handoffs/2026-09-08T091401Z_governance-post-merge_pre-hf.md
 ```
 
 ## Fresh state anchor
@@ -62,10 +62,18 @@ artifacts/project-state/handoffs/2026-09-08T084501Z_governance-bootstrap_epoch-3
 - Repository: [weby-homelab/power-framework](https://github.com/weby-homelab/power-framework).
 - State was read from GitHub REST during this session. Every future agent must
   fetch and revalidate the mutable values below before acting.
-- OBSERVED_AT_UTC: `2026-09-08T08:13:35Z`.
+- PRE_GOVERNANCE_OBSERVED_AT_UTC: `2026-09-08T08:13:35Z`.
 - GOVERNANCE_POLICY_OBSERVED_AT_UTC: `2026-09-08T08:45:01Z`.
-- The local verified base anchor is
+- POST_GOVERNANCE_OBSERVED_AT_UTC: `2026-09-08T09:14:03Z`.
+- The pre-governance verified base anchor was
   `119d5c39aa2c22734ca72c351f8a70790371678f`.
+- Current protected `main` is
+  `4b49e00c75866fa57f71e7bef61547915f7e01db`.
+- Governance merge tree:
+  `da33bef8fd4ecd5eafa68e04bb7db21246fb42b4`.
+- Governance merge parents:
+  `119d5c39aa2c22734ca72c351f8a70790371678f` and
+  `b6f54b0c04da545ba1fe3cd9fa932638d2ff8815`.
 - A document SHA is a state anchor, not a substitute for live GitHub verification.
 
 ## Public and phase state
@@ -87,7 +95,8 @@ artifacts/project-state/handoffs/2026-09-08T084501Z_governance-bootstrap_epoch-3
 |---|---|---|
 | Python admission | CLOSED | Prior merged repository evidence |
 | WEB-01 / WEB-05 | CLOSED | Security PR #405 and merge on `main` |
-| HF admission | BLOCKED / NOT MERGED | PR #406, exact head below |
+| Pre-HF governance snapshot | CLOSED | PR #408 protected merge on `main` |
+| HF admission | REFRESH REQUIRED | PR #406 remains open but its base is behind current `main` |
 | Actions #396 | HOLD / NOT STARTED | Must not begin in this gate |
 | Final integration | BLOCKED | Requires all dependency admissions |
 
@@ -95,8 +104,11 @@ artifacts/project-state/handoffs/2026-09-08T084501Z_governance-bootstrap_epoch-3
 
 - PR: [#406](https://github.com/weby-homelab/power-framework/pull/406),
   `OPEN`, `merged=false`.
-- Authorized base and current base:
+- Original authorized base:
   `119d5c39aa2c22734ca72c351f8a70790371678f`.
+- Current `main` is
+  `4b49e00c75866fa57f71e7bef61547915f7e01db`; the candidate base is stale and
+  must be refreshed before normal admission.
 - Authorized head:
   `201da2e0e78d1bbf860c98dc653008c0fb4984cd`.
 - Authorized head tree:
@@ -104,16 +116,14 @@ artifacts/project-state/handoffs/2026-09-08T084501Z_governance-bootstrap_epoch-3
 - Authorized head parent:
   `119d5c39aa2c22734ca72c351f8a70790371678f`.
 - GitHub commit verification: `verified=true`, `reason=valid`.
-- GitHub reports `mergeable=true`, `mergeable_state=blocked` at the observation
-  above. This field is diagnostic, not a standalone authorization or terminal
-  failure: required checks, review requirements, unresolved conversations,
-  branch freshness, rulesets, queue, and deployment policy must be diagnosed
-  before one normal protected-merge attempt.
-- At this observation, all 11 published required contexts for #406 were
-  successful, branch protection required zero approving reviews, and no
-  unresolved review conversation was reported. The remaining `blocked` reason
-  is not inferred from those facts and remains subject to the protected merge
-  admission test.
+- Before the governance merge, GitHub reported `mergeable=true` and
+  `mergeable_state=blocked`; after `main` advanced, the live API returned
+  `mergeable=null`, `mergeable_state=unknown` while recalculating the open PR.
+  These fields are diagnostic, not standalone authorization or terminal
+  failure. Branch freshness and all required checks must be recomputed for a
+  new candidate epoch.
+- The old exact-head required contexts were successful, but they are not
+  admission evidence for a candidate based on the new `main`.
 - Intended target: `huggingface-hub 1.30.0`.
 - Maintained specifier: `>=1.30.0,<1.31.0`.
 - PR #406 dependency diff is limited to `pyproject.toml`,
@@ -123,76 +133,77 @@ artifacts/project-state/handoffs/2026-09-08T084501Z_governance-bootstrap_epoch-3
 - Web export SHA-256:
   `4001e0b073acb7c6eb40bab6047bcb13adedbca3d2a6ebdf23e1b28687b435c3`.
 
-## Governance candidate #408
+## Governance merge #408
 
 - Branch: `docs/power-3.8-governance-bootstrap`.
 - PR: [#408](https://github.com/weby-homelab/power-framework/pull/408),
-  `OPEN`, `merged=false`.
+  `MERGED`, `merged=true`.
 - Candidate head:
-  `3166244bcbc7d6e6757e6b45dbde82b2be4ccbc5`.
+  `b6f54b0c04da545ba1fe3cd9fa932638d2ff8815`.
 - Candidate tree:
-  `15bd0f743d1a77bfdcdeed03fc61833229dd1e03`.
+  `da33bef8fd4ecd5eafa68e04bb7db21246fb42b4`.
 - Candidate parent:
-  `98f90b36e73e0e43ac77dce3dcf895c9caec1ef9`.
+  `3166244bcbc7d6e6757e6b45dbde82b2be4ccbc5`.
 - GitHub commit verification: `verified=true`, `reason=valid` at
-  `2026-09-08T08:37:42Z`.
-- The candidate contains only governance/handoff paths: nine files total,
-  including the seven imported source-material files and two append-only
-  governance handoffs.
+  `2026-09-08T08:54:20Z`.
+- Protected merge SHA:
+  `4b49e00c75866fa57f71e7bef61547915f7e01db`.
+- Protected merge parents are
+  `119d5c39aa2c22734ca72c351f8a70790371678f` and
+  `b6f54b0c04da545ba1fe3cd9fa932638d2ff8815`.
+- The merged tree contains only governance/handoff paths: nine files total,
+  including seven imported source-material files and two append-only handoffs.
 - Previous governance epoch: head
   `98f90b36e73e0e43ac77dce3dcf895c9caec1ef9`, tree
-  `f9046c678191fa97a9a4a9f29db32cc87b23a164`; it remains retained evidence,
-  not the current PR head.
+  `f9046c678191fa97a9a4a9f29db32cc87b23a164`; it remains retained evidence.
 
 ## Gate decision and blockers
 
 ```text
-HF MERGE = PENDING POLICY DIAGNOSIS / ADMISSION
-NORMAL MERGE = NOT YET ATTEMPTED FOR THIS OBSERVATION
-FRESH CHATGPT AUDIT REQUIRED
+GOVERNANCE MERGE = CLOSED / PR #408 MERGED
+HF MERGE = BLOCKED / NEW CANDIDATE EPOCH REQUIRED
+HF NORMAL MERGE = NOT YET ATTEMPTED FOR CURRENT MAIN
 ```
 
-The exact authorization text supplied for PR #406 does not override fresh
-GitHub state. Authenticated REST inspection is available and shows the
-required-check and review-policy values above; `mergeable_state=blocked` still
-requires diagnosis, not a magic-string stop. A normal merge attempt must use
-the exact current head guard, at most once for this candidate epoch, with no
-bypass or retry loop.
+The governance PR was accepted through one normal protected merge after fresh
+required-check and policy diagnosis. The HF authorization for its old base is
+now stale because `main` advanced. Refreshing #406 or creating a replacement is
+repair work: record the new tuple, recompute the diff/hashes/tests/security/CI,
+and then apply the one-normal-merge-attempt rule to the current candidate.
 
 ## Canonical governance status
 
-The pre-HF canonical governance bootstrap has started from live `main`:
+The pre-HF canonical governance bootstrap is canonical on protected `main`:
 
 - Governance branch: `docs/power-3.8-governance-bootstrap`.
-- Governance commit: `3166244bcbc7d6e6757e6b45dbde82b2be4ccbc5`, locally and
-  GitHub-verified signed candidate.
+- Governance merge: `4b49e00c75866fa57f71e7bef61547915f7e01db`, with GitHub
+  `verified=true`, `reason=valid`.
 - Governance PR: [#408](https://github.com/weby-homelab/power-framework/pull/408),
-  open/provisional until protected merge.
+  merged by one ordinary protected merge.
 - The prior `docs/power-3.8-premerge-state-publication` branch remains
   provisional evidence and is retained as source material; it is not replaced
   or deleted.
-- A governance merge before HF is permitted when GitHub's protected normal
-  merge policy accepts it. If `main` advances, #406 must be revalidated as a
-  new candidate epoch rather than treated as failed evidence.
+- HF #406 must now be revalidated as a new candidate epoch against current
+  `main`; its old evidence is retained but cannot authorize a merge.
 
 ## Next authorized work
 
-1. Validate and publish this pre-HF governance candidate through a normal
-   protected PR.
-2. Revalidate `main`, #406, required checks, reviews, conversations, rulesets,
-   queue/deployment requirements, and exact Git objects immediately before any
-   normal merge attempt.
-3. If governance merges first, record the new `main` and rebuild or merge it
-   into the HF candidate as a new candidate epoch; old evidence becomes stale,
-   not fatal.
-4. Admit HF #406 only after its current exact tuple and protected policy pass.
-5. After HF post-merge verification, publish a new governance state update.
+1. Publish this post-governance state update through a normal protected PR.
+2. Merge current `main` into the HF branch or create a verified replacement,
+   recording the new base/head/tree/parent tuple and preserving a three-file HF
+   diff from current `main`.
+3. Recompute lock/export hashes, targeted/full tests, security matrix, remote
+   checks, reviews, branch policy, and exact mergeability for the new epoch.
+4. Admit and normally merge HF #406 only after its current protected policy
+   accepts the exact head.
+5. After HF post-merge verification, publish the required post-HF governance
+   update.
 
 ## Do not start
 
-- Do not mutate the HF branch without recording a new candidate epoch and
-  recomputing its exact base/head/tree/parent, diff, hashes, tests, security,
-  CI, and policy evidence.
+- HF branch mutation is permitted only as a new candidate epoch with recomputed
+  exact base/head/tree/parent, diff, hashes, tests, security, CI, and policy
+  evidence.
 - Do not merge, auto-merge, force-push, or bypass protection.
 - Do not start Actions #396, Phase 5, or later phases.
 - Do not bump the public version, create a tag, create a release, or publish
@@ -205,4 +216,4 @@ The pre-HF canonical governance bootstrap has started from live `main`:
 - [Development protocol](POWER_3.8_DEVELOPMENT_PROTOCOL.md)
 - [Planning index](README.md)
 - [Handoff protocol](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/README.md)
-- [Latest governance handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-08T084501Z_governance-bootstrap_epoch-3.md)
+- [Latest governance handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-08T091401Z_governance-post-merge_pre-hf.md)

--- a/docs/plans/POWER_3.8_DEVELOPMENT_PROTOCOL.md
+++ b/docs/plans/POWER_3.8_DEVELOPMENT_PROTOCOL.md
@@ -215,23 +215,25 @@ Maximum retry discipline:
 - one CI rerun for a proven external infrastructure failure;
 - no repeated commands that add no evidence.
 
-## Current stop condition
+## Current operational state
 
-Current operational state until a fresh guard closes the HF gate:
+Current state after the protected governance merge and before the HF candidate
+refresh:
 
 ```text
-HF ADMISSION: BLOCKED / NOT MERGED
-CANONICAL GOVERNANCE: NOT STARTED
+HF ADMISSION: REFRESH REQUIRED / OLD CANDIDATE STALE
+CANONICAL GOVERNANCE: YES / PR #408 MERGED
 ACTIONS #396: HOLD / NOT STARTED
 PHASE 5: BLOCKED / NOT STARTED
 PUBLIC VERSION: 3.7.11
 POWER 3.8.0: NO-GO
 ```
 
-The governance line changes to `PRE-HF CANDIDATE / IN PROGRESS` while its
-protected PR is under review, and to `CANONICAL` only after merge. Do not start
-Actions #396, Phase 5–9, version bumps, tags, releases, release images, or
-final release notes.
+The old HF tuple remains retained evidence only. Merge current `main` into the
+HF branch or create a replacement, record a new candidate epoch, recompute the
+full required evidence, and continue through the ordinary protected merge
+path. Do not start Actions #396, Phase 5–9, version bumps, tags, releases,
+release images, or final release notes.
 
 ## Cross-links
 
@@ -239,4 +241,4 @@ final release notes.
 - [Execution roadmap](POWER_3.8_EXECUTION_ROADMAP.md)
 - [Planning index](README.md)
 - [Handoff protocol](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/README.md)
-- [Latest governance handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-08T084501Z_governance-bootstrap_epoch-3.md)
+- [Latest governance handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-08T091401Z_governance-post-merge_pre-hf.md)

--- a/docs/plans/POWER_3.8_EXECUTION_ROADMAP.md
+++ b/docs/plans/POWER_3.8_EXECUTION_ROADMAP.md
@@ -27,10 +27,10 @@ Phase 4
 CLOSED / FROZEN
         ↓
 Controlled Dependency Refresh
-        ├── Pre-HF governance snapshot — IN PROGRESS / protected review
+        ├── Pre-HF governance snapshot — CLOSED / PR #408 MERGED
         ├── Python admission — DONE
         ├── WEB-01 / WEB-05 — DONE
-        ├── HF admission PR #406 — BLOCKED / DIAGNOSIS IN PROGRESS
+        ├── HF admission PR #406 — REFRESH REQUIRED / NEW EPOCH
         ├── Actions admission PR #396 — NEXT AFTER HF / HOLD / NOT STARTED
         └── Final integration admission — BLOCKED
         ↓
@@ -61,8 +61,8 @@ NO-GO
 | Phases 0–4 | DONE / FROZEN | No reopening in this gate |
 | Python refresh | DONE | Prior controlled admission |
 | WEB-01 / WEB-05 | DONE | Closed through security PR #405 |
-| Pre-HF governance snapshot | IN PROGRESS | Fresh signed branch from live `main`; may merge before HF |
-| HF refresh | BLOCKED / DIAGNOSE | PR #406 is open; exact head is not merged; current state is not terminal |
+| Pre-HF governance snapshot | CLOSED | PR #408 protected merge is on `main` |
+| HF refresh | REFRESH REQUIRED | PR #406 remains open on the pre-governance base |
 | Actions #396 | NEXT AFTER HF / HOLD | Do not inspect or modify in this gate |
 | Final integration | BLOCKED BY HF | Requires separate admissions |
 | Phase 5 | BLOCKED / NOT STARTED | No implementation authorized |
@@ -77,11 +77,11 @@ dependency update:
 1. **Python admission — complete.** Preserve its merged evidence.
 2. **WEB-01 / WEB-05 — complete.** Security boundaries are closed through PR
    #405 and must not be reopened as part of HF work.
-3. **HF admission — current blocked gate.** PR #406 starts with an exact
-   authorized base, head, tree, and parent. A repair, compatibility fix, lock
-   regeneration, or merge of current `main` may create a new candidate epoch;
-   old evidence then becomes stale and must be recomputed, not treated as a
-   reason to terminate the gate.
+3. **HF admission — current refresh gate.** PR #406 retains an exact prior
+   tuple, but governance PR #408 advanced `main`. Merge current `main` into the
+   HF branch or create a replacement, then record a new candidate epoch and
+   recompute all evidence. Old evidence is stale input, not a reason to
+   terminate the gate.
 4. **Actions admission — next gate only after HF.** PR #396 remains on hold;
    no Actions dependency or workflow changes are authorized here.
 5. **Final integration admission — later gate.** It requires independent exact
@@ -109,13 +109,13 @@ SPECIFIER:
 >=1.30.0,<1.31.0
 
 LIVE_PR_STATE:
-OPEN / NOT MERGED
+OPEN / NOT MERGED / STALE BASE
 
 LIVE_MERGEABILITY:
-mergeable=true; mergeable_state=blocked (diagnostic observation)
+mergeable=null; mergeable_state=unknown while GitHub recalculates after main advance
 
 ADMISSION:
-PENDING REQUIRED-POLICY DIAGNOSIS / NORMAL-MERGE TEST
+NEW CANDIDATE EPOCH REQUIRED / NORMAL-MERGE TEST NOT ATTEMPTED
 ```
 
 `mergeable_state` alone is neither merge authorization nor an automatic stop.
@@ -174,8 +174,8 @@ Treat the following as remediation inputs rather than automatic stops:
 
 - HF base, head, tree, parent, diff, or PR state changes after authorization;
   start a new candidate epoch and recompute evidence.
-- `mergeable_state=unstable` or `blocked`; diagnose the concrete required
-  check/policy cause and retry admission only after remediation.
+- `mergeable_state=unstable`, `blocked`, or `unknown`; diagnose the concrete
+  required check/policy cause and retry admission only after remediation.
 - A required check fails; inspect its logs, apply a minimal related fix, and
   rerun the bounded gate.
 - Required policy is not observable through one interface; use the approved
@@ -196,4 +196,4 @@ Actions #396 or Phase 5 before the HF gate is closed.
 - [Development protocol](POWER_3.8_DEVELOPMENT_PROTOCOL.md)
 - [Planning index](README.md)
 - [Handoff protocol](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/README.md)
-- [Latest governance handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-08T084501Z_governance-bootstrap_epoch-3.md)
+- [Latest governance handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-08T091401Z_governance-post-merge_pre-hf.md)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,19 +6,19 @@ commits, branch protection, or authoritative phase reports.
 
 ## ACTIVE GOVERNANCE
 
-The following files are the active **pre-HF governance projection** in the
-current publication candidate:
+The following files are the active **post-governance HF-refresh projection** in
+the canonical `main` tree:
 
 - [POWER 3.8 — Current State](POWER_3.8_CURRENT_STATE.md)
 - [POWER 3.8 — Execution Roadmap](POWER_3.8_EXECUTION_ROADMAP.md)
 - [POWER 3.8 — Development Protocol](POWER_3.8_DEVELOPMENT_PROTOCOL.md)
 - [Project-state handoff protocol](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/README.md)
-- [Latest governance handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-08T084501Z_governance-bootstrap_epoch-3.md)
+- [Latest governance handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-08T091401Z_governance-post-merge_pre-hf.md)
 
-> These documents are published for recovery while the HF gate is blocked.
-> Before a protected merge they are provisional; after a protected merge they
-> become repository-native canonical memory for the recorded snapshot. They
-> must never be called `MERGED MAIN` evidence for a commit that has not merged.
+> Governance PR #408 is merged on protected `main`; the HF gate remains open
+> and requires a new candidate epoch because its old base is stale. These paths
+> are canonical memory for the recorded governance merge, not HF merge or
+> release evidence.
 
 > Links to `artifacts/` are GitHub evidence permalinks intentionally outside
 > the MkDocs navigation tree; they are not local documentation targets.
@@ -31,8 +31,8 @@ To recover the current POWER 3.8 state:
 2. Read `POWER_3.8_EXECUTION_ROADMAP.md`.
 3. Read `POWER_3.8_DEVELOPMENT_PROTOCOL.md`.
 4. Read the latest append-only handoff.
-5. Fetch current GitHub `main`, PR #406, and governance PR #408 independently
-   through authenticated REST API.
+5. Fetch current GitHub `main`, HF PR #406, and the merged governance PR #408
+   independently through authenticated REST API.
 6. Verify every documented SHA and mutable status, including each candidate's
    exact head, required checks, reviews, and protected-branch policy, before
    acting or attempting a governance merge.


### PR DESCRIPTION
## POWER 3.8 post-governance state update

Цей PR publishes canonical repository memory after the protected normal merge of governance PR #408. It does not start the HF gate, Actions #396, Phase 5, a version bump, or a release.

### Verified merge state

- Starting main: `119d5c39aa2c22734ca72c351f8a70790371678f`
- Current main after #408: `4b49e00c75866fa57f71e7bef61547915f7e01db`
- Governance PR #408: merged by one normal protected merge
- Governance head: `b6f54b0c04da545ba1fe3cd9fa932638d2ff8815`
- Governance tree: `da33bef8fd4ecd5eafa68e04bb7db21246fb42b4`
- Merge parents: `119d5c39aa2c22734ca72c351f8a70790371678f`, `b6f54b0c04da545ba1fe3cd9fa932638d2ff8815`
- Merge commit GitHub verification: `verified=true`, `reason=valid`

### HF boundary

HF PR #406 remains `OPEN / NOT MERGED` on the old base `119d5c39aa2c22734ca72c351f8a70790371678f`; its exact head `201da2e0e78d1bbf860c98dc653008c0fb4984cd` is retained evidence only. The next bounded action is a new candidate epoch by merging current main into the HF branch or creating a replacement, then recomputing the exact three-file diff, hashes, tests, security, CI, and policy.

### Scope

This update changes only governance state/handoff documentation. It adds the post-governance handoff and changes active current-state/roadmap/protocol/index status from `#408 OPEN` to `#408 MERGED` and `HF REFRESH REQUIRED`. Historical handoffs remain immutable.

### Validation

- Local GPG signature: PASS for `7a1b859804c39bb384380d1205ce65f17351577a`.
- GitHub commit verification: `verified=true`, `reason=valid`.
- `.venv/bin/mkdocs build --strict`: PASS before publication.
- Workspace `./verify.sh`: PASS before publication.
- No source/dependency/workflow/version/tag/release changes.

### Anti-bypass

Normal protected merge only. No admin bypass, protection change, fake approval, force push, auto-merge, or merge queue override. Actions #396 remains HOLD / NOT STARTED; Phase 5 remains BLOCKED / NOT STARTED; public version remains 3.7.11; POWER 3.8.0 remains NO-GO.