### PR TITLE
ci: run docs check for dependency changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,12 +6,20 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "release/web-runtime.requirements.txt"
+      - ".github/workflows/docs.yml"
       - ".github/workflows/release.yml"
   pull_request:
     branches: [main]
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "release/web-runtime.requirements.txt"
+      - ".github/workflows/docs.yml"
       - ".github/workflows/release.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Fix required Docs build admission for dependency-only changes

This narrowly scoped CI repair addresses the exact protected-merge rejection on HF PR #406: `HTTP 405 Required status check "build" is expected`. The Docs workflow's required `build` job was path-filtered to docs/release files, so dependency-only changes created no PR-associated `build` check. A manually dispatched Docs run passed but did not satisfy the PR protection context.

### Change

Add `pyproject.toml`, `uv.lock`, `release/web-runtime.requirements.txt`, and `.github/workflows/docs.yml` to both Docs `push` and `pull_request` path filters. This makes the strict Docs build run for dependency/lock/export and workflow changes while preserving the existing job, permissions, deploy skip, and protected policy.

### Exact lineage

- Base: `0400aea20776715d801339de325ba0cba65fab10`
- Head: `3036be04009922342d45ddf7306aa5be44b23f89`
- Tree: `85c859aac5d6fed2a49958897a36b3005fc28d86`
- Parent: `0400aea20776715d801339de325ba0cba65fab10`
- GitHub signature: `verified=true`, `reason=valid`

### Validation

- YAML parse and trigger-path assertion: PASS.
- `tests/test_ci_policy.py`: `18 passed`.
- `.venv/bin/mkdocs build --strict`: PASS; existing unlisted-page/Material warnings only.
- Workspace `./verify.sh`: PASS.
- No source, dependency, lockfile, version, release, Actions #396, or Phase 5 change.

After this PR's protected merge, HF #406 must be refreshed/revalidated against the new main as a new candidate epoch. No admin bypass, protection change, fake approval, force push, auto-merge, or merge queue override is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation checks now run when project configuration, dependency lockfiles, runtime requirements, or the documentation workflow changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->