### PR TITLE
security: harden POWER application authority and execution boundary

### DIFF
--- a/artifacts/project-state/handoffs/2026-09-09T163501Z_pre-phase5-foundation-hardening.md
+++ b/artifacts/project-state/handoffs/2026-09-09T163501Z_pre-phase5-foundation-hardening.md
@@ -109,6 +109,34 @@ The final documentation/handoff commit creates a new exact candidate epoch.
 Its live `HEAD`, tree, and parent are intentionally resolved from GitHub after
 publication rather than fabricated in this self-referential file.
 
+### EPOCH_2 — documentation candidate
+
+```text
+BASE: 95f8cadd7e90ef4b16773b3c45bbc9ab40569e7a
+HEAD: 9b04bbea6d42d700ae9c28534ce87277afafe2da
+TREE: 9a380020ad9b6356f69f6681d0b10aa921c832a0
+PARENTS: 77eb706a9794eb04b570c53520a5a891b96335c6
+WHY_HEAD_CHANGED: candidate state clarification and append-only handoff
+GPG: local git verify-commit GOOD / primary 2D49E810C7F2527E
+REMOTE_CI: all required contexts PASS
+```
+
+### EPOCH_3 — review remediation candidate
+
+```text
+BASE: 9b04bbea6d42d700ae9c28534ce87277afafe2da
+HEAD: 5d81a2dfb04c12b4fc18e499f198fe06823a9c07
+TREE: b911cddf3fdc9dfa92a1ca0b247305caff45e6c9
+PARENTS: 9b04bbea6d42d700ae9c28534ce87277afafe2da
+WHY_HEAD_CHANGED: bounded history replay, context propagation, truthful budget mapping, safe rename destination validation, and review regression tests
+GPG: local git verify-commit GOOD / primary 2D49E810C7F2527E
+TARGETED_TESTS_AT_EPOCH: 233 passed
+REMOTE_CI: pending until this epoch is published
+```
+
+The final documentation update below creates another exact candidate epoch;
+all remote approval evidence must attach to that later exact head.
+
 ## FILES CHANGED
 
 ```text
@@ -148,7 +176,7 @@ AUTO_MERGE: NO
 ## CANDIDATE / MERGE POINTERS
 
 ```text
-FOUNDATION_PR: RESOLVE_FROM_GITHUB
+FOUNDATION_PR: #414
 FINAL_CANDIDATE_HEAD: RESOLVE_FROM_GITHUB
 FINAL_CANDIDATE_TREE: RESOLVE_FROM_GITHUB
 FINAL_CANDIDATE_PARENTS: RESOLVE_FROM_GITHUB

--- a/artifacts/project-state/handoffs/2026-09-09T163501Z_pre-phase5-foundation-hardening.md
+++ b/artifacts/project-state/handoffs/2026-09-09T163501Z_pre-phase5-foundation-hardening.md
@@ -1,0 +1,176 @@
+# POWER 3.8 Pre-Phase-5 Foundation Hardening Handoff
+
+> Append-only candidate handoff. The Foundation implementation is not
+> `MERGED MAIN` until the exact candidate passes protected GitHub admission and
+> is independently read back after one normal merge. It does not start Phase 5.
+
+## PROJECT
+
+```text
+PROJECT: POWER Framework 3.8
+REPOSITORY: https://github.com/weby-homelab/power-framework
+PUBLIC_VERSION: 3.7.11
+ACTIVE_NODE: WS
+CHECKOUT: /root/gemma/projects/P.O.W.E.R
+BRANCH: feat/power-3.8-foundation-hardening
+```
+
+## STARTING VERIFIED MAIN
+
+```text
+STARTING_MAIN: 95f8cadd7e90ef4b16773b3c45bbc9ab40569e7a
+STARTING_TREE: 28f99fc71d6e163a242d7782ae87040805e79faf
+STARTING_PARENTS: a386858a45489eb5db213d42ffe773db9134ff88 bcd882815cbb7b2fe33d672b83421d98eefaaf48
+STARTING_MAIN_GITHUB: verified=true / reason=valid
+STARTING_BRANCH_PROTECTION: strict=true / enforce_admins=true / required_approvals=0 / signatures=true
+```
+
+Required contexts at the starting read were `test (3.13)`, `test (3.14)`,
+`security`, `package-smoke`, `upgrade-matrix (ubuntu-latest)`,
+`upgrade-matrix-aggregate`, `base-runtime-smoke`, `benchmark-integrity`,
+`analyze (python)`, `CodeQL`, and `build`. No open PR existed at the starting
+read; PR #413 was already protected-merged into this main.
+
+## FOUNDATION RESULTS
+
+### F1 — Explicit mutation authority
+
+ApplicationService mutation entry points now fail closed on `context=None`,
+read-only context, invalid/expired principal, or missing apply authority where
+the operation writes canonical state. Web apply approval is required, parses
+only the exact string `true`, and has no truthy default. PowerClient approval is
+keyword-only and has no default. MCP write tools require explicit
+`approved=True` where they perform a write; proposal intent remains separate.
+CLI actor input remains attribution only.
+
+### F2 — Principal/session binding
+
+The core `Principal` contract distinguishes `WEB_SIGNED_SESSION`, `LOCAL_CLI`,
+`LOCAL_MCP_STDIO`, and `SYSTEM_INTERNAL`. It carries an opaque reference,
+binding type, validity, and optional expiry without storing credentials. Web
+middleware preserves the verified signed-session subject only long enough to
+issue a hashed reference with the token's actual expiry; auth-disabled Web is
+trusted only on a loopback bind. MCP derives its principal from the local stdio
+server, and CLI derives a local-process principal. `actor` remains a separate
+attribution field. Web request IDs reach PowerClient/ApplicationService; MCP
+call metadata carries its server-derived correlation ID.
+
+### F3 — Retrieval boundary
+
+ApplicationService default retrieval injects `allow_search_db_override=False`;
+the legacy `POWER_SEARCH_DB` path remains an explicit lower-level
+test/developer compatibility API. Web, MCP search, MCP diagnostics, and the
+MCP synthesis graph projection use the configured vault/cache boundary.
+Control-subdirectory symlinks are rejected, and CLI rename targets use the
+existing vault containment helper. Existing source projection, safe relative
+paths, non-symlink reads, and WEB-01/WEB-05 boundaries were retained.
+
+### F4 — Bounded failure receipts
+
+Configured ApplicationService audit hooks receive bounded failure receipts with
+operation, outcome/status, request ID, idempotency key, empty-result digest,
+principal reference/binding, error category, duration, and budget metadata.
+Raw exception text, traceback, request body, note content, and credentials are
+not copied. Successful `power.receipt.v1` serialization retains its historical
+wire shape; principal metadata is present on the application envelope and on
+failure receipts. Proposal, ingest/synthesis, task, and decision idempotency
+replay paths reject conflicting reuse. MCP errors are bounded/redacted and MCP
+call results include `power.request_id` metadata.
+
+### F5 — Deadline/concurrency/result semantics
+
+`RequestContext` supports a monotonic absolute deadline derived from a positive
+budget, plus a caller-lower-only serialized result ceiling. Expired work is
+rejected before the action starts. Synchronous reads that exceed a budget emit
+failure evidence; synchronous mutations that finish late emit
+`completed_after_deadline` rather than claiming cancellation. Web mutation
+offload joins the worker before reporting late/canceled outcomes; read offload
+may detach only because it has no mutation effect. MCP blocking work uses a
+bounded process-wide worker pool and joined mutation cancellation. No automatic
+mutation retries were added. Federation probes are capped by node count,
+validated host/port shape, active probe slots, and an overall timeout.
+
+## CANDIDATE EPOCH HISTORY
+
+### EPOCH_1 — implementation candidate
+
+```text
+BASE: 95f8cadd7e90ef4b16773b3c45bbc9ab40569e7a
+HEAD: 77eb706a9794eb04b570c53520a5a891b96335c6
+TREE: 6b100c73dcb6b250f3bf46ac7e00958a9a182972
+PARENTS: 95f8cadd7e90ef4b16773b3c45bbc9ab40569e7a
+WHY_HEAD_CHANGED: first bounded F1-F5 implementation and regression-test slice
+GPG: local git verify-commit GOOD / primary 2D49E810C7F2527E
+TARGETED_TESTS_AT_EPOCH: 230 passed
+FULL_TESTS_AT_EPOCH: 1817 passed, 14 skipped, 0 deselected; coverage 83.20%
+```
+
+The final documentation/handoff commit creates a new exact candidate epoch.
+Its live `HEAD`, tree, and parent are intentionally resolved from GitHub after
+publication rather than fabricated in this self-referential file.
+
+## FILES CHANGED
+
+```text
+src/power_framework/core/** (authority, principal, receipts, retrieval, worker, CLI safety)
+src/power_framework/mcp/power_server.py
+src/power_framework/web/** (session, request binding, approval, offload, federation)
+tests/test_foundation_hardening.py
+tests/web/contract/test_foundation_hardening.py
+tests/test_mcp_server.py
+tests/test_rename.py
+tests/web/unit/test_auth.py
+docs/plans/POWER_3.8_CURRENT_STATE.md
+docs/plans/POWER_3.8_EXECUTION_ROADMAP.md
+docs/plans/POWER_3.8_DEVELOPMENT_PROTOCOL.md
+docs/plans/POWER_3.8_CONTEXT_MEMORY_ARCHITECTURE.md
+docs/plans/README.md
+artifacts/project-state/planning/pre-phase5-foundation-hardening-gate.md
+```
+
+No dependency, lockfile, workflow, public version, tag, release, OCI image,
+model, Phase 5 router/planner/ContextPack, capture adapter, vector database,
+or persistent IndexWorkQueue was added.
+
+## SECURITY AND REVIEW
+
+```text
+SOURCE_REVIEW: two fresh single-model adversarial cycles completed; actionable findings repaired or classified
+CROSS_MODEL_CODEX: explicitly attempted, HTTP 400 for unsupported Luna Max model, then skipped by user decision
+REAL_NETWORK_REQUIRED: NO
+SECRETS_IN_HANDOFF: NO
+ADMIN_BYPASS: NO
+PROTECTION_BYPASS: NO
+FORCE: NO
+AUTO_MERGE: NO
+```
+
+## CANDIDATE / MERGE POINTERS
+
+```text
+FOUNDATION_PR: RESOLVE_FROM_GITHUB
+FINAL_CANDIDATE_HEAD: RESOLVE_FROM_GITHUB
+FINAL_CANDIDATE_TREE: RESOLVE_FROM_GITHUB
+FINAL_CANDIDATE_PARENTS: RESOLVE_FROM_GITHUB
+FINAL_CANDIDATE_GPG: RESOLVE_FROM_GITHUB
+MERGE_SHA: RESOLVE_FROM_GITHUB
+MERGE_TREE: RESOLVE_FROM_GITHUB
+MERGE_PARENTS: RESOLVE_FROM_GITHUB
+MERGE_GPG: RESOLVE_FROM_GITHUB
+```
+
+## NEXT GATE
+
+```text
+FOUNDATION_HARDENING: IMPLEMENTED / VERIFIED LOCALLY / CLOSED ONLY WHEN THIS EXACT PR IS PROTECTED-MERGED
+PHASES_0_4: CLOSED / FROZEN
+CONTROLLED_DEPENDENCY_REFRESH: CLOSED
+PHASE_5: READY FOR SEPARATE PHASE 5A ADMISSION / NOT STARTED
+PHASES_6_9: NOT STARTED
+POWER_3_8_0: NO-GO
+NEXT_GATE: Phase 5A — Runtime Contracts v2 + Frozen Evaluation Corpus Admission
+```
+
+After protected merge, resolve the final PR/merge objects from live GitHub,
+verify the Foundation paths on `main`, append the protected closure comment to
+the Foundation PR, and stop. Do not start Phase 5A in this session.

--- a/artifacts/project-state/planning/pre-phase5-foundation-hardening-gate.md
+++ b/artifacts/project-state/planning/pre-phase5-foundation-hardening-gate.md
@@ -1,10 +1,10 @@
 # POWER 3.8 Pre-Phase-5 Foundation Hardening Gate
 
-> **Status:** PLANNED / NOT STARTED / NEXT RUNTIME GATE
+> **Status:** ADMISSION CANDIDATE / IMPLEMENTED / LOCALLY VERIFIED / PROTECTED MERGE REQUIRED
 >
 > **Publication class:** planning-only acceptance contract
 >
-> **Implementation status:** NOT IMPLEMENTED
+> **Implementation status:** IMPLEMENTED ON THE FOUNDATION CANDIDATE; MERGED-MAIN STATUS REQUIRES THE PROTECTED NORMAL MERGE
 >
 > **Scope boundary:** this gate is an integration admission before Phase 5. It
 > does not reopen or rewrite Phase 0–4 evidence and it does not implement Phase
@@ -148,8 +148,8 @@ The Foundation Hardening candidate must provide:
 ## Admission decision
 
 ```text
-FOUNDATION_HARDENING: PLANNED / NOT STARTED
-PHASE_5: BLOCKED / NOT STARTED
+FOUNDATION_HARDENING: ADMISSION CANDIDATE / IMPLEMENTED / LOCALLY VERIFIED / PROTECTED MERGE REQUIRED
+PHASE_5: READY FOR SEPARATE PHASE 5A ADMISSION / NOT STARTED
 PHASES_0_4: CLOSED / FROZEN
-NEXT_RUNTIME_GATE: FOUNDATION HARDENING ADMISSION
+NEXT_RUNTIME_GATE: PROTECTED NORMAL MERGE AND POST-MERGE FOUNDATION VERIFICATION
 ```

--- a/docs/plans/POWER_3.8_CONTEXT_MEMORY_ARCHITECTURE.md
+++ b/docs/plans/POWER_3.8_CONTEXT_MEMORY_ARCHITECTURE.md
@@ -1185,7 +1185,7 @@ Phase 5 is currently `BLOCKED / NOT STARTED`; every item below is
 
 The Controlled Dependency Refresh is already closed at final integration in the
 current governance snapshot. No Foundation or 5A–5H gate authorizes Actions
-#396, capture, migration, a release, or a version bump by itself.
+`#396`, capture, migration, a release, or a version bump by itself.
 
 ## 27. Phase 6 Work Breakdown
 

--- a/docs/plans/POWER_3.8_CURRENT_STATE.md
+++ b/docs/plans/POWER_3.8_CURRENT_STATE.md
@@ -42,7 +42,7 @@ LAST_CLOSED_GATE:
 Controlled Dependency Refresh — Final Integration
 
 NEXT_GATE:
-Pre-Phase-5 Foundation Hardening Admission
+Foundation Hardening Protected Normal Merge and Post-Merge Verification
 
 ACTIONS_396:
 CLOSED / MERGED
@@ -78,7 +78,7 @@ CANONICAL_GOVERNANCE_PR:
 413
 
 LATEST_HANDOFF:
-artifacts/project-state/handoffs/2026-09-09T162533Z_pre-phase5-foundation-hardening.md
+artifacts/project-state/handoffs/2026-09-09T163501Z_pre-phase5-foundation-hardening.md
 
 CONTEXT_MEMORY_ARCHITECTURE_PLAN:
 docs/plans/POWER_3.8_CONTEXT_MEMORY_ARCHITECTURE.md

--- a/docs/plans/POWER_3.8_CURRENT_STATE.md
+++ b/docs/plans/POWER_3.8_CURRENT_STATE.md
@@ -18,16 +18,19 @@ DEVELOPMENT_TARGET:
 3.8.0
 
 STATE_STATUS:
-CONTROLLED DEPENDENCY REFRESH CLOSED / FINAL INTEGRATION VERIFIED / V2 PLANNING RECORDED
+FOUNDATION HARDENING CANDIDATE / F1-F5 IMPLEMENTED / V2 PLANNING RECORDED
 
 SNAPSHOT_BASE_SHA:
-a386858a45489eb5db213d42ffe773db9134ff88
+95f8cadd7e90ef4b16773b3c45bbc9ab40569e7a
 
 SNAPSHOT_BASE_TREE:
-664f34995961a2990dee00ecde0ebe7c8ed0f5d8
+28f99fc71d6e163a242d7782ae87040805e79faf
 
 SNAPSHOT_LAST_INCLUDED_PR:
-396
+413
+
+LAST_KNOWN_MERGED_PR_AT_SNAPSHOT_START:
+413
 
 CURRENT_LIVE_MAIN:
 RESOLVE_FROM_GITHUB
@@ -44,9 +47,6 @@ Pre-Phase-5 Foundation Hardening Admission
 ACTIONS_396:
 CLOSED / MERGED
 
-LAST_MERGED_PR:
-396
-
 HF_PR:
 406 MERGED / POST-MERGE VERIFIED
 
@@ -57,7 +57,7 @@ PHASE_5_IMPLEMENTATION:
 BLOCKED / NOT STARTED
 
 FOUNDATION_HARDENING:
-NEXT GATE / PLANNED / NOT STARTED
+ADMISSION CANDIDATE / IMPLEMENTED / LOCALLY VERIFIED / CLOSED ONLY WHEN THIS EXACT PR IS PROTECTED-MERGED
 
 PHASES_0_4:
 CLOSED / FROZEN
@@ -72,13 +72,13 @@ CANONICAL_GOVERNANCE_BRANCH:
 docs/power-3.8-final-integration-course-correction
 
 CANONICAL_GOVERNANCE_COMMIT:
-RESOLVE_FROM_GITHUB
+95f8cadd7e90ef4b16773b3c45bbc9ab40569e7a
 
 CANONICAL_GOVERNANCE_PR:
-RESOLVE_FROM_GITHUB
+413
 
 LATEST_HANDOFF:
-artifacts/project-state/handoffs/2026-09-09T065950Z_controlled-dependency-refresh_final-integration.md
+artifacts/project-state/handoffs/2026-09-09T162533Z_pre-phase5-foundation-hardening.md
 
 CONTEXT_MEMORY_ARCHITECTURE_PLAN:
 docs/plans/POWER_3.8_CONTEXT_MEMORY_ARCHITECTURE.md
@@ -106,7 +106,7 @@ PHASE_ACCEPTANCE_GATES:
 artifacts/project-state/planning/phase5-9-acceptance-gates.md
 
 ARCHITECTURE_STATUS:
-PROVISIONAL PLANNING V2 / CANONICAL AFTER PROTECTED MERGE / NOT IMPLEMENTED
+CANONICAL PLANNING V2 / NOT IMPLEMENTED
 ```
 
 ## Fresh state anchor
@@ -143,8 +143,9 @@ PROVISIONAL PLANNING V2 / CANONICAL AFTER PROTECTED MERGE / NOT IMPLEMENTED
 - Phase 2: **CLOSED / FROZEN**.
 - Phase 3: **CLOSED / FROZEN**.
 - Phase 4: **CLOSED / FROZEN**.
-- Context / Memory / Retrieval architecture: **PROVISIONAL PLANNING V2 / CANONICAL AFTER PROTECTED MERGE / NOT IMPLEMENTED**.
-- Phase 5: **BLOCKED / NOT STARTED**.
+- Context / Memory / Retrieval architecture: **CANONICAL PLANNING V2 / NOT IMPLEMENTED**.
+- Foundation Hardening: **IMPLEMENTED / LOCALLY VERIFIED / PROTECTED-MERGE ADMISSION CANDIDATE**.
+- Phase 5: **READY FOR SEPARATE PHASE 5A ADMISSION / NOT STARTED**.
 - Phases 6–9: **NOT STARTED**.
 - POWER 3.8.0: **NO-GO**.
 
@@ -161,7 +162,7 @@ PROVISIONAL PLANNING V2 / CANONICAL AFTER PROTECTED MERGE / NOT IMPLEMENTED
 | PR #402 | DEFERRED / CLOSED WITHOUT MERGE | Broad maintenance bundle; split future admissions required |
 | PR #407 | SUPERSEDED / CLOSED WITHOUT MERGE | Historical pre-HF evidence retained for auditability |
 | Final integration | CLOSED / FINAL INTEGRATION VERIFIED | Current main graph, locks/exports, tests, security, package, upgrade, Docs, and CodeQL passed |
-| Foundation Hardening | PLANNED / NOT STARTED / NEXT GATE | F1–F5 contract before Phase 5 |
+| Foundation Hardening | ADMISSION CANDIDATE / IMPLEMENTED / LOCALLY VERIFIED | F1–F5 contract; closed only by protected normal merge of the exact Foundation PR |
 
 ## Actions #396 exact objects
 
@@ -276,8 +277,8 @@ CONTROLLED DEPENDENCY REFRESH = CLOSED / FINAL INTEGRATION VERIFIED
 PR #402 = CLOSED WITHOUT MERGE / DEFERRED
 PR #407 = CLOSED WITHOUT MERGE / SUPERSEDED HISTORICAL EVIDENCE
 ACTIONS #396 = CLOSED / MERGED
-FOUNDATION HARDENING = NEXT GATE / PLANNED / NOT STARTED
-PHASE 5 = BLOCKED / NOT STARTED
+FOUNDATION HARDENING = ADMISSION CANDIDATE / IMPLEMENTED / LOCALLY VERIFIED / CLOSED ONLY WHEN EXACT PR IS PROTECTED-MERGED
+PHASE 5 = READY FOR SEPARATE PHASE 5A ADMISSION / NOT STARTED
 ```
 
 The dependency surfaces and Actions admission were accepted through normal
@@ -288,14 +289,14 @@ Foundation Hardening. POWER 3.8.0 cannot be released from this state.
 ## Canonical governance status
 
 The prior governance and dependency merges are canonical on protected `main`;
-this consolidated course-correction branch becomes the next canonical snapshot
-only after its protected normal merge:
+the Foundation Hardening candidate below becomes closed only after its protected
+normal merge:
 
 - Governance branch: `docs/power-3.8-final-integration-course-correction`.
 - Prior governance bootstrap merge: `4b49e00c75866fa57f71e7bef61547915f7e01db`,
   with GitHub `verified=true`, `reason=valid`.
-- The final governance PR and protected merge SHA are intentionally resolved
-  from GitHub after publication; no future SHA is fabricated in this snapshot.
+- Governance PR #413 is protected-merged as `95f8cadd7e90ef4b16773b3c45bbc9ab40569e7a`;
+  no future Foundation merge SHA is fabricated in this candidate snapshot.
 - Post-governance state PR #409 and CI admission repair PR #410 are merged on
   protected `main`.
 - The prior `docs/power-3.8-premerge-state-publication` branch remains
@@ -306,11 +307,11 @@ only after its protected normal merge:
 
 ## Next authorized work
 
-1. Independently audit and admit Pre-Phase-5 Foundation Hardening from fresh
-   live `main`.
-2. If Foundation Hardening passes, create a fresh bounded Phase 5A candidate
-   from the then-current protected `main`; do not start Phase 5 in this gate.
-3. Keep Phase 5–9 runtime work, version bumps, tags, releases, and POWER 3.8.0
+1. Protected normal merge and independent post-merge verification of the
+   Foundation Hardening candidate.
+2. Then create a fresh bounded Phase 5A candidate from the then-current
+   protected `main`; do not start Phase 5A in this gate.
+3. Keep Phase 5B–9 runtime work, version bumps, tags, releases, and POWER 3.8.0
    publication blocked until each declared gate is independently closed.
 
 ## Do not start
@@ -319,8 +320,7 @@ only after its protected normal merge:
   dependency candidate must record its exact base/head/tree/parent, diff,
   hashes, tests, security, CI, and policy evidence.
 - Do not merge, auto-merge, force-push, or bypass protection.
-- Do not start Foundation Hardening implementation, Phase 5, or later phases
-  from this governance gate.
+- Do not start Phase 5A implementation or later phases in this gate.
 - Do not bump the public version, create a tag, create a release, or publish
   `POWER 3.8.0`.
 - Do not treat candidate or evidence-branch documents as `MERGED MAIN` evidence.

--- a/docs/plans/POWER_3.8_DEVELOPMENT_PROTOCOL.md
+++ b/docs/plans/POWER_3.8_DEVELOPMENT_PROTOCOL.md
@@ -395,19 +395,20 @@ Current state after the protected governance and HF merges:
 CONTROLLED DEPENDENCY REFRESH: CLOSED / FINAL INTEGRATION VERIFIED
 PR #402: CLOSED WITHOUT MERGE / DEFERRED
 PR #407: CLOSED WITHOUT MERGE / SUPERSEDED HISTORICAL EVIDENCE
-CONTEXT/MEMORY/RETRIEVAL ARCHITECTURE: PROVISIONAL PLANNING V2 / CANONICAL AFTER PROTECTED MERGE / NOT IMPLEMENTED
-FOUNDATION HARDENING: NEXT RUNTIME GATE / NOT STARTED
+CONTEXT/MEMORY/RETRIEVAL ARCHITECTURE: CANONICAL PLANNING V2 / NOT IMPLEMENTED
+FOUNDATION HARDENING: ADMISSION CANDIDATE / IMPLEMENTED / LOCALLY VERIFIED / PROTECTED MERGE REQUIRED
 ACTIONS #396: CLOSED / MERGED
-PHASE 5: BLOCKED / NOT STARTED
+PHASE 5: READY FOR SEPARATE PHASE 5A ADMISSION / NOT STARTED
 PUBLIC VERSION: 3.7.11
 POWER 3.8.0: NO-GO
 ```
 
 The HF and Actions merge receipts are retained `MERGED MAIN` evidence. Their
 candidate epochs are retained `REMOTE EXACT-HEAD`/historical evidence and are
-not themselves merged-main proof. Do not start Foundation Hardening or Phase 5–9, version bumps,
-tags, releases, release images, or final release notes from this snapshot;
-Foundation Hardening requires its own bounded admission.
+not themselves merged-main proof. Do not start Phase 5A–9, version bumps, tags,
+releases, release images, or final release notes from this snapshot. Foundation
+Hardening is locally implemented here but becomes `MERGED MAIN` only after the
+protected normal merge and independent post-merge verification.
 
 ## Cross-links
 

--- a/docs/plans/POWER_3.8_EXECUTION_ROADMAP.md
+++ b/docs/plans/POWER_3.8_EXECUTION_ROADMAP.md
@@ -38,10 +38,10 @@ Controlled Dependency Refresh
          └── Final integration admission — CLOSED / VERIFIED
           ↓
 Pre-Phase-5 Foundation Hardening
-PLANNED / NOT STARTED / NEXT RUNTIME GATE
-          ↓
+ADMISSION CANDIDATE / IMPLEMENTED / LOCALLY VERIFIED / PROTECTED MERGE REQUIRED
+           ↓
 Phase 5A–5H — Retrieval contracts, router, scope, planner, shadow, dense validity, MCP, closure
-BLOCKED / NOT STARTED
+READY FOR SEPARATE PHASE 5A ADMISSION / NOT STARTED
          ↓
 Phase 6 — Agent Capture & Integrations
 NOT STARTED
@@ -74,8 +74,8 @@ NO-GO
 | PR #402 | DEFERRED / CLOSED WITHOUT MERGE | Broad unsafe maintenance bundle; future updates require bounded split admissions |
 | PR #407 | SUPERSEDED / CLOSED WITHOUT MERGE | Historical pre-HF evidence retained for auditability |
 | Final integration | CLOSED / FINAL INTEGRATION VERIFIED | Current main dependency graph, security, package, upgrade, frozen regression, Docs, and CodeQL evidence passed |
-| Foundation Hardening | PLANNED / NOT STARTED / NEXT RUNTIME GATE | F1–F5 authority, principal, retrieval boundary, receipt, and deadline contract |
-| Phase 5 | BLOCKED / NOT STARTED | No implementation authorized |
+| Foundation Hardening | ADMISSION CANDIDATE / IMPLEMENTED / LOCALLY VERIFIED | F1–F5 authority, principal, retrieval boundary, receipt, and deadline contract; protected merge still required |
+| Phase 5 | READY FOR SEPARATE PHASE 5A ADMISSION / NOT STARTED | No implementation authorized in this gate |
 | Phases 6–9 | NOT STARTED | No work authorized |
 | POWER 3.8.0 | NO-GO | No tag, release, or public version change |
 
@@ -101,8 +101,9 @@ dependency update:
 8. **Final integration admission — complete.** Current main dependency,
    security, package, upgrade, frozen-regression, Docs, and CodeQL evidence
    passed on the exact protected main.
-9. **Foundation Hardening — next runtime gate.** It is planned/not started and
-   must be admitted before Phase 5.
+9. **Foundation Hardening — current implementation candidate.** It is locally
+   verified and closes only through its protected normal merge; Phase 5 remains
+   separately gated.
 
 The controlled refresh does not authorize a public version bump, tag, release,
 Phase 5, or any later phase.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -17,7 +17,7 @@ REST verification:
 - [POWER 3.8 — Context / Memory / Retrieval Architecture](POWER_3.8_CONTEXT_MEMORY_ARCHITECTURE.md)
 - [Project-state handoff protocol](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/README.md)
 - [Planning artifacts](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/planning/README.md)
-- [Latest Foundation Hardening handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-09T162533Z_pre-phase5-foundation-hardening.md)
+- [Latest Foundation Hardening handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-09T163501Z_pre-phase5-foundation-hardening.md)
 - [Historical HF post-merge handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-08T095310Z_hf-406_post-merge.md)
 
 > Controlled Dependency Refresh is **CLOSED / FINAL INTEGRATION VERIFIED**.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -17,16 +17,17 @@ REST verification:
 - [POWER 3.8 — Context / Memory / Retrieval Architecture](POWER_3.8_CONTEXT_MEMORY_ARCHITECTURE.md)
 - [Project-state handoff protocol](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/README.md)
 - [Planning artifacts](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/planning/README.md)
-- [Latest final-integration handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-09T065950Z_controlled-dependency-refresh_final-integration.md)
+- [Latest Foundation Hardening handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-09T162533Z_pre-phase5-foundation-hardening.md)
 - [Historical HF post-merge handoff](https://github.com/weby-homelab/power-framework/blob/main/artifacts/project-state/handoffs/2026-09-08T095310Z_hf-406_post-merge.md)
 
 > Controlled Dependency Refresh is **CLOSED / FINAL INTEGRATION VERIFIED**.
 > PR #402 is **DEFERRED / CLOSED WITHOUT MERGE** and PR #407 is
 > **SUPERSEDED HISTORICAL EVIDENCE / CLOSED WITHOUT MERGE**. The
-> context/memory/retrieval package is **CANONICAL PLANNING V2** only after this
-> governance package is protected-merged. Pre-Phase-5 Foundation Hardening is
-> the next runtime gate; Actions #396 is already closed/merged, while Phase 5
-> and all later runtime work are not started by this snapshot.
+> context/memory/retrieval package is **CANONICAL PLANNING V2**. Foundation
+> Hardening is **IMPLEMENTED / LOCALLY VERIFIED / PROTECTED-MERGE CANDIDATE**;
+> it becomes `MERGED MAIN` only after the exact protected normal merge. Actions
+> #396 is already closed/merged, while Phase 5A and all later runtime work are
+> not started by this snapshot.
 
 > Links to `artifacts/` are GitHub evidence permalinks intentionally outside
 > the MkDocs navigation tree; they are not local documentation targets.
@@ -49,8 +50,8 @@ To recover the current POWER 3.8 state:
    exact head, required checks, reviews, and protected-branch policy, before
    acting or attempting a new gate action.
 8. Treat this snapshot as repository governance memory and live GitHub as
-   mutable operational truth. The next bounded session audits only
-   Pre-Phase-5 Foundation Hardening; it must not start Phase 5.
+   mutable operational truth. Finish the protected Foundation merge/readback,
+   then prepare only the separate Phase 5A admission; do not start Phase 5A here.
 
 ## CURRENT PLANNING CONTRACTS
 
@@ -81,7 +82,7 @@ phase report, release artifact, or authorization to start Phase 5.
 | HISTORICAL EVIDENCE | Immutable prior gate or stale candidate record | Prior handoffs, closed #407 evidence |
 | PHASE EVIDENCE | Executed proof for a named phase/gate | Phase reports and receipts |
 | ARCHITECTURAL DECISION | Durable decision requiring an ADR | `docs/adr/` records |
-| NEXT RUNTIME GATE | Authorized sequence position, not implementation | Foundation Hardening |
+| NEXT RUNTIME GATE | Authorized sequence position, not implementation | Foundation protected merge; then Phase 5A |
 
 ## HISTORICAL PLAN
 
@@ -108,8 +109,9 @@ They are not a substitute for current-state projection or live GitHub truth:
 HF #406, Actions #396, and final-integration checks remain attached to their PR,
 commit, and handoff evidence. The context/memory/retrieval files under
 `artifacts/project-state/planning/` are pre-implementation planning contracts,
-not phase evidence. The final dependency evidence is `MERGED MAIN`; the next
-runtime gate is Foundation Hardening and Phase 5 remains `BLOCKED / NOT STARTED`.
+not phase evidence. The final dependency evidence is `MERGED MAIN`; Foundation
+Hardening is the current protected-merge candidate and Phase 5A remains
+`NOT STARTED`.
 
 ## ARCHITECTURAL DECISION
 

--- a/src/power_framework/core/__init__.py
+++ b/src/power_framework/core/__init__.py
@@ -17,7 +17,17 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING
 
-from .application import ApplicationEnvelope, ApplicationService, AuditReceipt, RequestContext
+from .application import (
+    MAX_RESULT_BYTES,
+    ApplicationEnvelope,
+    ApplicationService,
+    AuditReceipt,
+    CompletedAfterBudgetError,
+    CompletedAfterDeadlineError,
+    DeadlineExceededError,
+    RequestContext,
+    ResultBudgetExceededError,
+)
 from .chunker import SemanticChunker
 from .connect import ConnectPlan, apply_connect_plan, build_connect_plan
 from .control_plane import (
@@ -110,6 +120,7 @@ from .parser import (
     read_file_content,
     validate_metadata,
 )
+from .principal import Principal, PrincipalBinding
 from .provenance import (
     PROVENANCE_SCHEMA_VERSION,
     EvidenceCapture,
@@ -230,6 +241,7 @@ __all__ = [
     "CANONICAL_SEARCH_MODES",
     "DEFAULT_SEARCH_MODE",
     "MAX_DESCRIPTION_LENGTH",
+    "MAX_RESULT_BYTES",
     "MAX_TITLE_LENGTH",
     "NOTE_TYPE_ORDER",
     "PARA_FOLDERS",
@@ -241,9 +253,12 @@ __all__ = [
     "ApplicationEnvelope",
     "ApplicationService",
     "AuditReceipt",
+    "CompletedAfterBudgetError",
+    "CompletedAfterDeadlineError",
     "ConnectPlan",
     "ContentDedupDetector",
     "ContradictionDetector",
+    "DeadlineExceededError",
     "EmbeddingManager",
     "EvidenceCapture",
     "FreshnessScorer",
@@ -267,6 +282,8 @@ __all__ = [
     "NoteStatus",
     "NoteType",
     "OKFMetadata",
+    "Principal",
+    "PrincipalBinding",
     "ProvenanceError",
     "ProvenanceRecord",
     "QueryExpander",
@@ -275,6 +292,7 @@ __all__ = [
     "RelationSuggestion",
     "RequestContext",
     "RerankerManager",
+    "ResultBudgetExceededError",
     "SearchResult",
     "SemanticChunker",
     "Sensitivity",

--- a/src/power_framework/core/application.py
+++ b/src/power_framework/core/application.py
@@ -10,13 +10,16 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
+import math
 import re
 import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast
 
 from .application_models import (
     SourceListRequest,
@@ -24,6 +27,7 @@ from .application_models import (
 )
 from .capabilities import manifest
 from .decision_service import DecisionService
+from .errors import ConflictError
 from .healer import heal_vault
 from .indexer import run_generate_hierarchical_index, run_generate_sub_index, scan_folder_notes
 from .linter import archive_stale_notes, run_lint_report
@@ -37,6 +41,7 @@ from .memory_api import (
 from .models import PARA_FOLDERS, MemoryKind, MemoryMetadata, NoteType, OKFMetadata, WritePolicy
 from .mutation import execute_vault_mutation
 from .parser import build_frontmatter
+from .principal import Principal
 from .searcher import (
     DEFAULT_SEARCH_MODE,
     format_untrusted_search_envelope,
@@ -56,7 +61,47 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
 
+logger = logging.getLogger(__name__)
+
+
 ApplicationAuthority = Literal["read-only", "propose", "apply"]
+FailureOutcome = Literal[
+    "rejected_before_start",
+    "cancelled",
+    "failed",
+    "completed_after_deadline",
+    "completed_after_budget",
+]
+FailureCode = Literal[
+    "permission_denied",
+    "invalid_request",
+    "not_found",
+    "conflict",
+    "deadline_exceeded",
+    "cancelled",
+    "completed_after_deadline",
+    "result_budget_exceeded",
+    "internal_error",
+]
+
+MAX_RESULT_BYTES = 1_000_000
+_EMPTY_RESULT_SHA256 = hashlib.sha256(b"").hexdigest()
+
+
+class DeadlineExceededError(TimeoutError):
+    """A request deadline was already exhausted or a read exceeded its budget."""
+
+
+class CompletedAfterDeadlineError(TimeoutError):
+    """A synchronous operation finished after its deadline and may have committed."""
+
+
+class ResultBudgetExceededError(ValueError):
+    """A serialized application result exceeded the caller-lower-only ceiling."""
+
+
+class CompletedAfterBudgetError(ResultBudgetExceededError):
+    """A mutation completed before its result was found to exceed the budget."""
 
 
 @dataclass(frozen=True)
@@ -68,6 +113,9 @@ class RequestContext:
     idempotency_key: str | None = None
     deadline_ms: int | None = None
     request_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    principal: Principal | None = field(default_factory=Principal.local_cli)
+    deadline_at: float | None = None
+    max_result_bytes: int = MAX_RESULT_BYTES
 
     def __post_init__(self) -> None:
         if not isinstance(self.actor, str) or not self.actor.strip():
@@ -80,6 +128,29 @@ class RequestContext:
             raise ValueError("deadline_ms must be positive")
         if not isinstance(self.request_id, str) or not _TOKEN_PATTERN.fullmatch(self.request_id):
             raise ValueError("request_id must be a safe token")
+        if self.principal is None or not isinstance(self.principal, Principal):
+            raise ValueError("principal binding is required")
+        if self.deadline_at is not None and (
+            not isinstance(self.deadline_at, (int, float)) or not math.isfinite(self.deadline_at)
+        ):
+            raise ValueError("deadline_at must be a finite monotonic timestamp")
+        if (
+            isinstance(self.max_result_bytes, bool)
+            or not isinstance(self.max_result_bytes, int)
+            or not 1 <= self.max_result_bytes <= MAX_RESULT_BYTES
+        ):
+            raise ValueError(f"max_result_bytes must be between 1 and {MAX_RESULT_BYTES}")
+        if self.deadline_ms is not None and self.deadline_at is None:
+            object.__setattr__(
+                self,
+                "deadline_at",
+                time.monotonic() + (self.deadline_ms / 1000),
+            )
+
+    @property
+    def result_budget_bytes(self) -> int:
+        """Compatibility name for the bounded serialized-result budget."""
+        return self.max_result_bytes
 
 
 @dataclass(frozen=True)
@@ -93,9 +164,15 @@ class AuditReceipt:
     idempotency_key: str | None
     data_sha256: str
     duration_ms: int
+    outcome: str = "completed"
+    principal_ref: str | None = None
+    principal_binding: str | None = None
+    error_code: str | None = None
+    budget_ms: int | None = None
+    result_budget_bytes: int | None = None
 
     def as_dict(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "schema_version": self.schema_version,
             "operation": self.operation,
             "status": self.status,
@@ -104,6 +181,20 @@ class AuditReceipt:
             "data_sha256": self.data_sha256,
             "duration_ms": self.duration_ms,
         }
+        # Keep the successful power.receipt.v1 wire shape stable. Failure and
+        # late-completion receipts opt into the additional bounded evidence.
+        if self.status != "ok" or self.outcome != "completed":
+            payload.update(
+                {
+                    "outcome": self.outcome,
+                    "principal_ref": self.principal_ref,
+                    "principal_binding": self.principal_binding,
+                    "error_code": self.error_code,
+                    "budget_ms": self.budget_ms,
+                    "result_budget_bytes": self.result_budget_bytes,
+                }
+            )
+        return payload
 
 
 @dataclass(frozen=True)
@@ -127,6 +218,8 @@ class ApplicationEnvelope:
             "data": self.data,
             "receipt": self.receipt.as_dict(),
             "request_id": self.receipt.request_id,
+            "principal_ref": self.receipt.principal_ref,
+            "principal_binding": self.receipt.principal_binding,
             "actual_capability": self.actual_capability,
             "source_revision": self.source_revision,
             "degraded_reason": self.degraded_reason,
@@ -199,7 +292,7 @@ class ApplicationService:
     ) -> None:
         self.vault_dir = Path(vault_dir).expanduser().resolve()
         self._audit_hook = audit_hook
-        self._search_fn = search_fn or search_vault
+        self._search_fn = search_fn or partial(search_vault, allow_search_db_override=False)
         self.task_service = task_service or TaskService(self.vault_dir, create_vault=False)
         self.decision_service = DecisionService(self.vault_dir, task_service=self.task_service)
 
@@ -223,10 +316,18 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Retrieve untrusted, provenance-bearing source material."""
-        if not query.strip():
-            raise ValueError("Search query cannot be empty")
-        if not 1 <= max_results <= 100:
-            raise ValueError("max_results must be between 1 and 100")
+        if not isinstance(query, str) or not query.strip():
+            self._reject_request("retrieve", context, ValueError("Search query cannot be empty"))
+        if (
+            isinstance(max_results, bool)
+            or not isinstance(max_results, int)
+            or not 1 <= max_results <= 100
+        ):
+            self._reject_request(
+                "retrieve",
+                context,
+                ValueError("max_results must be between 1 and 100"),
+            )
 
         def execute() -> dict[str, object]:
             results = self._search_fn(
@@ -262,9 +363,24 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Persist a reviewable proposal, never the target note."""
-        request = context or RequestContext(authority="propose")
+        request = self._mutation_context(context, operation="propose")
         if request.authority not in {"propose", "apply"}:
-            raise PermissionError("proposal requires propose authority")
+            self._reject_mutation(
+                "propose", context, PermissionError("proposal requires propose authority")
+            )
+        if not isinstance(rel_path, str) or not isinstance(content, str):
+            self._reject_request(
+                "propose",
+                request,
+                ValueError("proposal path and content must be strings"),
+            )
+        estimated_result_bytes = len(content.encode("utf-8")) + 1024
+        if estimated_result_bytes > request.max_result_bytes:
+            error = ResultBudgetExceededError(
+                "proposal result exceeds the application result budget"
+            )
+            self._emit_failure_receipt("propose", request, error, duration_ms=0)
+            raise error
         return self._run(
             "propose",
             request,
@@ -274,6 +390,7 @@ class ApplicationService:
                 content,
                 idempotency_key=request.idempotency_key,
             ),
+            mutation=True,
         )
 
     def apply(
@@ -284,9 +401,13 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Apply a proposal only with explicit approval authority."""
-        request = context or RequestContext(authority="apply")
-        if not approved or request.authority != "apply":
-            raise PermissionError("apply requires explicit approved=True and apply authority")
+        request = self._mutation_context(context, operation="apply", require_apply=True)
+        if type(approved) is not bool or not approved or request.authority != "apply":
+            self._reject_mutation(
+                "apply",
+                context,
+                PermissionError("apply requires explicit approved=True and apply authority"),
+            )
         return self._run(
             "apply",
             request,
@@ -296,6 +417,7 @@ class ApplicationService:
                 approved=True,
                 idempotency_key=request.idempotency_key,
             ),
+            mutation=True,
         )
 
     def apply_proposal(
@@ -306,9 +428,13 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Apply a durable content-addressed proposal by ID only."""
-        request = context or RequestContext(authority="apply")
-        if not approved or request.authority != "apply":
-            raise PermissionError("apply requires explicit approved=True and apply authority")
+        request = self._mutation_context(context, operation="apply", require_apply=True)
+        if type(approved) is not bool or not approved or request.authority != "apply":
+            self._reject_mutation(
+                "apply",
+                context,
+                PermissionError("apply requires explicit approved=True and apply authority"),
+            )
         return self._run(
             "apply",
             request,
@@ -318,19 +444,69 @@ class ApplicationService:
                 approved=True,
                 idempotency_key=request.idempotency_key,
             ),
+            mutation=True,
         )
 
-    @staticmethod
-    def _mutation_context(context: RequestContext | None) -> RequestContext:
-        """Require an explicit application authority for a write use case."""
-        request = context or RequestContext(authority="apply")
-        if request.authority not in {"propose", "apply"}:
-            raise PermissionError("mutation requires propose or apply authority")
-        return request
+    def _reject_request(
+        self,
+        operation: str,
+        context: RequestContext | None,
+        error: Exception,
+    ) -> NoReturn:
+        """Emit bounded evidence for an admission failure before re-raising it."""
+        self._emit_failure_receipt(operation, context, error, duration_ms=0)
+        raise error
+
+    def _reject_mutation(
+        self,
+        operation: str,
+        context: RequestContext | None,
+        error: PermissionError,
+    ) -> NoReturn:
+        """Reject a mutation while preserving a bounded failure receipt."""
+        self._reject_request(operation, context, error)
+
+    def _mutation_context(
+        self,
+        context: RequestContext | None,
+        *,
+        operation: str,
+        require_apply: bool = False,
+    ) -> RequestContext:
+        """Require an explicit, currently valid application mutation context."""
+        if context is None:
+            self._reject_mutation(
+                operation,
+                None,
+                PermissionError("mutation requires an explicit RequestContext"),
+            )
+        if context.principal is None or not context.principal.is_valid():
+            self._reject_mutation(
+                operation,
+                context,
+                PermissionError("mutation requires a valid, non-expired principal binding"),
+            )
+        if context.authority not in {"propose", "apply"}:
+            self._reject_mutation(
+                operation,
+                context,
+                PermissionError("mutation requires propose or apply authority"),
+            )
+        if require_apply and context.authority != "apply":
+            self._reject_mutation(
+                operation,
+                context,
+                PermissionError("mutation requires apply authority"),
+            )
+        return context
 
     def generate_index(self, *, context: RequestContext | None = None) -> ApplicationEnvelope:
         """Regenerate the hierarchical index under the canonical vault lock."""
-        request = self._mutation_context(context)
+        request = self._mutation_context(
+            context,
+            operation="index.generate",
+            require_apply=True,
+        )
         return self._run(
             "index.generate",
             request,
@@ -339,6 +515,7 @@ class ApplicationService:
                     self.vault_dir, lambda: run_generate_hierarchical_index(self.vault_dir)
                 )
             },
+            mutation=True,
         )
 
     def ensure_sub_index(
@@ -349,15 +526,31 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Generate and return one bounded P.A.R.A. catalog page."""
-        request = self._mutation_context(context)
+        request = self._mutation_context(
+            context,
+            operation="index.ensure-sub-index",
+            require_apply=True,
+        )
         if category not in PARA_FOLDERS:
-            raise ValueError(
-                f"Invalid category: {category}. Must be one of: {', '.join(PARA_FOLDERS)}"
+            self._reject_request(
+                "index.ensure-sub-index",
+                request,
+                ValueError(
+                    f"Invalid category: {category}. Must be one of: {', '.join(PARA_FOLDERS)}"
+                ),
             )
         if not (self.vault_dir / category).is_dir():
-            raise ValueError(f"Category folder not found: {category}")
+            self._reject_request(
+                "index.ensure-sub-index",
+                request,
+                ValueError(f"Category folder not found: {category}"),
+            )
         if isinstance(page, bool) or not isinstance(page, int) or page < 1:
-            raise ValueError("page must be a positive integer starting at 1")
+            self._reject_request(
+                "index.ensure-sub-index",
+                request,
+                ValueError("page must be a positive integer starting at 1"),
+            )
 
         def execute() -> dict[str, object]:
             notes = scan_folder_notes(self.vault_dir).get(category, [])
@@ -371,7 +564,7 @@ class ApplicationService:
 
             return execute_vault_mutation(self.vault_dir, mutate)
 
-        return self._run("index.ensure-sub-index", request, execute)
+        return self._run("index.ensure-sub-index", request, execute, mutation=True)
 
     def sync_vault(
         self,
@@ -383,7 +576,7 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Publish an atomic search generation through the application boundary."""
-        request = self._mutation_context(context)
+        request = self._mutation_context(context, operation="index.sync", require_apply=True)
 
         def build() -> dict[str, object]:
             from .generation_index import (
@@ -448,6 +641,7 @@ class ApplicationService:
             "index.sync",
             request,
             lambda: execute_vault_mutation(self.vault_dir, build),
+            mutation=True,
         )
 
     def ingest_note(
@@ -463,18 +657,36 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Create one validated note and publish all required projections."""
-        request = self._mutation_context(context)
+        request = self._mutation_context(
+            context,
+            operation="memory.ingest-note",
+            require_apply=True,
+        )
+        if not isinstance(name, str) or not isinstance(content, str):
+            self._reject_request(
+                "memory.ingest-note",
+                request,
+                ValueError("note name and content must be strings"),
+            )
         note_name = name if name.endswith(".md") else f"{name}.md"
         try:
             target_file = resolve_path_in_vault(
                 self.vault_dir, note_name, allowed_directories=PARA_FOLDERS
             )
-        except ValueError as exc:
-            raise ValueError(
-                "Invalid note path; use an existing PARA directory and a Markdown filename."
-            ) from exc
-        if target_file.exists():
-            raise FileExistsError(f"Note already exists at {note_name}")
+        except ValueError:
+            self._reject_request(
+                "memory.ingest-note",
+                request,
+                ValueError(
+                    "Invalid note path; use an existing PARA directory and a Markdown filename."
+                ),
+            )
+        if target_file.exists() and request.idempotency_key is None:
+            self._reject_request(
+                "memory.ingest-note",
+                request,
+                FileExistsError(f"Note already exists at {note_name}"),
+            )
 
         metadata = OKFMetadata(
             type=NoteType(note_type),
@@ -492,6 +704,21 @@ class ApplicationService:
             timestamp=datetime.now(UTC),
         )
         full_content = f"{build_frontmatter(metadata)}\n\n{content}\n"
+        idempotency_fingerprint = hashlib.sha256(
+            json.dumps(
+                {
+                    "name": name,
+                    "note_type": note_type,
+                    "title": title,
+                    "description": description,
+                    "content": content,
+                    "resource": resource,
+                    "tags": tags or [],
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            ).encode("utf-8")
+        ).hexdigest()
 
         def execute() -> dict[str, object]:
             date_str = datetime.now(UTC).strftime("%Y-%m-%d")
@@ -508,6 +735,10 @@ class ApplicationService:
                 allowed_directories=PARA_FOLDERS,
                 operation="mcp.ingest_note",
                 log_entry=log_entry,
+                idempotency_key=request.idempotency_key,
+                idempotency_fingerprint=(
+                    idempotency_fingerprint if request.idempotency_key is not None else None
+                ),
             )
             lint_result = run_lint_report(self.vault_dir)
             return {
@@ -522,7 +753,7 @@ class ApplicationService:
                 "receipt": receipt,
             }
 
-        return self._run("memory.ingest-note", request, execute)
+        return self._run("memory.ingest-note", request, execute, mutation=True)
 
     def synthesize_session(
         self,
@@ -538,14 +769,28 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Create a governed session artifact through the core ingest workflow."""
-        request = self._mutation_context(context)
+        request = self._mutation_context(
+            context,
+            operation="synthesize.session",
+            require_apply=True,
+        )
+        if not isinstance(name, str) or not isinstance(content, str):
+            self._reject_request(
+                "synthesize.session",
+                request,
+                ValueError("session name and content must be strings"),
+            )
         note_name = name if name.endswith(".md") else f"{name}.md"
         try:
             resolve_path_in_vault(self.vault_dir, note_name, allowed_directories=PARA_FOLDERS)
-        except ValueError as exc:
-            raise ValueError(
-                "Invalid note path; use an existing PARA directory and a Markdown filename."
-            ) from exc
+        except ValueError:
+            self._reject_request(
+                "synthesize.session",
+                request,
+                ValueError(
+                    "Invalid note path; use an existing PARA directory and a Markdown filename."
+                ),
+            )
         return self._run(
             "synthesize.session",
             request,
@@ -560,8 +805,10 @@ class ApplicationService:
                     related=related,
                     owner=owner,
                     vault_path=self.vault_dir,
+                    idempotency_key=request.idempotency_key,
                 )
             },
+            mutation=True,
         )
 
     def archive_notes(
@@ -571,7 +818,15 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Preview or apply stale-note archival through the core boundary."""
-        request = context if dry_run else self._mutation_context(context)
+        request = (
+            context or RequestContext()
+            if dry_run
+            else self._mutation_context(
+                context,
+                operation="maintenance.archive-notes",
+                require_apply=True,
+            )
+        )
         return self._run(
             "maintenance.archive-notes",
             request,
@@ -585,6 +840,7 @@ class ApplicationService:
                     )
                 )
             },
+            mutation=not dry_run,
         )
 
     def heal_frontmatter(
@@ -594,7 +850,15 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Preview or apply frontmatter healing through the core boundary."""
-        request = context if dry_run else self._mutation_context(context)
+        request = (
+            context or RequestContext()
+            if dry_run
+            else self._mutation_context(
+                context,
+                operation="maintenance.heal-frontmatter",
+                require_apply=True,
+            )
+        )
         return self._run(
             "maintenance.heal-frontmatter",
             request,
@@ -608,6 +872,7 @@ class ApplicationService:
                     )
                 )
             },
+            mutation=not dry_run,
         )
 
     def task(
@@ -619,7 +884,15 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Compatibility facade over the canonical TaskService v2 lifecycle."""
-        request = context or RequestContext()
+        request = (
+            self._mutation_context(
+                context,
+                operation="task",
+                require_apply=action == "advance",
+            )
+            if action in {"create", "advance"}
+            else context or RequestContext()
+        )
         values = dict(values or {})
 
         def execute() -> dict[str, object] | list[dict[str, object]]:
@@ -638,6 +911,9 @@ class ApplicationService:
                 task_authority = str(values.get("authority", request.authority))
                 if task_authority not in {"read-only", "propose", "apply"}:
                     raise ValueError("unsupported task authority")
+                authority_rank = {"read-only": 0, "propose": 1, "apply": 2}
+                if authority_rank[task_authority] > authority_rank[request.authority]:
+                    raise PermissionError("task authority cannot exceed request authority")
                 objective = str(values.get("objective", ""))
                 return self.task_service.create_task(
                     task_id=task_id,
@@ -670,13 +946,21 @@ class ApplicationService:
                 if not new_state:
                     raise ValueError("task advance requires new_state or a supported legacy action")
                 expected_revision = values.pop("expected_revision", None)
-                if expected_revision is None:
-                    raise ValueError("task advance requires expected_revision")
+                if (
+                    expected_revision is None
+                    or isinstance(expected_revision, bool)
+                    or not isinstance(expected_revision, int)
+                    or expected_revision < 1
+                ):
+                    raise ValueError("task advance requires a positive expected_revision")
 
                 current = self.task_service.get_task(task_id)
                 if current is None:
                     raise FileNotFoundError(f"Task {task_id} not found")
-                approved = bool(values.pop("approved", False))
+                approved_value = values.pop("approved", False)
+                if not isinstance(approved_value, bool):
+                    raise ValueError("approved must be a boolean")
+                approved = approved_value
                 blocker = values.pop("blocker", None)
                 required_approval = values.pop("required_approval", None)
                 changed_artifacts = values.pop("changed_artifacts", None)
@@ -720,7 +1004,7 @@ class ApplicationService:
                     task_id,
                     new_state=cast("Any", new_state),
                     actor=request.actor,
-                    expected_revision=cast("int", expected_revision),
+                    expected_revision=expected_revision,
                     receipt_id=cast("str | None", values.pop("receipt_id", None)),
                     completion_postcondition=cast(
                         "str | None", values.pop("completion_postcondition", None)
@@ -734,7 +1018,12 @@ class ApplicationService:
                 ).model_dump()
             raise ValueError(f"unsupported task action: {action}")
 
-        return self._run("task", request, execute)
+        return self._run(
+            "task",
+            request,
+            execute,
+            mutation=action in {"create", "advance"},
+        )
 
     def fleet_status(self, *, context: RequestContext | None = None) -> ApplicationEnvelope:
         """Expose the optional fleet capability without a broken endpoint."""
@@ -756,8 +1045,12 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Read bounded, content-free transaction receipts through the boundary."""
-        if not 1 <= limit <= 1000:
-            raise ValueError("receipt limit must be between 1 and 1000")
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 1000:
+            self._reject_request(
+                "receipt",
+                context,
+                ValueError("receipt limit must be between 1 and 1000"),
+            )
         return self._run(
             "receipt",
             context,
@@ -785,7 +1078,10 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Read a note securely with path containment and ETag."""
-        req = SourceReadRequest(rel_path=rel_path, max_bytes=max_bytes)
+        try:
+            req = SourceReadRequest(rel_path=rel_path, max_bytes=max_bytes)
+        except (TypeError, ValueError) as error:
+            self._reject_request("source.read", context, error)
         return self._run(
             "source.read",
             context,
@@ -839,9 +1135,13 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Create a typed decision gate bound to one Task v2 revision."""
-        request = context or RequestContext(authority="propose")
+        request = self._mutation_context(context, operation="decision.create")
         if request.authority not in {"propose", "apply"}:
-            raise PermissionError("decision creation requires propose authority")
+            self._reject_mutation(
+                "decision.create",
+                context,
+                PermissionError("decision creation requires propose authority"),
+            )
         return self._run(
             "decision.create",
             request,
@@ -860,6 +1160,7 @@ class ApplicationService:
                 response_schema=cast("Any", response_schema),
                 expires_at=expires_at,
             ).model_dump(),
+            mutation=True,
         )
 
     def decision_list(
@@ -910,9 +1211,13 @@ class ApplicationService:
         context: RequestContext | None = None,
     ) -> ApplicationEnvelope:
         """Resolve a decision with actor/authority and binding checks."""
-        request = context or RequestContext(authority="apply")
+        request = self._mutation_context(context, operation="decision.resolve")
         if request.authority not in {"propose", "apply"}:
-            raise PermissionError("decision resolution requires proposal authority")
+            self._reject_mutation(
+                "decision.resolve",
+                context,
+                PermissionError("decision resolution requires proposal authority"),
+            )
 
         def execute() -> dict[str, object]:
             decision, receipt = self.decision_service.resolve_decision(
@@ -926,7 +1231,7 @@ class ApplicationService:
             )
             return {"decision": decision.model_dump(), "receipt": receipt.model_dump()}
 
-        return self._run("decision.resolve", request, execute)
+        return self._run("decision.resolve", request, execute, mutation=True)
 
     def task_create(
         self,
@@ -943,9 +1248,13 @@ class ApplicationService:
         **kwargs: Any,
     ) -> ApplicationEnvelope:
         """Create a durable Task v2."""
-        request = context or RequestContext(authority="propose")
+        request = self._mutation_context(context, operation="task.create")
         if request.authority not in {"propose", "apply"}:
-            raise PermissionError("task creation requires propose authority")
+            self._reject_mutation(
+                "task.create",
+                context,
+                PermissionError("task creation requires propose authority"),
+            )
         return self._run(
             "task.create",
             request,
@@ -962,6 +1271,7 @@ class ApplicationService:
                 idempotency_key=request.idempotency_key,
                 **kwargs,
             ).model_dump(),
+            mutation=True,
         )
 
     def task_transition(
@@ -976,9 +1286,26 @@ class ApplicationService:
         **kwargs: Any,
     ) -> ApplicationEnvelope:
         """Advance a Task v2 state."""
-        request = context or RequestContext(authority="apply")
+        request = self._mutation_context(
+            context,
+            operation="task.transition",
+            require_apply=True,
+        )
         if request.authority != "apply":
-            raise PermissionError("task transition requires apply authority")
+            self._reject_mutation(
+                "task.transition",
+                context,
+                PermissionError("task transition requires apply authority"),
+            )
+        if (
+            expected_revision is None
+            or isinstance(expected_revision, bool)
+            or not isinstance(expected_revision, int)
+            or expected_revision < 1
+        ):
+            error = ValueError("task transition requires a positive expected_revision")
+            self._emit_failure_receipt("task.transition", request, error, duration_ms=0)
+            raise error
         return self._run(
             "task.transition",
             request,
@@ -992,6 +1319,7 @@ class ApplicationService:
                 idempotency_key=request.idempotency_key,
                 **kwargs,
             ).model_dump(),
+            mutation=True,
         )
 
     def task_list(
@@ -1049,6 +1377,83 @@ class ApplicationService:
             ],
         )
 
+    @staticmethod
+    def _failure_code(error: Exception) -> FailureCode:
+        """Map internal exceptions to a bounded, non-content error category."""
+        if isinstance(error, CompletedAfterDeadlineError):
+            return "completed_after_deadline"
+        if isinstance(error, DeadlineExceededError):
+            return "deadline_exceeded"
+        if isinstance(error, PermissionError):
+            return "permission_denied"
+        if isinstance(error, FileNotFoundError):
+            return "not_found"
+        if isinstance(error, (FileExistsError, ConflictError)):
+            return "conflict"
+        if isinstance(error, ResultBudgetExceededError):
+            return "result_budget_exceeded"
+        if isinstance(error, (ValueError, TypeError)):
+            return "invalid_request"
+        if isinstance(error, TimeoutError):
+            return "deadline_exceeded"
+        return "internal_error"
+
+    def _emit_failure_receipt(
+        self,
+        operation: str,
+        context: RequestContext | None,
+        error: Exception,
+        *,
+        duration_ms: int,
+        outcome: FailureOutcome | None = None,
+    ) -> AuditReceipt:
+        """Send bounded failure evidence to the configured audit sink."""
+        principal = context.principal if context is not None else None
+        failure_outcome = outcome or (
+            "completed_after_deadline"
+            if isinstance(error, CompletedAfterDeadlineError)
+            else "completed_after_budget"
+            if isinstance(error, CompletedAfterBudgetError)
+            else "rejected_before_start"
+            if isinstance(error, DeadlineExceededError) and "before operation started" in str(error)
+            else "failed"
+        )
+        receipt = AuditReceipt(
+            schema_version="power.receipt.v1",
+            operation=operation,
+            status=failure_outcome,
+            request_id=context.request_id if context is not None else uuid.uuid4().hex,
+            idempotency_key=context.idempotency_key if context is not None else None,
+            data_sha256=_EMPTY_RESULT_SHA256,
+            duration_ms=max(0, duration_ms),
+            outcome=failure_outcome,
+            principal_ref=principal.ref if principal is not None else None,
+            principal_binding=principal.binding if principal is not None else None,
+            error_code=self._failure_code(error),
+            budget_ms=context.deadline_ms if context is not None else None,
+            result_budget_bytes=context.max_result_bytes if context is not None else None,
+        )
+        if self._audit_hook is not None:
+            self._notify_audit_hook(receipt)
+        return receipt
+
+    def _notify_audit_hook(self, receipt: AuditReceipt) -> None:
+        """Notify the optional sink without changing the operation outcome."""
+        if self._audit_hook is None:
+            return
+        try:
+            self._audit_hook(receipt)
+        except Exception as error:  # pragma: no cover - defensive sink boundary
+            logger.error(
+                "Application audit hook failed operation=%s exception_type=%s",
+                receipt.operation,
+                type(error).__name__,
+            )
+
+    def _deadline_expired(self, request: RequestContext) -> bool:
+        """Check an absolute monotonic deadline without starting the action."""
+        return request.deadline_at is not None and time.monotonic() >= request.deadline_at
+
     def _run(
         self,
         operation: str,
@@ -1056,50 +1461,136 @@ class ApplicationService:
         action: Callable[[], Any],
         *,
         status: Literal["ok", "unavailable"] = "ok",
+        mutation: bool = False,
     ) -> ApplicationEnvelope:
+        if mutation and context is None:
+            error = PermissionError("mutation requires an explicit RequestContext")
+            self._emit_failure_receipt(operation, None, error, duration_ms=0)
+            raise error
         request = context or RequestContext()
         started = time.perf_counter()
-        data = action()
-        if request.deadline_ms is not None:
+        if mutation and request.authority == "read-only":
+            authority_error = PermissionError("mutation requires propose or apply authority")
+            self._emit_failure_receipt(operation, context, authority_error, duration_ms=0)
+            raise authority_error
+        if mutation and (request.principal is None or not request.principal.is_valid()):
+            principal_error = PermissionError(
+                "mutation requires a valid, non-expired principal binding"
+            )
+            self._emit_failure_receipt(operation, context, principal_error, duration_ms=0)
+            raise principal_error
+        if self._deadline_expired(request):
+            deadline_error = DeadlineExceededError(
+                "application deadline exceeded before operation started"
+            )
+            self._emit_failure_receipt(
+                operation,
+                context,
+                deadline_error,
+                duration_ms=0,
+                outcome="rejected_before_start",
+            )
+            raise deadline_error
+
+        receipt_emitted = False
+        try:
+            data = action()
             elapsed_ms = (time.perf_counter() - started) * 1000
-            if elapsed_ms > request.deadline_ms:
-                raise TimeoutError(
-                    f"application deadline exceeded after {elapsed_ms:.1f} ms "
-                    f"(budget {request.deadline_ms} ms)"
+            deadline_elapsed = request.deadline_ms is not None and elapsed_ms > request.deadline_ms
+            deadline_absolute = self._deadline_expired(request)
+            if deadline_elapsed or deadline_absolute:
+                if mutation:
+                    late_error = CompletedAfterDeadlineError(
+                        f"application completed after deadline ({elapsed_ms:.1f} ms)"
+                    )
+                    self._emit_failure_receipt(
+                        operation,
+                        request,
+                        late_error,
+                        duration_ms=int(elapsed_ms),
+                        outcome="completed_after_deadline",
+                    )
+                    receipt_emitted = True
+                    raise late_error
+                deadline_error = DeadlineExceededError(
+                    f"application deadline exceeded after {elapsed_ms:.1f} ms"
                 )
-        if not isinstance(data, dict):
-            data = {"items": data}
-        serializable = json.loads(json.dumps(data, ensure_ascii=False, sort_keys=True, default=str))
-        digest = hashlib.sha256(
-            json.dumps(serializable, ensure_ascii=False, sort_keys=True).encode("utf-8")
-        ).hexdigest()
-        receipt = AuditReceipt(
-            schema_version="power.receipt.v1",
-            operation=operation,
-            status=status,
-            request_id=request.request_id,
-            idempotency_key=request.idempotency_key,
-            data_sha256=digest,
-            duration_ms=max(0, int((time.perf_counter() - started) * 1000)),
-        )
-        if self._audit_hook is not None:
-            self._audit_hook(receipt)
-        actual_capability = str(
-            serializable.get("actual_capability", serializable.get("actual_mode", operation))
-        )
-        raw_source_revision = serializable.get("source_revision")
-        source_revision = str(raw_source_revision) if raw_source_revision is not None else None
-        raw_degraded_reason = serializable.get("degraded_reason")
-        degraded_reason = str(raw_degraded_reason) if raw_degraded_reason is not None else None
-        return ApplicationEnvelope(
-            operation=operation,
-            status=status,
-            data=serializable,
-            receipt=receipt,
-            actual_capability=actual_capability,
-            source_revision=source_revision,
-            degraded_reason=degraded_reason,
-        )
+                self._emit_failure_receipt(
+                    operation,
+                    request,
+                    deadline_error,
+                    duration_ms=int(elapsed_ms),
+                    outcome="failed",
+                )
+                receipt_emitted = True
+                raise deadline_error
+            if not isinstance(data, dict):
+                data = {"items": data}
+            encoded = json.dumps(
+                data,
+                ensure_ascii=False,
+                sort_keys=True,
+                default=str,
+            ).encode("utf-8")
+            if len(encoded) > request.max_result_bytes:
+                if mutation:
+                    raise CompletedAfterBudgetError(
+                        f"application result budget exceeded ({len(encoded)} bytes)"
+                    )
+                raise ResultBudgetExceededError(
+                    f"application result budget exceeded ({len(encoded)} bytes)"
+                )
+            serializable = json.loads(encoded.decode("utf-8"))
+            digest = hashlib.sha256(encoded).hexdigest()
+            receipt = AuditReceipt(
+                schema_version="power.receipt.v1",
+                operation=operation,
+                status=status,
+                request_id=request.request_id,
+                idempotency_key=request.idempotency_key,
+                data_sha256=digest,
+                duration_ms=max(0, int((time.perf_counter() - started) * 1000)),
+                principal_ref=request.principal.ref if request.principal else None,
+                principal_binding=request.principal.binding if request.principal else None,
+                budget_ms=request.deadline_ms,
+                result_budget_bytes=request.max_result_bytes,
+            )
+            self._notify_audit_hook(receipt)
+            actual_capability = str(
+                serializable.get("actual_capability", serializable.get("actual_mode", operation))
+            )
+            raw_source_revision = serializable.get("source_revision")
+            source_revision = str(raw_source_revision) if raw_source_revision is not None else None
+            raw_degraded_reason = serializable.get("degraded_reason")
+            degraded_reason = str(raw_degraded_reason) if raw_degraded_reason is not None else None
+            return ApplicationEnvelope(
+                operation=operation,
+                status=status,
+                data=serializable,
+                receipt=receipt,
+                actual_capability=actual_capability,
+                source_revision=source_revision,
+                degraded_reason=degraded_reason,
+            )
+        except Exception as error:
+            if not receipt_emitted:
+                self._emit_failure_receipt(
+                    operation,
+                    request,
+                    error,
+                    duration_ms=int((time.perf_counter() - started) * 1000),
+                )
+            raise
 
 
-__all__ = ["ApplicationEnvelope", "ApplicationService", "AuditReceipt", "RequestContext"]
+__all__ = [
+    "MAX_RESULT_BYTES",
+    "ApplicationEnvelope",
+    "ApplicationService",
+    "AuditReceipt",
+    "CompletedAfterBudgetError",
+    "CompletedAfterDeadlineError",
+    "DeadlineExceededError",
+    "RequestContext",
+    "ResultBudgetExceededError",
+]

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -746,7 +746,7 @@ def _cmd_rename(args: argparse.Namespace) -> int:
 
     try:
         old_file = resolve_path_in_vault(vault_dir, old_rel)
-        new_file = resolve_path_in_vault(vault_dir, new_rel)
+        new_file = resolve_path_in_vault(vault_dir, new_rel, allow_missing_parent=True)
     except ValueError as exc:
         logger.error("Invalid rename path: %s", exc)
         return 1

--- a/src/power_framework/core/cli.py
+++ b/src/power_framework/core/cli.py
@@ -83,6 +83,7 @@ from .memory_api import (
 from .models import VAULT_STRUCTURE, NoteType, OKFMetadata
 from .mutation import execute_vault_mutation
 from .parser import build_frontmatter, read_file_content
+from .principal import Principal
 from .searcher import (
     CANONICAL_SEARCH_MODES,
     DEFAULT_SEARCH_MODE,
@@ -90,7 +91,13 @@ from .searcher import (
 )
 from .state_migration import build_state_migration_plan
 from .synthesize import synthesize_session_ingest
-from .utils import __version__, atomic_write, enforce_cpu_throttling_env, iter_vault_markdown_files
+from .utils import (
+    __version__,
+    atomic_write,
+    enforce_cpu_throttling_env,
+    iter_vault_markdown_files,
+    resolve_path_in_vault,
+)
 
 logger = logging.getLogger("power")
 
@@ -134,6 +141,21 @@ def _resolve_path(path_str: str) -> Path:
     if env_val:
         return Path(env_val).resolve()
     return Path.cwd().resolve()
+
+
+def _cli_context(
+    *,
+    actor: str,
+    authority: str = "read-only",
+    idempotency_key: str | None = None,
+) -> RequestContext:
+    """Bind CLI calls to the local process while retaining actor attribution."""
+    return RequestContext(
+        actor=actor,
+        authority=authority,  # type: ignore[arg-type]
+        idempotency_key=idempotency_key,
+        principal=Principal.local_cli(),
+    )
 
 
 def _positive_int(value: str) -> int:
@@ -433,7 +455,7 @@ def _cmd_search(args: argparse.Namespace) -> int:
         temporal_view=args.temporal_view,
         as_of=args.as_of,
         domain=args.domain,
-        context=RequestContext(actor="cli"),
+        context=_cli_context(actor="cli"),
     )
     if args.envelope:
         print(json.dumps(envelope.as_dict(), ensure_ascii=False, sort_keys=True))
@@ -722,8 +744,12 @@ def _cmd_rename(args: argparse.Namespace) -> int:
     new_rel = args.new
     dry_run = not args.no_dry_run
 
-    old_file = vault_dir / old_rel
-    new_file = vault_dir / new_rel
+    try:
+        old_file = resolve_path_in_vault(vault_dir, old_rel)
+        new_file = resolve_path_in_vault(vault_dir, new_rel)
+    except ValueError as exc:
+        logger.error("Invalid rename path: %s", exc)
+        return 1
 
     if not old_file.exists() or not old_file.is_file():
         logger.error("Source note not found: %s", old_file)
@@ -1003,7 +1029,7 @@ def _cmd_memory(args: argparse.Namespace) -> int:
                     .propose(
                         args.note_path,
                         content,
-                        context=RequestContext(actor="cli", authority="propose"),
+                        context=_cli_context(actor="cli", authority="propose"),
                     )
                     .data,
                     sort_keys=True,
@@ -1031,7 +1057,7 @@ def _cmd_memory(args: argparse.Namespace) -> int:
                     .apply(
                         proposal,
                         approved=args.approved,
-                        context=RequestContext(actor="cli", authority="apply"),
+                        context=_cli_context(actor="cli", authority="apply"),
                     )
                     .data,
                     sort_keys=True,
@@ -1077,7 +1103,7 @@ def _cmd_handoff(args: argparse.Namespace) -> int:
                         else None
                     ),
                 },
-                context=RequestContext(
+                context=_cli_context(
                     actor=args.actor,
                     authority="propose",
                     idempotency_key=args.idempotency_key,
@@ -1105,7 +1131,7 @@ def _cmd_handoff(args: argparse.Namespace) -> int:
                     "completion_postcondition": args.completion_postcondition,
                     "completion_artifact_refs": args.changed_artifacts,
                 },
-                context=RequestContext(
+                context=_cli_context(
                     actor=args.actor,
                     authority="apply",
                     idempotency_key=args.idempotency_key,
@@ -1162,7 +1188,7 @@ def _cmd_task(args: argparse.Namespace) -> int:
                 next_action=args.next_action,
                 open_gates=args.open_gates,
                 due_at=args.due_at,
-                context=RequestContext(
+                context=_cli_context(
                     actor=args.actor,
                     authority="propose",
                     idempotency_key=args.idempotency_key,
@@ -1180,7 +1206,7 @@ def _cmd_task(args: argparse.Namespace) -> int:
                 error_ref=args.error_ref,
                 completion_postcondition=args.completion_postcondition,
                 completion_artifact_refs=args.completion_artifacts,
-                context=RequestContext(
+                context=_cli_context(
                     actor=args.actor,
                     authority="apply",
                     idempotency_key=args.idempotency_key,

--- a/src/power_framework/core/connect.py
+++ b/src/power_framework/core/connect.py
@@ -375,7 +375,7 @@ def build_connect_plan(
 
 def apply_connect_plan(plan: dict[str, Any], *, approved: bool) -> dict[str, Any]:
     """Apply one unchanged approved plan and return a content-free receipt."""
-    if not approved:
+    if type(approved) is not bool or not approved:
         raise PermissionError("connect apply requires explicit approval")
     if plan.get("schema_version") != CONNECT_SCHEMA_VERSION:
         raise ValueError("unsupported connect plan schema")

--- a/src/power_framework/core/coverage.py
+++ b/src/power_framework/core/coverage.py
@@ -16,7 +16,11 @@ from .vault_storage import existing_vault_db_path
 logger = logging.getLogger(__name__)
 
 
-def get_index_coverage(vault_dir: Path) -> tuple[int, int]:
+def get_index_coverage(
+    vault_dir: Path,
+    *,
+    allow_search_db_override: bool = True,
+) -> tuple[int, int]:
     """Return ``(indexed_files, total_files)`` for a vault.
 
     Coverage is observational only.  Search never starts a worker or changes
@@ -40,7 +44,10 @@ def get_index_coverage(vault_dir: Path) -> tuple[int, int]:
     # migration. The legacy search.db fallback is valid only for vaults that
     # have not been migrated yet; reading it first makes a successful sync
     # appear as 0 indexed notes in doctor/search coverage receipts.
-    db_path = resolve_active_generation_path(root) or existing_vault_db_path(root)
+    db_path = resolve_active_generation_path(root) or existing_vault_db_path(
+        root,
+        allow_search_db_override=allow_search_db_override,
+    )
     if db_path is None or not db_path.exists():
         return indexed, total
     try:

--- a/src/power_framework/core/decision_service.py
+++ b/src/power_framework/core/decision_service.py
@@ -242,8 +242,12 @@ class DecisionService:
             raise ValueError(f"Malformed decision receipt {receipt_id}") from exc
 
     def _ensure_dirs(self) -> None:
-        self.decisions_dir.mkdir(parents=True, exist_ok=True)
-        self.receipts_dir.mkdir(parents=True, exist_ok=True)
+        for directory in (self.decisions_dir, self.receipts_dir):
+            if directory.is_symlink():
+                raise ValueError(f"decision state directory must not be a symlink: {directory}")
+            directory.mkdir(parents=True, exist_ok=True)
+            if directory.is_symlink() or not directory.is_dir():
+                raise ValueError(f"decision state directory is not safe: {directory}")
 
     def _decision_file(self, decision_id: str) -> Path:
         Decision.validate_decision_id(decision_id)

--- a/src/power_framework/core/doctor.py
+++ b/src/power_framework/core/doctor.py
@@ -261,7 +261,11 @@ def _unprobed_embedding_status() -> tuple[dict[str, Any], list[dict[str, str]]]:
     return embedding, issues
 
 
-def _probe_vault(vault_dir: Path) -> tuple[dict[str, Any], list[dict[str, str]]]:
+def _probe_vault(
+    vault_dir: Path,
+    *,
+    allow_search_db_override: bool = True,
+) -> tuple[dict[str, Any], list[dict[str, str]]]:
     """Inspect a vault and its search state without creating cache or index files."""
     root = Path(vault_dir).expanduser().resolve()
     vault: dict[str, Any] = {
@@ -335,7 +339,10 @@ def _probe_vault(vault_dir: Path) -> tuple[dict[str, Any], list[dict[str, str]]]
         legacy: Path | None = None
         if vault["index_state"] != "unreadable":
             try:
-                legacy = existing_vault_db_path(root)
+                legacy = existing_vault_db_path(
+                    root,
+                    allow_search_db_override=allow_search_db_override,
+                )
             except (OSError, ValueError) as exc:
                 vault["index_state"] = "unreadable"
                 issues.append(
@@ -379,7 +386,10 @@ def _probe_vault(vault_dir: Path) -> tuple[dict[str, Any], list[dict[str, str]]]
         )
 
     try:
-        indexed, scanned = get_index_coverage(root)
+        indexed, scanned = get_index_coverage(
+            root,
+            allow_search_db_override=allow_search_db_override,
+        )
         vault["indexed_notes"] = (
             indexed if vault["indexed_notes"] is None else vault["indexed_notes"]
         )
@@ -438,7 +448,12 @@ def _probe_vault(vault_dir: Path) -> tuple[dict[str, Any], list[dict[str, str]]]
     return vault, issues
 
 
-def run_doctor(vault_dir: Path | None = None, *, probe_embedding: bool = False) -> dict[str, Any]:
+def run_doctor(
+    vault_dir: Path | None = None,
+    *,
+    probe_embedding: bool = False,
+    allow_search_db_override: bool = True,
+) -> dict[str, Any]:
     """Build the versioned, read-only doctor report.
 
     The default is lightweight discovery: it reports configuration and vault
@@ -482,7 +497,10 @@ def run_doctor(vault_dir: Path | None = None, *, probe_embedding: bool = False) 
     report["embedding"] = embedding
     issues.extend(embedding_issues)
     if vault_dir is not None:
-        vault, vault_issues = _probe_vault(vault_dir)
+        vault, vault_issues = _probe_vault(
+            vault_dir,
+            allow_search_db_override=allow_search_db_override,
+        )
         report["vault"] = vault
         issues.extend(vault_issues)
     report["issues"] = issues

--- a/src/power_framework/core/handoff.py
+++ b/src/power_framework/core/handoff.py
@@ -207,6 +207,8 @@ def advance_work_packet(
         _validate_token(receipt_id, "receipt_id")
     if not isinstance(actor, str) or not actor.strip():
         raise ValueError("actor must be a non-empty string")
+    if type(approved) is not bool:
+        raise ValueError("approved must be a boolean")
     if phase is not None and phase not in _MAINTENANCE_PHASES:
         raise ValueError("unknown maintenance phase")
 

--- a/src/power_framework/core/integrations.py
+++ b/src/power_framework/core/integrations.py
@@ -160,7 +160,7 @@ def build_skill_check_plan(target: str | Path) -> dict[str, Any]:
 
 def apply_skill_install_plan(plan: dict[str, Any], *, approved: bool) -> dict[str, Any]:
     """Atomically install a missing Skill tree after an explicit approval."""
-    if not approved:
+    if type(approved) is not bool or not approved:
         raise PermissionError("skill install requires explicit approved=True")
     if plan.get("schema") != SKILL_SCHEMA_VERSION:
         raise ValueError("unsupported Skill plan schema")
@@ -802,7 +802,7 @@ def apply_native_install_plan(
     no_deps: bool = False,
 ) -> dict[str, Any]:
     """Build, verify, and atomically activate one unified POWER release slot."""
-    if not approved:
+    if type(approved) is not bool or not approved:
         raise PermissionError("native install requires explicit approved=True")
     if no_deps:
         raise ValueError("native install refuses the insecure no_deps bypass")

--- a/src/power_framework/core/maintenance.py
+++ b/src/power_framework/core/maintenance.py
@@ -192,7 +192,7 @@ def apply_maintenance_plan(
     root = Path(vault_dir).expanduser().resolve()
     if str(root) != plan.vault:
         raise ValueError("maintenance plan belongs to a different vault")
-    if not approved:
+    if type(approved) is not bool or not approved:
         raise PermissionError("maintenance apply requires explicit approved=True")
     if any(action.action_class != "safe_auto" for action in plan.actions):
         raise PermissionError("plan contains approval-required or plan-only actions")

--- a/src/power_framework/core/memory_api.py
+++ b/src/power_framework/core/memory_api.py
@@ -26,11 +26,16 @@ from .utils import (
     iter_vault_markdown_files,
     resolve_path_in_vault,
     vault_control_dir,
+    vault_control_subdir,
 )
 from .vault_storage import existing_vault_cache_dir
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+MAX_HISTORY_BYTES = 2_000_000
+MAX_HISTORY_LINE_BYTES = 64_000
 
 
 @dataclass(frozen=True)
@@ -79,6 +84,14 @@ def propose_change(
         }
         proposal_id = _proposal_id(payload)
         proposal_path = _proposal_path(vault_dir, proposal_id)
+        if idempotency_key is not None:
+            for existing_path in sorted(proposal_path.parent.glob("*.json")):
+                existing = _read_proposal_file(existing_path)
+                if _proposal_idempotency_key(existing) != idempotency_key:
+                    continue
+                if _proposal_payload(existing) != payload:
+                    raise ConflictError("idempotency key was already used for a different proposal")
+                return _public_proposal(existing)
         if proposal_path.exists():
             existing = _read_proposal_file(proposal_path)
             if _proposal_payload(existing) != payload:
@@ -111,6 +124,7 @@ def commit_note_change(
     log_entry: str | None = None,
     proposal_id: str | None = None,
     idempotency_key: str | None = None,
+    idempotency_fingerprint: str | None = None,
 ) -> dict[str, str]:
     """Commit one note through the shared write → verify → publish workflow."""
 
@@ -118,8 +132,17 @@ def commit_note_change(
         target = resolve_path_in_vault(vault_dir, rel_path, allowed_directories)
         if idempotency_key is not None:
             _validate_idempotency_key(idempotency_key)
+            if idempotency_fingerprint is not None and not _is_sha256(idempotency_fingerprint):
+                raise ValueError("idempotency_fingerprint must be a SHA-256 hex digest")
             prior_receipt = _find_idempotent_receipt(vault_dir, idempotency_key)
             if prior_receipt is not None:
+                if (
+                    idempotency_fingerprint is not None
+                    and prior_receipt.get("idempotency_fingerprint") == idempotency_fingerprint
+                    and prior_receipt.get("operation") == operation
+                    and prior_receipt.get("path") == rel_path
+                ):
+                    return prior_receipt
                 expected_after = hashlib.sha256(content.encode()).hexdigest()
                 if (
                     prior_receipt.get("operation") == operation
@@ -165,6 +188,8 @@ def commit_note_change(
             receipt["proposal_id"] = proposal_id
         if idempotency_key is not None:
             receipt["idempotency_key"] = idempotency_key
+        if idempotency_fingerprint is not None:
+            receipt["idempotency_fingerprint"] = idempotency_fingerprint
 
         store = TaskStore(vault_dir)
         try:
@@ -271,7 +296,7 @@ def apply_change(
     idempotency_key: str | None = None,
 ) -> dict[str, str]:
     """Apply an approved proposal through the shared mutation boundary."""
-    if not approved:
+    if type(approved) is not bool or not approved:
         raise PermissionError("proposal requires explicit approved=True")
     if not isinstance(proposal, dict):
         raise ValueError("proposal must be an object")
@@ -374,7 +399,7 @@ def _proposal_id(payload: dict[str, str]) -> str:
 
 def _proposal_path(vault_dir: Path, proposal_id: str) -> Path:
     """Return the safe durable path for a validated proposal ID."""
-    return vault_control_dir(vault_dir, create=True) / "proposals" / f"{proposal_id}.json"
+    return vault_control_subdir(vault_dir, "proposals", create=True) / f"{proposal_id}.json"
 
 
 def _read_proposal_file(path: Path) -> dict[str, object]:
@@ -543,4 +568,31 @@ def read_history(vault_dir: Path) -> list[dict[str, str]]:
         raise ValueError("memory history must not be a symlink")
     if not history.exists():
         return []
-    return [json.loads(line) for line in history.read_text(encoding="utf-8").splitlines() if line]
+    try:
+        if history.stat().st_size > MAX_HISTORY_BYTES:
+            raise RuntimeError("memory history exceeds its bounded receipt size")
+        lines = history.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise RuntimeError("memory history is unreadable") from exc
+
+    records: list[dict[str, str]] = []
+    for line in lines:
+        if not line:
+            continue
+        if len(line.encode("utf-8")) > MAX_HISTORY_LINE_BYTES:
+            raise RuntimeError("memory history contains an oversized receipt")
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("memory history contains invalid JSON") from exc
+        if not isinstance(record, dict) or any(
+            not isinstance(key, str)
+            or not isinstance(value, str)
+            or key in {"content", "body", "exception", "traceback"}
+            or len(key) > 128
+            or len(value) > MAX_HISTORY_LINE_BYTES
+            for key, value in record.items()
+        ):
+            raise RuntimeError("memory history contains non-content-free receipt data")
+        records.append(record)
+    return records

--- a/src/power_framework/core/memory_api.py
+++ b/src/power_framework/core/memory_api.py
@@ -521,23 +521,11 @@ def _append_receipt(history: Path, receipt: dict[str, str]) -> None:
 
 def _find_idempotent_receipt(vault_dir: Path, idempotency_key: str) -> dict[str, str] | None:
     """Find one prior receipt without treating malformed history as success."""
-    history = vault_control_dir(vault_dir) / "memory-history.jsonl"
-    if history.is_symlink():
-        raise RuntimeError("memory history is a symlink; refusing idempotent replay")
-    if not history.exists():
-        return None
     try:
-        lines = history.read_text(encoding="utf-8").splitlines()
-        records = [json.loads(line) for line in lines if line]
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        records = read_history(vault_dir)
+    except (OSError, UnicodeError, ValueError, RuntimeError) as exc:
         raise RuntimeError("memory history is unreadable; refusing idempotent replay") from exc
     for record in records:
-        if not isinstance(record, dict):
-            raise RuntimeError("memory history contains an invalid receipt")
-        if not all(
-            isinstance(key, str) and isinstance(value, str) for key, value in record.items()
-        ):
-            raise RuntimeError("memory history contains a non-content-free receipt")
         if record.get("idempotency_key") != idempotency_key:
             continue
         return record

--- a/src/power_framework/core/mutation.py
+++ b/src/power_framework/core/mutation.py
@@ -36,6 +36,12 @@ from .utils import vault_control_dir
 _registry_guard = threading.Lock()
 _vault_locks: dict[Path, threading.RLock] = {}
 _compatibility_lock = threading.RLock()
+_blocking_worker_limit = max(1, (os.cpu_count() or 4) // 2)
+_blocking_slots = threading.BoundedSemaphore(_blocking_worker_limit)
+_blocking_executor = ThreadPoolExecutor(
+    max_workers=_blocking_worker_limit,
+    thread_name_prefix="power-blocking",
+)
 
 
 def _lock_descriptor(descriptor: int) -> None:
@@ -102,24 +108,57 @@ def execute_vault_mutation[T](vault_dir: Path, operation: Callable[[], T]) -> T:
         return operation()
 
 
-async def run_blocking[T](sync_fn: Callable[[], T]) -> T:
-    """Run a blocking operation and join its executor before returning.
+async def run_blocking[T](sync_fn: Callable[[], T], *, mutation: bool = False) -> T:
+    """Run a blocking operation through the bounded process-wide worker.
 
     Polling the submitted future avoids a Python 3.13 runtime deadlock seen
     when ``asyncio`` waits for an executor callback after file-backed work.
-    The work still runs in the bounded executor; only completion observation is
-    kept on the event loop.
+    Reads may be abandoned on cancellation because they have no write effect;
+    mutations keep observing the future until the outcome is known.
     """
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        future = executor.submit(sync_fn)
-        while not future.done():
+    while not _blocking_slots.acquire(blocking=False):
+        try:
             await asyncio.sleep(0.01)
-        return future.result()
+        except asyncio.CancelledError:
+            # No worker has been admitted, so a canceled queued operation has
+            # no write effect to recover.
+            raise
+
+    try:
+        future = _blocking_executor.submit(_run_with_blocking_slot, sync_fn)
+    except Exception:
+        _blocking_slots.release()
+        raise
+    cancellation_requested = False
+    while not future.done():
+        try:
+            await asyncio.sleep(0.01)
+        except asyncio.CancelledError:
+            if not mutation:
+                if future.cancel():
+                    _blocking_slots.release()
+                raise
+            # A thread running a mutation cannot be safely killed. Keep the
+            # caller suspended until the worker has a truthful outcome.
+            cancellation_requested = True
+            continue
+    result = future.result()
+    if cancellation_requested:
+        raise asyncio.CancelledError
+    return result
+
+
+def _run_with_blocking_slot[T](sync_fn: Callable[[], T]) -> T:
+    """Run one admitted callback and release its global worker slot."""
+    try:
+        return sync_fn()
+    finally:
+        _blocking_slots.release()
 
 
 async def run_vault_mutation[T](vault_dir: Path, operation: Callable[[], T]) -> T:
     """Run a synchronous mutation under per-vault locks without blocking asyncio."""
-    return await run_blocking(lambda: execute_vault_mutation(vault_dir, operation))
+    return await run_blocking(lambda: execute_vault_mutation(vault_dir, operation), mutation=True)
 
 
 async def enqueue_compatibility_write[T](sync_fn: Callable[[], T]) -> T:
@@ -128,7 +167,7 @@ async def enqueue_compatibility_write[T](sync_fn: Callable[[], T]) -> T:
     Production CLI/MCP paths use :func:`run_vault_mutation`; this fallback is
     intentionally process-local and has no worker task or active-vault state.
     """
-    return await run_blocking(lambda: _run_compatibility_write(sync_fn))
+    return await run_blocking(lambda: _run_compatibility_write(sync_fn), mutation=True)
 
 
 def _run_compatibility_write[T](sync_fn: Callable[[], T]) -> T:

--- a/src/power_framework/core/mutation.py
+++ b/src/power_framework/core/mutation.py
@@ -13,6 +13,7 @@ import contextlib
 import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import Context, copy_context
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -125,7 +126,8 @@ async def run_blocking[T](sync_fn: Callable[[], T], *, mutation: bool = False) -
             raise
 
     try:
-        future = _blocking_executor.submit(_run_with_blocking_slot, sync_fn)
+        caller_context = copy_context()
+        future = _blocking_executor.submit(_run_with_blocking_slot, caller_context, sync_fn)
     except Exception:
         _blocking_slots.release()
         raise
@@ -148,10 +150,10 @@ async def run_blocking[T](sync_fn: Callable[[], T], *, mutation: bool = False) -
     return result
 
 
-def _run_with_blocking_slot[T](sync_fn: Callable[[], T]) -> T:
+def _run_with_blocking_slot[T](caller_context: Context, sync_fn: Callable[[], T]) -> T:
     """Run one admitted callback and release its global worker slot."""
     try:
-        return sync_fn()
+        return caller_context.run(sync_fn)
     finally:
         _blocking_slots.release()
 

--- a/src/power_framework/core/principal.py
+++ b/src/power_framework/core/principal.py
@@ -1,0 +1,112 @@
+"""Trusted local principal bindings for the application boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Literal
+
+PrincipalBinding = Literal[
+    "WEB_SIGNED_SESSION",
+    "LOCAL_CLI",
+    "LOCAL_MCP_STDIO",
+    "SYSTEM_INTERNAL",
+]
+
+_PRINCIPAL_REF_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_ISSUED = object()
+
+
+@dataclass(frozen=True)
+class Principal:
+    """A server-issued, non-secret identity binding for one application call.
+
+    The public constructor deliberately cannot issue a binding. Transport
+    adapters must use one of the named factories, which keeps an attribution
+    label separate from the proof that the local transport was trusted.
+    """
+
+    ref: str
+    binding: PrincipalBinding
+    valid: bool = True
+    expires_at: datetime | None = None
+    _issued: object = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._issued is not _ISSUED:
+            raise ValueError("principal must be issued by a trusted binding factory")
+        if not _PRINCIPAL_REF_PATTERN.fullmatch(self.ref):
+            raise ValueError("principal ref must be a safe opaque token")
+        if self.binding not in {
+            "WEB_SIGNED_SESSION",
+            "LOCAL_CLI",
+            "LOCAL_MCP_STDIO",
+            "SYSTEM_INTERNAL",
+        }:
+            raise ValueError("unsupported principal binding")
+        if self.expires_at is not None:
+            if self.expires_at.tzinfo is None:
+                raise ValueError("principal expiry must include a timezone")
+            object.__setattr__(self, "expires_at", self.expires_at.astimezone(UTC))
+
+    @classmethod
+    def _issue(
+        cls,
+        ref: str,
+        binding: PrincipalBinding,
+        *,
+        expires_at: datetime | None = None,
+        proof: object,
+    ) -> Principal:
+        if proof is not _ISSUED:
+            raise ValueError("principal must be issued by a trusted binding factory")
+        return cls(ref=ref, binding=binding, expires_at=expires_at, _issued=proof)
+
+    @classmethod
+    def web_signed_session(
+        cls,
+        subject: str,
+        *,
+        expires_at: datetime | None = None,
+    ) -> Principal:
+        """Bind a verified signed-session subject without retaining the subject."""
+        if not isinstance(subject, str) or not subject.strip() or len(subject) > 256:
+            raise ValueError("session subject must be a bounded non-empty string")
+        reference = hashlib.sha256(subject.encode("utf-8")).hexdigest()[:32]
+        return cls._issue(
+            f"web-{reference}",
+            "WEB_SIGNED_SESSION",
+            expires_at=expires_at,
+            proof=_ISSUED,
+        )
+
+    @classmethod
+    def local_cli(cls) -> Principal:
+        """Issue the trusted principal for one local CLI/library process."""
+        return cls._issue("local-cli", "LOCAL_CLI", proof=_ISSUED)
+
+    @classmethod
+    def local_mcp_stdio(cls) -> Principal:
+        """Issue the trusted principal for the local MCP stdio process."""
+        return cls._issue("local-mcp-stdio", "LOCAL_MCP_STDIO", proof=_ISSUED)
+
+    @classmethod
+    def system_internal(cls) -> Principal:
+        """Issue the non-expiring binding for an explicitly internal operation."""
+        return cls._issue("system-internal", "SYSTEM_INTERNAL", proof=_ISSUED)
+
+    def is_valid(self, *, now: datetime | None = None) -> bool:
+        """Return whether this binding is currently usable for a mutation."""
+        if not self.valid:
+            return False
+        if self.expires_at is None:
+            return True
+        current = now or datetime.now(UTC)
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=UTC)
+        return current.astimezone(UTC) < self.expires_at
+
+
+__all__ = ["Principal", "PrincipalBinding"]

--- a/src/power_framework/core/searcher.py
+++ b/src/power_framework/core/searcher.py
@@ -71,6 +71,19 @@ logger = logging.getLogger(__name__)
 _SOURCE_READ_CONTEXT: ContextVar[SourceReadContext | None] = ContextVar(
     "power_source_read_context", default=None
 )
+_SEARCH_DB_OVERRIDE_POLICY: ContextVar[bool | None] = ContextVar(
+    "power_search_db_override_policy", default=None
+)
+
+
+@contextlib.contextmanager
+def search_db_override_policy(allowed: bool):
+    """Temporarily bind the legacy DB override policy to one local call."""
+    token = _SEARCH_DB_OVERRIDE_POLICY.set(allowed)
+    try:
+        yield
+    finally:
+        _SEARCH_DB_OVERRIDE_POLICY.reset(token)
 
 
 def get_embedding_manager() -> Any:
@@ -147,7 +160,11 @@ def _get_reranker() -> RerankerProtocol:
 
 def _db_path(vault_dir: Path | None = None) -> Path:
     """Resolve the isolated DB for a vault, honoring POWER_SEARCH_DB in tests."""
-    return vault_db_path(vault_dir)
+    policy = _SEARCH_DB_OVERRIDE_POLICY.get()
+    return vault_db_path(
+        vault_dir,
+        allow_search_db_override=True if policy is None else policy,
+    )
 
 
 def _read_db_path(vault_dir: Path) -> Path | None:

--- a/src/power_framework/core/synthesize.py
+++ b/src/power_framework/core/synthesize.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import datetime
 import hashlib
+import json
 import logging
 from pathlib import Path
 
@@ -41,6 +42,7 @@ def synthesize_session_ingest(
     owner: str | None = None,
     vault_path: str | str | Path = ".",
     timestamp: datetime.datetime | None = None,
+    idempotency_key: str | None = None,
 ) -> str:
     """Create a session synthesis note with auto-classified OKF metadata + ingest.
 
@@ -59,7 +61,7 @@ def synthesize_session_ingest(
         name += ".md"
 
     target_file = resolve_path_in_vault(vault, name)
-    if target_file.exists():
+    if target_file.exists() and idempotency_key is None:
         raise FileExistsError(f"Note already exists at {name}")
 
     ts = timestamp or datetime.datetime.now(_DEFAULT_TZ)
@@ -82,6 +84,22 @@ def synthesize_session_ingest(
 
     frontmatter = build_frontmatter(metadata)
     full_content = f"{frontmatter}\n\n{content}\n"
+    idempotency_fingerprint = hashlib.sha256(
+        json.dumps(
+            {
+                "name": name,
+                "title": title,
+                "description": description,
+                "content": content,
+                "note_type": note_type,
+                "tags": tags,
+                "related": related,
+                "owner": owner,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
 
     date_str = ts.strftime("%Y-%m-%d")
     log_entry = (
@@ -98,14 +116,18 @@ def synthesize_session_ingest(
         require_absent=True,
         operation="synthesize.session",
         log_entry=log_entry,
+        idempotency_key=idempotency_key,
+        idempotency_fingerprint=(idempotency_fingerprint if idempotency_key is not None else None),
     )
 
     # Graph extraction is deliberately an optional projection.  A failure here
     # must not invalidate the already verified Markdown/search transaction.
     try:
+        from power_framework.core.searcher import search_db_override_policy
         from power_framework.experimental.graph_extraction import store_note_triplets
 
-        store_note_triplets(vault, name, content)
+        with search_db_override_policy(False):
+            store_note_triplets(vault, name, content)
     except Exception as exc:
         logger.warning("Triplet extraction failed for %s: %s", name, exc)
 

--- a/src/power_framework/core/synthesize.py
+++ b/src/power_framework/core/synthesize.py
@@ -95,6 +95,7 @@ def synthesize_session_ingest(
                 "tags": tags,
                 "related": related,
                 "owner": owner,
+                "timestamp": timestamp.isoformat() if timestamp is not None else None,
             },
             ensure_ascii=False,
             sort_keys=True,

--- a/src/power_framework/core/utils.py
+++ b/src/power_framework/core/utils.py
@@ -195,13 +195,16 @@ def resolve_path_in_vault(
     vault_root: Path,
     untrusted_relative_path: str,
     allowed_directories: tuple[str, ...] | None = None,
+    *,
+    allow_missing_parent: bool = False,
 ) -> Path:
     """Resolve a Markdown file path without allowing it to escape a vault root.
 
     The supplied path is intentionally treated as untrusted input: absolute and
     Windows-drive paths, traversal components, control characters, backslashes,
     non-Markdown targets, and symlink escapes are rejected.  The parent must
-    already exist so callers do not create an attacker-selected directory tree.
+    already exist unless a caller explicitly validates a new destination parent;
+    existing ancestors remain required to be inside the vault and non-symlinked.
     """
     root = validate_vault_path(str(vault_root))
     raw_path = str(untrusted_relative_path)
@@ -226,8 +229,22 @@ def resolve_path_in_vault(
 
     candidate = root.joinpath(*path_parts)
     try:
-        parent = candidate.parent.resolve(strict=True)
-        parent.relative_to(root)
+        if allow_missing_parent:
+            existing_parent = candidate.parent
+            while not existing_parent.exists() and existing_parent != root:
+                existing_parent = existing_parent.parent
+            parent = candidate.parent.resolve(strict=False)
+            parent.relative_to(root)
+            current = candidate.parent
+            while current != existing_parent:
+                if current.is_symlink():
+                    raise ValueError("Target parent must not contain a symlink")
+                current = current.parent
+            if existing_parent.is_symlink():
+                raise ValueError("Target parent must not contain a symlink")
+        else:
+            parent = candidate.parent.resolve(strict=True)
+            parent.relative_to(root)
     except (FileNotFoundError, ValueError) as exc:
         raise ValueError("Target parent is outside the vault or does not exist") from exc
 

--- a/src/power_framework/core/utils.py
+++ b/src/power_framework/core/utils.py
@@ -112,6 +112,28 @@ def vault_control_dir(vault_root: Path, *, create: bool = False) -> Path:
     return control_dir
 
 
+def vault_control_subdir(
+    vault_root: Path,
+    name: str,
+    *,
+    create: bool = False,
+) -> Path:
+    """Resolve one non-symlink child directory of the vault control root."""
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", name):
+        raise ValueError("control subdirectory name is not safe")
+    control_dir = vault_control_dir(vault_root, create=create)
+    child = control_dir / name
+    if child.is_symlink():
+        raise ValueError(f"vault control subdirectory must not be a symlink: {name}")
+    if child.exists() and not child.is_dir():
+        raise NotADirectoryError(f"vault control subdirectory is not a directory: {name}")
+    if create:
+        child.mkdir(parents=False, exist_ok=True)
+        if child.is_symlink() or not child.is_dir():
+            raise ValueError(f"vault control subdirectory is not safe: {name}")
+    return child
+
+
 def resolve_vault_path(
     arguments: dict[str, Any],
     env_var: str = "POWER_VAULT_DIR",

--- a/src/power_framework/core/vault_storage.py
+++ b/src/power_framework/core/vault_storage.py
@@ -182,10 +182,14 @@ def existing_vault_db_path(
     return cache_dir / "search.db" if cache_dir is not None else None
 
 
-def vault_db_path(vault_dir: Path | None = None) -> Path:
-    """Resolve an isolated search database, honoring the explicit test override."""
+def vault_db_path(
+    vault_dir: Path | None = None,
+    *,
+    allow_search_db_override: bool = True,
+) -> Path:
+    """Resolve an isolated search database with an explicit override policy."""
     override = os.getenv("POWER_SEARCH_DB")
-    if override:
+    if allow_search_db_override and override:
         return Path(override)
     if vault_dir is None:
         raise ValueError("A vault path is required when POWER_SEARCH_DB is not set")

--- a/src/power_framework/mcp/power_server.py
+++ b/src/power_framework/mcp/power_server.py
@@ -27,7 +27,9 @@ from __future__ import annotations
 import json
 import logging
 import re
+import uuid
 from collections.abc import Callable
+from contextvars import ContextVar
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
@@ -43,6 +45,7 @@ from power_framework.core import (
     DEFAULT_SEARCH_MODE,
     PARA_FOLDERS,
     ApplicationService,
+    Principal,
     RateLimiter,
     RequestContext,
     __version__,
@@ -84,6 +87,11 @@ _MCP_ANNOTATION_ALIASES = {
 }
 _ToolCallable = TypeVar("_ToolCallable", bound=Callable[..., Any])
 _ABSOLUTE_PATH_RE = re.compile(r"(?<![\w])/(?:[^\s'\"`,;)]*)+")
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)(\b(?:api[_-]?key|authorization|cookie|password|secret|token)\b\s*[:=]\s*)[^\s,;]+"
+)
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
+_MCP_REQUEST_ID: ContextVar[str | None] = ContextVar("power_mcp_request_id", default=None)
 
 
 def _normalize_tool_annotations(
@@ -99,12 +107,38 @@ def _normalize_tool_annotations(
 
 
 def _safe_mcp_error_text(error: Exception) -> str:
-    """Return actionable MCP error text without absolute paths or tracebacks."""
+    """Return bounded MCP error text without paths, secrets, or tracebacks."""
     message = str(error).strip()
     if not message or "Traceback (most recent call last)" in message:
         return "POWER MCP tool failed; inspect the server log for details."
+    message = _SECRET_ASSIGNMENT_RE.sub(r"\1<redacted>", message)
+    message = _BEARER_RE.sub("Bearer <redacted>", message)
+    if "secret" in message.casefold() and "<redacted>" not in message:
+        return "POWER MCP tool failed; inspect the server log for details."
     message = _ABSOLUTE_PATH_RE.sub("<path>", message)
-    return message[:512]
+    return message[:509] + "..." if len(message) > 512 else message
+
+
+def _mcp_context(
+    *,
+    actor: str = "mcp",
+    authority: Literal["read-only", "propose", "apply"] = "read-only",
+    idempotency_key: str | None = None,
+) -> RequestContext:
+    """Build context from the trusted local stdio process, not tool input."""
+    return RequestContext(
+        actor=actor,
+        authority=authority,
+        idempotency_key=idempotency_key,
+        request_id=_MCP_REQUEST_ID.get() or uuid.uuid4().hex,
+        principal=Principal.local_mcp_stdio(),
+    )
+
+
+def _require_explicit_approval(approved: bool, operation: str) -> None:
+    """Require a real boolean true rather than truthy transport coercion."""
+    if type(approved) is not bool or not approved:
+        raise ToolError(f"{operation} requires explicit approved=True")
 
 
 class PowerMCPServer(MCPServer):
@@ -138,15 +172,30 @@ class PowerMCPServer(MCPServer):
         context: Any = None,
     ) -> CallToolResult | InputRequiredResult:
         """Execute a tool and convert SDK execution errors to safe results."""
+        request_token = _MCP_REQUEST_ID.set(uuid.uuid4().hex)
+        request_id = _MCP_REQUEST_ID.get()
         try:
-            result = await super().call_tool(name, arguments, context)
-        except ToolError as exc:
-            logger.info("MCP tool execution failed: %s", name)
-            return CallToolResult(
-                content=[TextContent(type="text", text=_safe_mcp_error_text(exc))],
-                is_error=True,
-            )
-        return result
+            try:
+                result = await super().call_tool(name, arguments, context)
+            except ToolError as exc:
+                logger.info("MCP tool execution failed: %s", name)
+                return CallToolResult(
+                    content=[TextContent(type="text", text=_safe_mcp_error_text(exc))],
+                    is_error=True,
+                    _meta={"power.request_id": request_id},
+                )
+            except Exception as exc:
+                logger.info("MCP tool execution failed: %s", name)
+                return CallToolResult(
+                    content=[TextContent(type="text", text=_safe_mcp_error_text(exc))],
+                    is_error=True,
+                    _meta={"power.request_id": request_id},
+                )
+            metadata = dict(result.meta or {})
+            metadata["power.request_id"] = request_id
+            return result.model_copy(update={"meta": metadata})
+        finally:
+            _MCP_REQUEST_ID.reset(request_token)
 
     def run(self, transport: str = "stdio", **kwargs: Any) -> None:
         """Run the official SDK over the one supported native stdio transport."""
@@ -307,7 +356,15 @@ async def get_server_info(
     """
     path = _get_vault_path(vault_path)
     report = json.loads(
-        await run_blocking(lambda: report_as_json(run_doctor(path, probe_embedding=probe_provider)))
+        await run_blocking(
+            lambda: report_as_json(
+                run_doctor(
+                    path,
+                    probe_embedding=probe_provider,
+                    allow_search_db_override=False,
+                )
+            )
+        )
     )
     tools = await mcp.list_tools()
     report["mcp"] = mcp_discovery_contract(tools)
@@ -339,8 +396,9 @@ async def lint_vault(vault_path: str | None = None) -> str:
     },
     meta={"power.risk": {"local_only": True, "egress": "none", "approval": "caller"}},
 )
-async def generate_index(vault_path: str | None = None) -> str:
+async def generate_index(vault_path: str | None = None, approved: bool = False) -> str:
     """Compile the vault hierarchical index: a summary index.md plus per-folder _index.md files."""
+    _require_explicit_approval(approved, "generate_index")
     if not _index_limiter.is_allowed("generate_index"):
         remaining = _index_limiter.remaining("generate_index")
         raise ToolError(
@@ -349,9 +407,8 @@ async def generate_index(vault_path: str | None = None) -> str:
 
     path = _get_vault_path(vault_path)
     envelope = await run_blocking(
-        lambda: ApplicationService(path).generate_index(
-            context=RequestContext(actor="mcp", authority="apply")
-        )
+        lambda: ApplicationService(path).generate_index(context=_mcp_context(authority="apply")),
+        mutation=True,
     )
     return str(envelope.data["result"])
 
@@ -371,6 +428,7 @@ async def sync_vault(
     force_rebuild: bool = False,
     allow_partial: bool = False,
     vault_path: str | None = None,
+    approved: bool = False,
 ) -> str:
     """Publish an atomic search-index generation for the configured vault.
 
@@ -386,6 +444,7 @@ async def sync_vault(
     When ``fts_only=True`` would discard an active dense index, the call fails
     closed unless ``accept_dense_loss=True`` is explicit.
     """
+    _require_explicit_approval(approved, "sync_vault")
     if not _index_limiter.is_allowed("sync_vault"):
         remaining = _index_limiter.remaining("sync_vault")
         raise ToolError(
@@ -400,8 +459,9 @@ async def sync_vault(
                 accept_dense_loss=accept_dense_loss,
                 force_rebuild=force_rebuild,
                 allow_partial=allow_partial,
-                context=RequestContext(actor="mcp", authority="apply"),
-            )
+                context=_mcp_context(authority="apply"),
+            ),
+            mutation=True,
         )
     except (
         FileExistsError,
@@ -411,7 +471,7 @@ async def sync_vault(
         ValueError,
         OSError,
     ) as exc:
-        raise ToolError(str(exc)) from exc
+        raise ToolError(_safe_mcp_error_text(exc)) from exc
     return str(envelope.data["result"])
 
 
@@ -452,8 +512,14 @@ async def read_sub_index(category: str, vault_path: str | None = None, page: int
     },
     meta={"power.risk": {"local_only": True, "egress": "none", "approval": "caller"}},
 )
-async def ensure_sub_index(category: str, vault_path: str | None = None, page: int = 1) -> str:
+async def ensure_sub_index(
+    category: str,
+    vault_path: str | None = None,
+    page: int = 1,
+    approved: bool = False,
+) -> str:
     """Generate and read one bounded page of a P.A.R.A. sub-index."""
+    _require_explicit_approval(approved, "ensure_sub_index")
     path = _get_vault_path(vault_path)
     page = _validate_catalog_page(page)
     try:
@@ -461,8 +527,9 @@ async def ensure_sub_index(category: str, vault_path: str | None = None, page: i
             lambda: ApplicationService(path).ensure_sub_index(
                 category,
                 page=page,
-                context=RequestContext(actor="mcp", authority="apply"),
-            )
+                context=_mcp_context(authority="apply"),
+            ),
+            mutation=True,
         )
     except (
         FileExistsError,
@@ -472,7 +539,7 @@ async def ensure_sub_index(category: str, vault_path: str | None = None, page: i
         ValueError,
         OSError,
     ) as exc:
-        raise ToolError(str(exc)) from exc
+        raise ToolError(_safe_mcp_error_text(exc)) from exc
     result = str(envelope.data["result"])
     content = str(envelope.data.get("content", ""))
     return f"{result}\n\n{content}" if content else result
@@ -496,8 +563,11 @@ async def ingest_note(
     resource: str | None = None,
     tags: list[str] | None = None,
     vault_path: str | None = None,
+    approved: bool = False,
+    idempotency_key: str | None = None,
 ) -> str:
     """Create a new note with strict OKF metadata frontmatter, regenerate the index, and log the change."""
+    _require_explicit_approval(approved, "ingest_note")
     if not _write_limiter.is_allowed("ingest"):
         remaining = _write_limiter.remaining("ingest")
         raise ToolError(
@@ -515,8 +585,12 @@ async def ingest_note(
                 content=content,
                 resource=resource,
                 tags=tags,
-                context=RequestContext(actor="mcp", authority="apply"),
-            )
+                context=_mcp_context(
+                    authority="apply",
+                    idempotency_key=idempotency_key,
+                ),
+            ),
+            mutation=True,
         )
     except (
         FileExistsError,
@@ -530,7 +604,7 @@ async def ingest_note(
             raise ToolError(
                 "Invalid note path; use an existing PARA directory and a Markdown filename."
             ) from exc
-        raise ToolError(str(exc)) from exc
+        raise ToolError(_safe_mcp_error_text(exc)) from exc
     return str(envelope.data["result"])
 
 
@@ -567,8 +641,9 @@ async def propose_memory_change(path: str, content: str, vault_path: str | None 
         lambda: ApplicationService(root).propose(
             path,
             content,
-            context=RequestContext(actor="mcp", authority="propose"),
-        )
+            context=_mcp_context(authority="propose"),
+        ),
+        mutation=True,
     )
     return json.dumps(envelope.data, sort_keys=True)
 
@@ -586,17 +661,19 @@ async def apply_memory_change(
     proposal: dict[str, str], approved: bool, vault_path: str | None = None
 ) -> str:
     """Apply only an explicitly approved memory proposal."""
+    _require_explicit_approval(approved, "apply_memory_change")
     root = _get_vault_path(vault_path)
     try:
         receipt = await run_blocking(
             lambda: ApplicationService(root).apply(
                 proposal,
                 approved=approved,
-                context=RequestContext(actor="mcp", authority="apply"),
-            )
+                context=_mcp_context(authority="apply"),
+            ),
+            mutation=True,
         )
     except (PermissionError, RuntimeError, ValueError, OSError) as exc:
-        raise ToolError(str(exc)) from exc
+        raise ToolError(_safe_mcp_error_text(exc)) from exc
     return json.dumps(receipt.data, sort_keys=True)
 
 
@@ -627,7 +704,7 @@ async def validate_memory_state(vault_path: str | None = None) -> bool:
 async def read_memory_history(vault_path: str | None = None) -> str:
     """Read append-only transaction receipts without note content."""
     root = _get_vault_path(vault_path)
-    envelope = await run_blocking(lambda: ApplicationService(root).receipt())
+    envelope = await run_blocking(lambda: ApplicationService(root).receipt(context=_mcp_context()))
     return json.dumps(envelope.data["receipts"], sort_keys=True)
 
 
@@ -701,20 +778,25 @@ async def handoff_work(
                                 else None
                             ),
                         },
-                        context=RequestContext(
+                        context=_mcp_context(
                             actor=actor,
                             authority="propose",
                             idempotency_key=idempotency_key,
                         ),
                     ).data
-                )
+                ),
+                mutation=True,
             )
         elif action == "list":
-            result = await run_blocking(lambda: {"packets": service.task(action="list").data})
+            result = await run_blocking(
+                lambda: {"packets": service.task(action="list", context=_mcp_context()).data}
+            )
         elif action == "show":
             if not task_id:
                 raise ToolError("show requires task_id")
-            result = await run_blocking(lambda: service.task(action="read", task_id=task_id).data)
+            result = await run_blocking(
+                lambda: service.task(action="read", task_id=task_id, context=_mcp_context()).data
+            )
         else:
             if not task_id or not idempotency_key or expected_revision is None:
                 raise ToolError(
@@ -739,13 +821,14 @@ async def handoff_work(
                             "completion_postcondition": completion_postcondition,
                             "completion_artifact_refs": changed_artifacts,
                         },
-                        context=RequestContext(
+                        context=_mcp_context(
                             actor=actor,
                             authority="apply",
                             idempotency_key=idempotency_key,
                         ),
                     ).data
-                )
+                ),
+                mutation=True,
             )
     except ToolError:
         raise
@@ -757,7 +840,7 @@ async def handoff_work(
         ValueError,
         OSError,
     ) as exc:
-        raise ToolError(str(exc)) from exc
+        raise ToolError(_safe_mcp_error_text(exc)) from exc
     return json.dumps(result, ensure_ascii=False, sort_keys=True)
 
 
@@ -798,7 +881,7 @@ async def search_vault_tool(
         temporal_view = normalize_temporal_view(temporal_view).value
         normalized_as_of = normalize_as_of(as_of).isoformat()
     except (ValueError, DomainConfigError) as exc:
-        raise ToolError(str(exc)) from exc
+        raise ToolError(_safe_mcp_error_text(exc)) from exc
 
     def _do_search() -> str:
         try:
@@ -812,7 +895,7 @@ async def search_vault_tool(
                 temporal_view=temporal_view,
                 as_of=normalized_as_of,
                 domain=domain,
-                context=RequestContext(actor="mcp"),
+                context=_mcp_context(),
             )
         except RuntimeError as exc:
             from power_framework.core.generation_index import ActiveGenerationError
@@ -820,7 +903,7 @@ async def search_vault_tool(
 
             if not isinstance(exc, (ActiveGenerationError, DenseIndexUnavailableError)):
                 raise
-            raise ToolError(str(exc)) from exc
+            raise ToolError(_safe_mcp_error_text(exc)) from exc
         return json.dumps(envelope.data, ensure_ascii=False, sort_keys=True)
 
     return await run_blocking(_do_search)
@@ -845,6 +928,8 @@ async def synthesize_session(
     related: list[str] | None = None,
     owner: str | None = None,
     vault_path: str | None = None,
+    approved: bool = False,
+    idempotency_key: str | None = None,
 ) -> str:
     """
     Create a new session synthesis note with auto-classified OKF frontmatter,
@@ -854,6 +939,7 @@ async def synthesize_session(
     session automatically generates a persistent knowledge artifact with
     governance metadata.
     """
+    _require_explicit_approval(approved, "synthesize_session")
     if not _write_limiter.is_allowed("synthesize"):
         remaining = _write_limiter.remaining("synthesize")
         raise ToolError(
@@ -872,8 +958,12 @@ async def synthesize_session(
                 tags=tags,
                 related=related,
                 owner=owner,
-                context=RequestContext(actor="mcp", authority="apply"),
-            )
+                context=_mcp_context(
+                    authority="apply",
+                    idempotency_key=idempotency_key,
+                ),
+            ),
+            mutation=True,
         )
     except (
         FileExistsError,
@@ -887,7 +977,7 @@ async def synthesize_session(
             raise ToolError(
                 "Invalid note path; use an existing PARA directory and a Markdown filename."
             ) from exc
-        raise ToolError(str(exc)) from exc
+        raise ToolError(_safe_mcp_error_text(exc)) from exc
     return str(envelope.data["result"])
 
 
@@ -921,8 +1011,8 @@ async def rot_audit(
     """
     if (allow_link_rot or allow_remote_llm) and not extended:
         raise ToolError("remote ROT capabilities require extended=True")
-    if (allow_link_rot or allow_remote_llm) and not approved:
-        raise ToolError("remote ROT capabilities require explicit approved=True")
+    if allow_link_rot or allow_remote_llm:
+        _require_explicit_approval(approved, "remote ROT capabilities")
     path = _get_vault_path(vault_path)
     return await run_blocking(
         lambda: run_rot_report(
@@ -949,14 +1039,15 @@ async def archive_notes(
     vault_path: str | None = None,
 ) -> str:
     """Move stale/expired notes to 04_Archive. Use dry_run=True (default) to preview first."""
-    if not dry_run and not approved:
-        raise ToolError("archive_notes apply requires explicit approved=True")
+    if not dry_run:
+        _require_explicit_approval(approved, "archive_notes apply")
     path = _get_vault_path(vault_path)
     envelope = await run_blocking(
         lambda: ApplicationService(path).archive_notes(
             dry_run=dry_run,
-            context=RequestContext(actor="mcp", authority="apply") if not dry_run else None,
-        )
+            context=_mcp_context(authority="apply") if not dry_run else None,
+        ),
+        mutation=not dry_run,
     )
     return str(envelope.data["result"])
 
@@ -1009,14 +1100,15 @@ async def heal_frontmatter_tool(
     vault_path: str | None = None,
 ) -> str:
     """Scan and heal missing/invalid frontmatter fields across vault notes. Use dry_run=True (default) to preview first."""
-    if not dry_run and not approved:
-        raise ToolError("heal_frontmatter_tool apply requires explicit approved=True")
+    if not dry_run:
+        _require_explicit_approval(approved, "heal_frontmatter_tool apply")
     path = _get_vault_path(vault_path)
     envelope = await run_blocking(
         lambda: ApplicationService(path).heal_frontmatter(
             dry_run=dry_run,
-            context=RequestContext(actor="mcp", authority="apply") if not dry_run else None,
-        )
+            context=_mcp_context(authority="apply") if not dry_run else None,
+        ),
+        mutation=not dry_run,
     )
     return str(envelope.data["result"])
 

--- a/src/power_framework/web/app.py
+++ b/src/power_framework/web/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import ipaddress
 import logging
 import threading
 import uuid
@@ -19,6 +20,7 @@ from fastapi.templating import Jinja2Templates
 from jinja2 import pass_context
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from power_framework.core.principal import Principal
 from power_framework.core.utils import __version__
 
 if TYPE_CHECKING:
@@ -30,6 +32,7 @@ from .config import Settings, get_global_settings
 from .errors import (
     http_exception_handler,
     make_public_error_response,
+    request_id_for,
     request_validation_handler,
     unhandled_exception_handler,
 )
@@ -49,6 +52,17 @@ from .routes import (
 POWER_VERSION = __version__
 APPLICATION_SCHEMA = "power.application.v2"
 ERROR_LOGGER = logging.getLogger("power_framework.web.errors")
+
+
+def _is_loopback_bind(host: str) -> bool:
+    """Return whether a Web listener is restricted to the local machine."""
+    normalized = host.strip().strip("[]").casefold()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
 
 
 def jinja_csrf_token(context: dict[str, Any]) -> str:
@@ -159,40 +173,72 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # Authentication, Language & Theme guard middleware
     @app.middleware("http")
     async def auth_middleware(request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if not getattr(request.state, "request_id", None):
+            request.state.request_id = uuid.uuid4().hex
         lang = get_request_lang(request)
         theme = get_request_theme(request)
         request.state.lang = lang
         request.state.theme = theme
 
         is_auth = False
-        if not app_settings.auth_enabled:
+        principal: Principal | None = None
+        request.state.session_subject = None
+        path = request.url.path
+        public_paths = {
+            "/login",
+            "/healthz",
+            "/readiness",
+            "/set-lang",
+            "/set-theme",
+        }
+        if not app_settings.auth_enabled and _is_loopback_bind(app_settings.host):
+            # This is a local-process trust rule, not anonymous remote access.
             is_auth = True
+            principal = Principal.local_cli()
+        elif not app_settings.auth_enabled:
+            if path in public_paths or path.startswith("/static/"):
+                response = await call_next(request)
+                _maybe_set_csrf_cookie(request, response, app_settings)
+                return response
+            request.state.is_authenticated = False
+            request.state.principal = None
+            return make_public_error_response(
+                request,
+                403,
+                "authentication_required",
+                "Authentication is required.",
+            )
         else:
             cookie = request.cookies.get(app_settings.session_cookie_name)
             if cookie:
                 session_mgr = SessionManager(app_settings.secret_key)
-                user_id = session_mgr.verify_session(cookie)
-                if user_id:
+                verified_session = session_mgr.verify_session_details(
+                    cookie,
+                    max_age_seconds=app_settings.session_max_age_seconds,
+                )
+                if verified_session is not None:
+                    user_id, session_expires_at = verified_session
                     is_auth = True
+                    request.state.session_subject = user_id
+                    principal = Principal.web_signed_session(
+                        user_id,
+                        expires_at=session_expires_at,
+                    )
 
         request.state.is_authenticated = is_auth
+        request.state.principal = principal
 
         if app_settings.auth_enabled:
-            path = request.url.path
             # Allow public assets, login, language switch, theme switch, and healthcheck
-            if path in {
-                "/login",
-                "/healthz",
-                "/readiness",
-                "/set-lang",
-                "/set-theme",
-            } or path.startswith("/static/"):
+            if path in public_paths or path.startswith("/static/"):
                 response = await call_next(request)
                 _maybe_set_csrf_cookie(request, response, app_settings)
                 return response
 
             if not is_auth:
-                return RedirectResponse(url="/login", status_code=303)
+                response = RedirectResponse(url="/login", status_code=303)
+                response.headers["X-Request-ID"] = request_id_for(request)
+                return response
 
         response = await call_next(request)
         _maybe_set_csrf_cookie(request, response, app_settings)
@@ -249,6 +295,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             issues.append("configured vault is missing")
         if settings.auth_enabled and not (settings.admin_password or settings.admin_password_hash):
             issues.append("authentication is enabled without credentials")
+        local_trust = _is_loopback_bind(settings.host)
+        if not settings.auth_enabled and not local_trust:
+            issues.append("auth-disabled mode requires a loopback bind")
         vault_identity = hashlib.sha256(
             str(settings.vault_path.expanduser().resolve()).encode("utf-8")
         ).hexdigest()[:16]
@@ -262,8 +311,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 "exists": settings.vault_path.is_dir(),
                 "identity": vault_identity,
             },
-            "auth_configured": not settings.auth_enabled
-            or bool(settings.admin_password or settings.admin_password_hash),
+            "auth_configured": (
+                local_trust
+                if not settings.auth_enabled
+                else bool(settings.admin_password or settings.admin_password_hash)
+            ),
             "issues": issues,
         }
         return JSONResponse(payload, status_code=200 if not issues else 503)

--- a/src/power_framework/web/auth/session.py
+++ b/src/power_framework/web/auth/session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime, timedelta
 
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 
@@ -21,9 +22,35 @@ class SessionManager:
 
     def verify_session(self, token: str, max_age_seconds: int = 86400) -> str | None:
         """Verify signed session token and return user ID if valid and not expired."""
+        verified = self.verify_session_details(token, max_age_seconds=max_age_seconds)
+        return verified[0] if verified is not None else None
+
+    def verify_session_details(
+        self,
+        token: str,
+        max_age_seconds: int = 86400,
+    ) -> tuple[str, datetime] | None:
+        """Verify a session and return its subject plus the token's actual expiry."""
+        if not isinstance(token, str) or not token or max_age_seconds <= 0:
+            return None
         try:
-            data = self.serializer.loads(token, max_age=max_age_seconds)
-            return str(data.get("sub"))
+            loaded = self.serializer.loads(
+                token,
+                max_age=max_age_seconds,
+                return_timestamp=True,
+            )
+            if not isinstance(loaded, tuple) or len(loaded) != 2:
+                return None
+            data, issued_at = loaded
+            subject = data.get("sub") if isinstance(data, dict) else None
+            if (
+                not isinstance(subject, str)
+                or not subject.strip()
+                or len(subject) > 256
+                or not isinstance(issued_at, datetime)
+            ):
+                return None
+            return subject, issued_at.astimezone(UTC) + timedelta(seconds=max_age_seconds)
         except SignatureExpired:
             logger.debug("Session expired")
             return None

--- a/src/power_framework/web/clients/power.py
+++ b/src/power_framework/web/clients/power.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+import uuid
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -16,27 +18,64 @@ from power_framework.core.application_models import (
     TaskDTO,
     TaskEventDTO,
 )
+from power_framework.core.principal import Principal
 from power_framework.core.searcher import search_vault
 
 
 class PowerClient:
     """Client port interacting with POWER core exclusively through ApplicationService boundary."""
 
-    def __init__(self, vault_path: Path) -> None:
+    def __init__(
+        self,
+        vault_path: Path,
+        *,
+        principal: Principal | None = None,
+        request_id: str | None = None,
+    ) -> None:
         self.vault_path = Path(vault_path).expanduser().resolve()
+        self.principal = principal or Principal.local_cli()
+        self.request_id = request_id or uuid.uuid4().hex
+        self._deadline_at: float | None = None
+        self._deadline_ms: int | None = None
         self._service = ApplicationService(
             self.vault_path,
             search_fn=partial(search_vault, allow_search_db_override=False),
         )
 
+    def bind_request_budget(self, request_id: str, timeout_seconds: float) -> None:
+        """Bind one Web request correlation ID and absolute execution budget."""
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self.request_id = request_id
+        self._deadline_at = time.monotonic() + timeout_seconds
+        self._deadline_ms = max(1, int(timeout_seconds * 1000))
+
+    def _context(
+        self,
+        *,
+        actor: str,
+        authority: str = "read-only",
+        idempotency_key: str | None = None,
+    ) -> RequestContext:
+        """Create a context with server-bound principal and request metadata."""
+        return RequestContext(
+            actor=actor,
+            authority=authority,  # type: ignore[arg-type]
+            idempotency_key=idempotency_key,
+            request_id=self.request_id,
+            principal=self.principal,
+            deadline_at=self._deadline_at,
+            deadline_ms=self._deadline_ms,
+        )
+
     def discover(self, actor: str = "web") -> ApplicationEnvelope:
         """Fetch system capability manifest."""
-        ctx = RequestContext(actor=actor, authority="read-only")
+        ctx = self._context(actor=actor)
         return self._service.discover(context=ctx)
 
     def get_source_stats(self, actor: str = "web") -> SourceStatsResponse:
         """Fetch aggregated vault statistics."""
-        ctx = RequestContext(actor=actor, authority="read-only")
+        ctx = self._context(actor=actor)
         env = self._service.source_stats(context=ctx)
         return SourceStatsResponse.model_validate(env.data)
 
@@ -54,7 +93,7 @@ class PowerClient:
         req = SourceListRequest(
             prefix=prefix, category=category, tag=tag, limit=limit, cursor=cursor
         )
-        ctx = RequestContext(actor=actor, authority="read-only")
+        ctx = self._context(actor=actor)
         env = self._service.source_list(req, context=ctx)
         return SourceListResponse.model_validate(env.data)
 
@@ -62,7 +101,7 @@ class PowerClient:
         self, rel_path: str, max_bytes: int = 2_000_000, actor: str = "web"
     ) -> SourceReadResponse:
         """Read a note securely."""
-        ctx = RequestContext(actor=actor, authority="read-only")
+        ctx = self._context(actor=actor)
         env = self._service.source_read(rel_path, max_bytes=max_bytes, context=ctx)
         return SourceReadResponse.model_validate(env.data)
 
@@ -74,7 +113,7 @@ class PowerClient:
         actor: str = "web",
     ) -> GraphProjectionResponse:
         """Fetch knowledge graph projection."""
-        ctx = RequestContext(actor=actor, authority="read-only")
+        ctx = self._context(actor=actor)
         env = self._service.source_graph(
             max_nodes=max_nodes,
             focus_path=focus_path,
@@ -92,7 +131,7 @@ class PowerClient:
         actor: str = "web",
     ) -> ApplicationEnvelope:
         """Search the vault."""
-        ctx = RequestContext(actor=actor, authority="read-only")
+        ctx = self._context(actor=actor)
         return self._service.retrieve(query, mode=mode, max_results=max_results, context=ctx)
 
     def list_tasks(
@@ -106,7 +145,7 @@ class PowerClient:
         actor: str = "web",
     ) -> list[TaskDTO]:
         """List Task v2 items."""
-        ctx = RequestContext(actor=actor, authority="read-only")
+        ctx = self._context(actor=actor)
         env = self._service.task_list(
             state=state, owner=owner, assignee=assignee, limit=limit, offset=offset, context=ctx
         )
@@ -117,7 +156,7 @@ class PowerClient:
 
     def get_task(self, task_id: str, actor: str = "web") -> TaskDTO:
         """Read a single Task v2."""
-        ctx = RequestContext(actor=actor, authority="read-only")
+        ctx = self._context(actor=actor)
         env = self._service.task_read(task_id, context=ctx)
         return TaskDTO.model_validate(env.data)
 
@@ -137,7 +176,11 @@ class PowerClient:
         **kwargs: Any,
     ) -> TaskDTO:
         """Create a new Task v2."""
-        ctx = RequestContext(actor=actor, authority="propose", idempotency_key=idempotency_key)
+        ctx = self._context(
+            actor=actor,
+            authority="propose",
+            idempotency_key=idempotency_key,
+        )
         env = self._service.task_create(
             task_id=task_id,
             title=title,
@@ -165,7 +208,11 @@ class PowerClient:
         **kwargs: Any,
     ) -> TaskDTO:
         """Transition Task v2 state."""
-        ctx = RequestContext(actor=actor, authority="apply", idempotency_key=idempotency_key)
+        ctx = self._context(
+            actor=actor,
+            authority="apply",
+            idempotency_key=idempotency_key,
+        )
         env = self._service.task_transition(
             task_id=task_id,
             new_state=new_state,
@@ -181,7 +228,7 @@ class PowerClient:
         self, task_id: str, since_sequence: int = 0, actor: str = "web"
     ) -> list[TaskEventDTO]:
         """Fetch task event stream."""
-        ctx = RequestContext(actor=actor, authority="read-only")
+        ctx = self._context(actor=actor)
         env = self._service.task_events(task_id, since_sequence=since_sequence, context=ctx)
         raw_items = env.data.get("items", []) if isinstance(env.data, dict) else env.data
         if isinstance(raw_items, list):
@@ -196,25 +243,34 @@ class PowerClient:
         idempotency_key: str | None = None,
     ) -> ApplicationEnvelope:
         """Create a proposal for a note modification."""
-        ctx = RequestContext(actor=actor, authority="propose", idempotency_key=idempotency_key)
+        ctx = self._context(
+            actor=actor,
+            authority="propose",
+            idempotency_key=idempotency_key,
+        )
         return self._service.propose(rel_path, content, context=ctx)
 
     def apply(
         self,
         proposal_id: str,
-        approved: bool = True,
+        *,
+        approved: bool,
         actor: str = "web",
         idempotency_key: str | None = None,
     ) -> ApplicationEnvelope:
         """Apply a durable proposal by content-addressed ID only."""
-        ctx = RequestContext(actor=actor, authority="apply", idempotency_key=idempotency_key)
+        ctx = self._context(
+            actor=actor,
+            authority="apply",
+            idempotency_key=idempotency_key,
+        )
         if not proposal_id.strip():
             raise ValueError("proposal_id is required")
         return self._service.apply_proposal(proposal_id, approved=approved, context=ctx)
 
     def list_decisions(self, actor: str = "web") -> list[dict[str, Any]]:
         """Read canonical DecisionService projections."""
-        ctx = RequestContext(actor=actor, authority="read-only")
+        ctx = self._context(actor=actor)
         env = self._service.decision_list(context=ctx)
         raw = env.data.get("items", []) if isinstance(env.data, dict) else env.data
         return raw if isinstance(raw, list) else []
@@ -230,7 +286,11 @@ class PowerClient:
         idempotency_key: str | None = None,
     ) -> ApplicationEnvelope:
         """Resolve a canonical decision through ApplicationService."""
-        ctx = RequestContext(actor=actor, authority="apply", idempotency_key=idempotency_key)
+        ctx = self._context(
+            actor=actor,
+            authority="apply",
+            idempotency_key=idempotency_key,
+        )
         return self._service.decision_resolve(
             decision_id,
             action=action,
@@ -241,7 +301,7 @@ class PowerClient:
 
     def get_receipts(self, limit: int = 100, actor: str = "web") -> list[dict[str, Any]]:
         """Fetch audit receipts."""
-        ctx = RequestContext(actor=actor, authority="read-only")
+        ctx = self._context(actor=actor)
         env = self._service.receipt(limit=limit, context=ctx)
         receipts = env.data.get("receipts", [])
         if isinstance(receipts, list):

--- a/src/power_framework/web/config.py
+++ b/src/power_framework/web/config.py
@@ -13,8 +13,11 @@ from fastapi import HTTPException, Request
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from power_framework.core.principal import Principal
+
 from .auth.csrf import verify_csrf_token
 from .auth.session import SessionManager
+from .errors import request_id_for
 
 if TYPE_CHECKING:
     from .clients.power import PowerClient
@@ -114,7 +117,14 @@ def get_client(request: Request) -> PowerClient:
     from .clients.power import PowerClient
 
     settings: Settings = get_settings(request)
-    return PowerClient(settings.vault_path)
+    principal = getattr(request.state, "principal", None)
+    if not isinstance(principal, Principal):
+        raise HTTPException(status_code=403, detail="A bound application principal is required")
+    return PowerClient(
+        settings.vault_path,
+        principal=principal,
+        request_id=request_id_for(request),
+    )
 
 
 def require_mutation_enabled(request: Request) -> None:

--- a/src/power_framework/web/errors.py
+++ b/src/power_framework/web/errors.py
@@ -10,6 +10,11 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from power_framework.core.application import (
+    CompletedAfterDeadlineError,
+    DeadlineExceededError,
+    ResultBudgetExceededError,
+)
 from power_framework.core.errors import ConflictError
 
 _REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
@@ -17,6 +22,14 @@ _REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 
 class PowerCallTimeoutError(TimeoutError):
     """A bounded synchronous POWER call exceeded its request deadline."""
+
+
+class PowerCallCompletedAfterDeadlineError(TimeoutError):
+    """A mutation worker was joined and completed after the caller deadline."""
+
+
+class PowerCallCompletedAfterCancellationError(TimeoutError):
+    """A canceled mutation worker was joined and its outcome is now known."""
 
 
 class PublicError(BaseModel):
@@ -75,6 +88,26 @@ def _exception_mapping(exc: BaseException) -> tuple[int, str, str]:
         default_code, message = domain_messages[domain_status]
         code = domain_code if isinstance(domain_code, str) else default_code
         return domain_status, code, message
+    if isinstance(exc, PowerCallCompletedAfterDeadlineError):
+        return 504, "completed_after_deadline", "The POWER operation completed after its deadline."
+    if isinstance(exc, PowerCallCompletedAfterCancellationError):
+        return (
+            499,
+            "completed_after_cancellation",
+            "The POWER operation completed after cancellation.",
+        )
+    if isinstance(exc, CompletedAfterDeadlineError):
+        return 504, "completed_after_deadline", "The POWER operation completed after its deadline."
+    if isinstance(exc, DeadlineExceededError):
+        if "before operation started" in str(exc):
+            return (
+                408,
+                "rejected_before_start",
+                "The POWER operation was rejected before it started.",
+            )
+        return 408, "deadline_exceeded", "The POWER operation exceeded its deadline."
+    if isinstance(exc, ResultBudgetExceededError):
+        return 413, "result_budget_exceeded", "The POWER result exceeded its response budget."
     if isinstance(exc, (PowerCallTimeoutError, TimeoutError)):
         return 504, "timeout", "The POWER service did not complete the request in time."
     if isinstance(exc, FileNotFoundError):
@@ -106,6 +139,20 @@ def public_http_exception(exc: BaseException) -> HTTPException:
 def _http_mapping(exc: StarletteHTTPException) -> tuple[int, str, str]:
     """Map framework HTTP failures without reflecting their detail field."""
     status_code = exc.status_code
+    if status_code == 504 and exc.detail == "completed_after_deadline":
+        return 504, "completed_after_deadline", "The POWER operation completed after its deadline."
+    if status_code == 499 and exc.detail == "completed_after_cancellation":
+        return (
+            499,
+            "completed_after_cancellation",
+            "The POWER operation completed after cancellation.",
+        )
+    if status_code == 408 and exc.detail == "rejected_before_start":
+        return 408, "rejected_before_start", "The POWER operation was rejected before it started."
+    if status_code == 408 and exc.detail == "deadline_exceeded":
+        return 408, "deadline_exceeded", "The POWER operation exceeded its deadline."
+    if status_code == 413 and exc.detail == "result_budget_exceeded":
+        return 413, "result_budget_exceeded", "The POWER result exceeded its response budget."
     known = {
         400: ("invalid_request", "The request is invalid."),
         401: ("authentication_required", "Authentication is required."),
@@ -162,6 +209,8 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
 
 
 __all__ = [
+    "PowerCallCompletedAfterCancellationError",
+    "PowerCallCompletedAfterDeadlineError",
     "PowerCallTimeoutError",
     "PublicError",
     "PublicErrorResponse",

--- a/src/power_framework/web/errors.py
+++ b/src/power_framework/web/errors.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from power_framework.core.application import (
+    CompletedAfterBudgetError,
     CompletedAfterDeadlineError,
     DeadlineExceededError,
     ResultBudgetExceededError,
@@ -106,6 +107,12 @@ def _exception_mapping(exc: BaseException) -> tuple[int, str, str]:
                 "The POWER operation was rejected before it started.",
             )
         return 408, "deadline_exceeded", "The POWER operation exceeded its deadline."
+    if isinstance(exc, CompletedAfterBudgetError):
+        return (
+            413,
+            "completed_after_budget",
+            "The POWER operation completed beyond its response budget.",
+        )
     if isinstance(exc, ResultBudgetExceededError):
         return 413, "result_budget_exceeded", "The POWER result exceeded its response budget."
     if isinstance(exc, (PowerCallTimeoutError, TimeoutError)):
@@ -153,6 +160,12 @@ def _http_mapping(exc: StarletteHTTPException) -> tuple[int, str, str]:
         return 408, "deadline_exceeded", "The POWER operation exceeded its deadline."
     if status_code == 413 and exc.detail == "result_budget_exceeded":
         return 413, "result_budget_exceeded", "The POWER result exceeded its response budget."
+    if status_code == 413 and exc.detail == "completed_after_budget":
+        return (
+            413,
+            "completed_after_budget",
+            "The POWER operation completed beyond its response budget.",
+        )
     known = {
         400: ("invalid_request", "The request is invalid."),
         401: ("authentication_required", "Authentication is required."),

--- a/src/power_framework/web/offload.py
+++ b/src/power_framework/web/offload.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
 import anyio
 
-from .errors import PowerCallTimeoutError, public_http_exception
+from .errors import (
+    PowerCallCompletedAfterCancellationError,
+    PowerCallCompletedAfterDeadlineError,
+    PowerCallTimeoutError,
+    public_http_exception,
+    request_id_for,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -25,28 +32,70 @@ async def run_power_call[R](
     /,
     *args: Any,
     timeout_seconds: float | None = None,
+    mutation: bool = False,
     **kwargs: Any,
 ) -> R:
     """Run one blocking POWER call in a bounded, cancellation-aware worker slot."""
     limiter = getattr(request.app.state, "power_call_limiter", None)
     if limiter is None:
-        limiter = anyio.CapacityLimiter(settings.power_call_max_concurrency)
+        raise RuntimeError("shared POWER worker limiter is not configured")
+
+    timeout = settings.power_call_timeout_seconds if timeout_seconds is None else timeout_seconds
+    if timeout <= 0:
+        raise ValueError("timeout_seconds must be positive")
+
+    binder = getattr(getattr(function, "__self__", None), "bind_request_budget", None)
+    if callable(binder):
+        binder(request_id_for(request), timeout)
 
     call = partial(function, *args, **kwargs)
-    timeout = timeout_seconds or settings.power_call_timeout_seconds
-    try:
-        return await asyncio.wait_for(
-            anyio.to_thread.run_sync(
-                call,
-                abandon_on_cancel=True,
-                limiter=limiter,
-            ),
-            timeout=timeout,
+    worker = asyncio.create_task(
+        anyio.to_thread.run_sync(
+            call,
+            abandon_on_cancel=True,
+            limiter=limiter,
         )
+    )
+    try:
+        return await asyncio.wait_for(asyncio.shield(worker), timeout=timeout)
     except TimeoutError as exc:
+        if mutation:
+            try:
+                await _join_worker(worker)
+            except Exception as worker_error:
+                raise public_http_exception(worker_error) from worker_error
+            raise PowerCallCompletedAfterDeadlineError from exc
+        worker.add_done_callback(_consume_worker_result)
         raise PowerCallTimeoutError from exc
+    except asyncio.CancelledError:
+        if mutation:
+            try:
+                await _join_worker(worker)
+            except Exception as worker_error:
+                raise public_http_exception(worker_error) from worker_error
+            raise PowerCallCompletedAfterCancellationError from None
+        worker.add_done_callback(_consume_worker_result)
+        raise
     except Exception as exc:
         raise public_http_exception(exc) from exc
+
+
+async def _join_worker[R](worker: asyncio.Task[R]) -> R:
+    """Observe a worker to completion without abandoning a mutation."""
+    while not worker.done():
+        try:
+            await asyncio.sleep(0.01)
+        except asyncio.CancelledError:
+            # Keep the mutation joined; the cancellation is re-raised by the
+            # caller after the worker's outcome is known.
+            continue
+    return worker.result()
+
+
+def _consume_worker_result[R](worker: asyncio.Task[R]) -> None:
+    """Consume a detached read worker result to avoid unhandled-task warnings."""
+    with contextlib.suppress(BaseException):
+        worker.result()
 
 
 __all__ = ["run_power_call"]

--- a/src/power_framework/web/offload.py
+++ b/src/power_framework/web/offload.py
@@ -82,14 +82,13 @@ async def run_power_call[R](
 
 async def _join_worker[R](worker: asyncio.Task[R]) -> R:
     """Observe a worker to completion without abandoning a mutation."""
-    while not worker.done():
+    while True:
         try:
-            await asyncio.sleep(0.01)
+            return await asyncio.shield(worker)
         except asyncio.CancelledError:
             # Keep the mutation joined; the cancellation is re-raised by the
             # caller after the worker's outcome is known.
             continue
-    return worker.result()
 
 
 def _consume_worker_result[R](worker: asyncio.Task[R]) -> None:

--- a/src/power_framework/web/routes/decisions.py
+++ b/src/power_framework/web/routes/decisions.py
@@ -61,6 +61,7 @@ async def resolve_decision_action(
         action=action,
         input_data={"value": input_value} if action == "provide_input" else None,
         idempotency_key=key_for("resolve", decision_id=decision_id, decision_action=action),
+        mutation=True,
     )
 
     return RedirectResponse(url="/decisions", status_code=303)

--- a/src/power_framework/web/routes/federation.py
+++ b/src/power_framework/web/routes/federation.py
@@ -50,6 +50,7 @@ DEFAULT_FLEET_TOPOLOGY: list[dict[str, Any]] = [
         "vault_id_type": "mounted",
     },
 ]
+_MAX_FEDERATION_NODES = 16
 
 
 def _get_fleet_topology(settings: Settings) -> list[dict[str, Any]]:
@@ -57,17 +58,40 @@ def _get_fleet_topology(settings: Settings) -> list[dict[str, Any]]:
     if settings.federation_nodes:
         try:
             parsed = json.loads(settings.federation_nodes)
-            if isinstance(parsed, list) and all(isinstance(item, dict) for item in parsed):
-                return parsed
+            if not isinstance(parsed, list) or len(parsed) > _MAX_FEDERATION_NODES:
+                raise ValueError("federation topology exceeds its node limit")
+            validated: list[dict[str, Any]] = []
+            for item in parsed:
+                if not isinstance(item, dict):
+                    raise ValueError("federation topology entries must be objects")
+                host = item.get("host", "127.0.0.1")
+                port = item.get("port", 8080)
+                if (
+                    not isinstance(host, str)
+                    or not host.strip()
+                    or len(host) > 253
+                    or any(char.isspace() for char in host)
+                    or "://" in host
+                    or not isinstance(port, int)
+                    or isinstance(port, bool)
+                    or not 1 <= port <= 65535
+                ):
+                    raise ValueError("federation topology contains an invalid host or port")
+                validated.append({**item, "host": host, "port": port})
+            return validated
         except Exception as exc:
-            logger.warning("Failed to parse POWER_WEB_FEDERATION_NODES: %s", exc)
+            logger.warning(
+                "Ignoring invalid POWER_WEB_FEDERATION_NODES configuration exception_type=%s",
+                type(exc).__name__,
+            )
     return DEFAULT_FLEET_TOPOLOGY
 
 
 async def _probe_node(node: dict[str, Any], vault_id: str, total_notes: int) -> dict[str, Any]:
     """Asynchronously probe TCP port with low timeout and measure latency."""
     host = str(node.get("host", "127.0.0.1"))
-    port = int(node.get("port", 8080))
+    raw_port = node.get("port", 8080)
+    port = raw_port if isinstance(raw_port, int) and not isinstance(raw_port, bool) else 8080
     t0 = time.perf_counter()
     status = "unreachable"
     latency_ms: float | None = None
@@ -112,9 +136,18 @@ async def federation_view(
     )
     topology = _get_fleet_topology(settings)
 
-    # Parallel asynchronous health probing across the configured fleet topology
-    nodes = await asyncio.gather(
-        *(_probe_node(n, vault_id=stats.vault_id, total_notes=stats.total_notes) for n in topology)
+    # Parallel probing remains bounded both by node count and active probes.
+    probe_limiter = asyncio.Semaphore(
+        min(_MAX_FEDERATION_NODES, settings.power_call_max_concurrency)
+    )
+
+    async def bounded_probe(node: dict[str, Any]) -> dict[str, Any]:
+        async with probe_limiter:
+            return await _probe_node(node, vault_id=stats.vault_id, total_notes=stats.total_notes)
+
+    nodes = await asyncio.wait_for(
+        asyncio.gather(*(bounded_probe(node) for node in topology)),
+        timeout=settings.power_call_timeout_seconds,
     )
 
     return templates.TemplateResponse(

--- a/src/power_framework/web/routes/notes.py
+++ b/src/power_framework/web/routes/notes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, Depends, Form, Query, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
 from ..auth.csrf import validate_csrf
@@ -141,6 +141,7 @@ async def propose_note_view(
         path,
         content,
         idempotency_key=key_for("propose", path=path, content=content),
+        mutation=True,
     )
 
     return templates.TemplateResponse(
@@ -162,17 +163,20 @@ async def propose_note_view(
 async def apply_note_view(
     request: Request,
     proposal_id: str = Form(..., max_length=128),
-    approved: bool = Form(True),
+    approved: str = Form(..., max_length=5),
     client: PowerClient = Depends(get_client),
 ) -> RedirectResponse:
     """Apply an approved proposal with explicit authority and postcondition check."""
+    if approved != "true":
+        raise HTTPException(status_code=403, detail="Apply requires an explicit true approval")
     settings = get_settings(request)
     envelope = await run_power_call(
         request,
         settings,
         client.apply,
         proposal_id,
-        approved=approved,
+        approved=True,
+        mutation=True,
     )
 
     path = envelope.data.get("path", "") if isinstance(envelope.data, dict) else ""

--- a/src/power_framework/web/routes/tasks.py
+++ b/src/power_framework/web/routes/tasks.py
@@ -117,6 +117,7 @@ async def create_task_action(
             priority=priority,
             authority=authority,
         ),
+        mutation=True,
     )
 
     return RedirectResponse(
@@ -184,6 +185,7 @@ async def transition_task_action(
             expected_revision=expected_revision,
             next_action=next_action,
         ),
+        mutation=True,
     )
 
     return RedirectResponse(

--- a/src/power_framework/web/templates/proposal_review.html
+++ b/src/power_framework/web/templates/proposal_review.html
@@ -38,7 +38,10 @@
     name="proposal_id"
     value="{{ proposal.get('proposal_id', '') }}"
   />
-  <input type="hidden" name="approved" value="true" />
+  <label style="display: flex; gap: 8px; align-items: center; margin-bottom: 16px">
+    <input type="checkbox" name="approved" value="true" required />
+    Я підтверджую явне застосування цієї пропозиції.
+  </label>
 
   <div style="margin-bottom: 16px">
     <h3 style="font-size: 1rem; margin-bottom: 8px">

--- a/tests/test_foundation_hardening.py
+++ b/tests/test_foundation_hardening.py
@@ -1,0 +1,415 @@
+"""Focused F1--F5 foundation hardening contracts."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from contextlib import closing
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+from power_framework.core.application import (
+    ApplicationService,
+    CompletedAfterBudgetError,
+    CompletedAfterDeadlineError,
+    DeadlineExceededError,
+    RequestContext,
+    ResultBudgetExceededError,
+)
+from power_framework.core.errors import ConflictError
+from power_framework.core.principal import Principal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_principal_factories_keep_binding_separate_from_actor() -> None:
+    """Principal references are issued by a binding, never copied from actor text."""
+    local = Principal.local_cli()
+    web = Principal.web_signed_session("admin")
+
+    assert local.binding == "LOCAL_CLI"
+    assert local.ref == "local-cli"
+    assert web.binding == "WEB_SIGNED_SESSION"
+    assert web.ref.startswith("web-")
+    assert "admin" not in web.ref
+    assert local.is_valid()
+    assert web.is_valid()
+
+    with pytest.raises(ValueError, match="trusted binding"):
+        Principal(ref="forged", binding="WEB_SIGNED_SESSION")  # type: ignore[call-arg]
+    with pytest.raises(ValueError, match="principal binding"):
+        RequestContext(authority="apply", principal=None)
+
+
+def test_mutation_requires_context_and_emits_bounded_failure_receipt(
+    sample_vault: Path,
+) -> None:
+    """Missing mutation context cannot reach a writer and is safely receipted."""
+    audit = []
+    service = ApplicationService(sample_vault, audit_hook=audit.append)
+    content = (
+        '---\ntype: Project\ntitle: "Rejected"\n'
+        'description: "must not write"\ntimestamp: 2026-09-09T00:00:00Z\n---\n'
+    )
+
+    with pytest.raises(PermissionError, match="explicit RequestContext"):
+        service.propose("01_Projects/Rejected.md", content)
+
+    assert not (sample_vault / ".power" / "proposals").exists()
+    assert audit
+    failure = audit[-1].as_dict()
+    assert failure["status"] != "ok"
+    assert failure["outcome"] == "failed"
+    assert failure["error_code"] == "permission_denied"
+    assert failure["principal_ref"] is None
+    assert len(json.dumps(failure)) < 2048
+
+
+def test_generic_mutation_runner_does_not_default_missing_context(sample_vault: Path) -> None:
+    """The shared execution boundary also fails closed for direct mutation calls."""
+    called = False
+
+    def sentinel() -> None:
+        nonlocal called
+        called = True
+
+    with pytest.raises(PermissionError, match="explicit RequestContext"):
+        ApplicationService(sample_vault)._run("test.mutation", None, sentinel, mutation=True)
+
+    assert called is False
+
+
+def test_generic_mutation_runner_rejects_read_only_context(sample_vault: Path) -> None:
+    """A read-only context cannot be relabeled as a mutation by the runner."""
+    called = False
+
+    def sentinel() -> None:
+        nonlocal called
+        called = True
+
+    with pytest.raises(PermissionError, match="propose or apply"):
+        ApplicationService(sample_vault)._run(
+            "test.mutation",
+            RequestContext(principal=Principal.local_cli()),
+            sentinel,
+            mutation=True,
+        )
+
+    assert called is False
+
+
+def test_proposal_idempotency_key_cannot_bind_two_different_payloads(sample_vault: Path) -> None:
+    """A repeated proposal key is replay-safe and cannot create a second claim."""
+    service = ApplicationService(sample_vault)
+    first = (
+        '---\ntype: Project\ntitle: "First"\ndescription: "one"\n'
+        "timestamp: 2026-09-09T00:00:00Z\n---\n"
+    )
+    second = first.replace('title: "First"', 'title: "Second"')
+    context = RequestContext(
+        authority="propose",
+        idempotency_key="same-proposal-key",
+        principal=Principal.local_cli(),
+    )
+
+    service.propose("01_Projects/First.md", first, context=context)
+    with pytest.raises(ConflictError, match="idempotency key"):
+        service.propose("01_Projects/Second.md", second, context=context)
+
+    proposals = list((sample_vault / ".power" / "proposals").glob("*.json"))
+    assert len(proposals) == 1
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink policy test requires POSIX")
+def test_proposal_control_directory_symlink_is_rejected(sample_vault: Path, tmp_path: Path) -> None:
+    """A control-subdirectory symlink cannot redirect proposal writes."""
+    external = tmp_path / "external-proposals"
+    external.mkdir()
+    (sample_vault / ".power").mkdir()
+    (sample_vault / ".power" / "proposals").symlink_to(external, target_is_directory=True)
+    content = (
+        '---\ntype: Project\ntitle: "Symlink"\ndescription: "reject"\n'
+        "timestamp: 2026-09-09T00:00:00Z\n---\n"
+    )
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        ApplicationService(sample_vault).propose(
+            "01_Projects/Symlink.md",
+            content,
+            context=RequestContext(authority="propose", principal=Principal.local_cli()),
+        )
+
+    assert list(external.iterdir()) == []
+
+
+def test_ingest_replays_same_idempotency_key_without_duplicate_write(sample_vault: Path) -> None:
+    """A lost response can be replayed without treating the existing note as new work."""
+    service = ApplicationService(sample_vault)
+    context = RequestContext(
+        authority="apply",
+        idempotency_key="ingest-replay",
+        principal=Principal.local_cli(),
+    )
+    values = {
+        "name": "01_Projects/Replay.md",
+        "note_type": "Project",
+        "title": "Replay",
+        "description": "Idempotent ingest",
+        "content": "body",
+        "context": context,
+    }
+
+    first = service.ingest_note(**values)
+    replay = service.ingest_note(**values)
+
+    assert first.data["receipt"] == replay.data["receipt"]
+
+
+def test_expired_principal_cannot_mutate(sample_vault: Path) -> None:
+    """A verified binding with an expired lifetime is rejected at the core boundary."""
+    expired = Principal.web_signed_session(
+        "admin",
+        expires_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+
+    with pytest.raises(PermissionError, match="expired"):
+        ApplicationService(sample_vault).task_create(
+            "expired-task",
+            "Expired task",
+            context=RequestContext(
+                actor="forged-attribution",
+                authority="propose",
+                principal=expired,
+            ),
+        )
+
+    assert not (sample_vault / ".power" / "tasks").exists()
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        "absolute-external.db",
+        "../relative-traversal.db",
+        "file:///tmp/uri-looking.db",
+        "http://127.0.0.1:9/network-looking.db",
+    ],
+)
+def test_application_retrieval_ignores_external_search_db_overrides(
+    sample_vault: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    override: str,
+) -> None:
+    """Agent-facing ApplicationService retrieval cannot select POWER_SEARCH_DB."""
+    external = tmp_path / "external-search.db"
+    external.write_text("not a database", encoding="utf-8")
+    monkeypatch.setenv(
+        "POWER_SEARCH_DB",
+        str(external) if override == "absolute-external.db" else override,
+    )
+
+    result = ApplicationService(sample_vault).retrieve("not-present", mode="fts")
+
+    assert result.data["result_count"] == 0
+    assert external.read_text(encoding="utf-8") == "not a database"
+
+
+def test_application_retrieval_cannot_use_a_valid_external_index(
+    sample_vault: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid attacker-selected SQLite index is not the ApplicationService authority."""
+    from power_framework.core.db import _init_db
+
+    external = tmp_path / "valid-external.db"
+    with closing(sqlite3.connect(external)) as connection:
+        _init_db(connection)
+        connection.execute(
+            "INSERT INTO fts_notes(title, tags, description, content, rel_path, note_type) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("External", "", "", "external-only-marker", "external.md", "Resource"),
+        )
+        connection.commit()
+    monkeypatch.setenv("POWER_SEARCH_DB", str(external))
+
+    result = ApplicationService(sample_vault).retrieve("external-only-marker", mode="fts")
+
+    assert result.data["result_count"] == 0
+
+
+def test_failure_receipt_redacts_exception_text_and_preserves_correlation(
+    sample_vault: Path,
+) -> None:
+    """Failure evidence contains categories and IDs, never exception content."""
+    audit = []
+    service = ApplicationService(sample_vault, audit_hook=audit.append)
+    context = RequestContext(actor="cli-label", principal=Principal.local_cli())
+
+    def fail() -> None:
+        raise RuntimeError("password=super-secret request body with note content")
+
+    with pytest.raises(RuntimeError):
+        service._run("test.failure", context, fail)
+
+    receipt = audit[-1]
+    payload = receipt.as_dict()
+    assert payload["status"] == "failed"
+    assert payload["error_code"] == "internal_error"
+    assert payload["request_id"] == context.request_id
+    assert payload["principal_ref"] == "local-cli"
+    assert "super-secret" not in json.dumps(payload)
+    assert "request body" not in json.dumps(payload)
+    assert len(json.dumps(payload)) < 2048
+
+
+def test_invalid_retrieval_request_emits_failure_receipt(sample_vault: Path) -> None:
+    """Boundary validation failures are correlated without echoing the query."""
+    audit = []
+    service = ApplicationService(sample_vault, audit_hook=audit.append)
+
+    with pytest.raises(ValueError, match="empty"):
+        service.retrieve("   ")
+
+    assert audit[-1].as_dict()["operation"] == "retrieve"
+    assert audit[-1].as_dict()["error_code"] == "invalid_request"
+
+
+def test_deadline_expiry_before_start_skips_action_and_receipts_failure(
+    sample_vault: Path,
+) -> None:
+    """An already expired absolute deadline prevents even sentinel execution."""
+    audit = []
+    service = ApplicationService(sample_vault, audit_hook=audit.append)
+    called = False
+    context = RequestContext(
+        authority="apply",
+        principal=Principal.local_cli(),
+        deadline_ms=100,
+        deadline_at=time.monotonic() - 1,
+    )
+
+    def sentinel() -> None:
+        nonlocal called
+        called = True
+
+    with pytest.raises(DeadlineExceededError, match="before operation started"):
+        service._run("test.prestart", context, sentinel, mutation=True)
+
+    assert called is False
+    assert audit[-1].as_dict()["outcome"] == "rejected_before_start"
+    assert audit[-1].as_dict()["error_code"] == "deadline_exceeded"
+
+
+def test_mutation_late_completion_is_not_reported_as_cancellation(sample_vault: Path) -> None:
+    """A committed slow action reports completed-after-deadline truthfully."""
+    audit = []
+    service = ApplicationService(sample_vault, audit_hook=audit.append)
+    marker = sample_vault / "late-completion.marker"
+    context = RequestContext(
+        authority="apply",
+        principal=Principal.local_cli(),
+        deadline_ms=1,
+    )
+
+    def slow_mutation() -> dict[str, object]:
+        time.sleep(0.01)
+        marker.write_text("committed", encoding="utf-8")
+        return {"changed": True}
+
+    with pytest.raises(CompletedAfterDeadlineError, match="completed after deadline"):
+        service._run("test.mutation", context, slow_mutation, mutation=True)
+
+    assert marker.read_text(encoding="utf-8") == "committed"
+    failure = audit[-1].as_dict()
+    assert failure["status"] == "completed_after_deadline"
+    assert failure["outcome"] == "completed_after_deadline"
+    assert failure["error_code"] == "completed_after_deadline"
+
+
+def test_result_budget_rejects_oversized_envelope(sample_vault: Path) -> None:
+    """Generic application results have a server-selected structural ceiling."""
+    audit = []
+    service = ApplicationService(sample_vault, audit_hook=audit.append)
+    context = RequestContext(
+        authority="apply",
+        principal=Principal.local_cli(),
+        max_result_bytes=128,
+    )
+
+    with pytest.raises(ResultBudgetExceededError, match="result budget"):
+        service._run("test.result-budget", context, lambda: {"value": "x" * 1024})
+
+    failure = audit[-1].as_dict()
+    assert failure["status"] == "failed"
+    assert failure["error_code"] == "result_budget_exceeded"
+    assert "x" * 128 not in json.dumps(failure)
+
+
+def test_mutation_result_budget_has_truthful_late_outcome(sample_vault: Path) -> None:
+    """A post-action result-bound violation cannot be mistaken for pre-action failure."""
+    audit = []
+    service = ApplicationService(sample_vault, audit_hook=audit.append)
+    context = RequestContext(
+        authority="apply",
+        principal=Principal.local_cli(),
+        max_result_bytes=128,
+    )
+
+    with pytest.raises(CompletedAfterBudgetError, match="result budget"):
+        service._run(
+            "test.mutation-result-budget",
+            context,
+            lambda: {"value": "x" * 1024},
+            mutation=True,
+        )
+
+    assert audit[-1].as_dict()["outcome"] == "completed_after_budget"
+    assert audit[-1].as_dict()["status"] == "completed_after_budget"
+
+
+def test_receipt_history_rejects_unbounded_or_content_bearing_records(sample_vault: Path) -> None:
+    """The readback surface fails closed on unsafe durable receipt state."""
+    history = sample_vault / ".power" / "memory-history.jsonl"
+    history.parent.mkdir()
+    history.write_text('{"operation":"x","content":"must not be here"}\n', encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="non-content-free"):
+        ApplicationService(sample_vault).receipt()
+
+
+def test_success_receipt_legacy_shape_is_preserved_with_principal_on_envelope(
+    sample_vault: Path,
+) -> None:
+    """Existing content-free success receipts stay wire-compatible."""
+    result = ApplicationService(sample_vault).discover()
+
+    assert set(result.receipt.as_dict()) == {
+        "schema_version",
+        "operation",
+        "status",
+        "request_id",
+        "idempotency_key",
+        "data_sha256",
+        "duration_ms",
+    }
+    assert result.as_dict()["principal_ref"] == "local-cli"
+
+
+def test_audit_hook_failure_cannot_turn_committed_success_into_operation_failure(
+    sample_vault: Path,
+) -> None:
+    """A broken optional sink is isolated from the application outcome."""
+
+    def broken_hook(_receipt: object) -> None:
+        raise RuntimeError("sink unavailable")
+
+    result = ApplicationService(sample_vault, audit_hook=broken_hook).discover()
+
+    assert result.status == "ok"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -21,10 +21,13 @@ from mcp.server.mcpserver.exceptions import ToolError
 
 from power_framework.core import __version__
 from power_framework.core.capabilities import manifest
+from power_framework.core.mutation import run_blocking
 from power_framework.core.parser import validate_metadata
 from power_framework.mcp import power_server
 from power_framework.mcp.contract import canonical_tool_catalog
 from power_framework.mcp.power_server import (
+    _MCP_REQUEST_ID,
+    _mcp_context,
     _safe_mcp_error_text,
     apply_memory_change,
     archive_notes,
@@ -396,6 +399,17 @@ async def test_mcp_call_carries_bounded_request_correlation(sample_vault: Path) 
     request_id = result.meta.get("power.request_id")
     assert isinstance(request_id, str)
     assert re.fullmatch(r"[a-f0-9]{32}", request_id)
+
+
+async def test_mcp_request_correlation_survives_blocking_offload() -> None:
+    """The worker receives the outer MCP request ID instead of minting another one."""
+    token = _MCP_REQUEST_ID.set("mcp-correlated-request")
+    try:
+        observed = await run_blocking(lambda: _mcp_context().request_id)
+    finally:
+        _MCP_REQUEST_ID.reset(token)
+
+    assert observed == "mcp-correlated-request"
 
 
 async def test_mcp_write_tools_require_explicit_approval(sample_vault: Path) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import select
 import sqlite3
 import subprocess
@@ -24,6 +25,7 @@ from power_framework.core.parser import validate_metadata
 from power_framework.mcp import power_server
 from power_framework.mcp.contract import canonical_tool_catalog
 from power_framework.mcp.power_server import (
+    _safe_mcp_error_text,
     apply_memory_change,
     archive_notes,
     ensure_sub_index,
@@ -233,6 +235,23 @@ async def test_get_server_info_is_read_only_and_does_not_probe_by_default(
     assert not (sample_vault / ".power").exists()
 
 
+async def test_mcp_discovery_ignores_external_search_db_override(
+    sample_vault: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Read-only MCP discovery observes only the configured vault namespace."""
+    external = tmp_path / "external-discovery.db"
+    external.write_text("external sentinel", encoding="utf-8")
+    monkeypatch.setenv("POWER_SEARCH_DB", str(external))
+
+    result = json.loads(await get_server_info(vault_path=str(sample_vault)))
+
+    database_path = result["vault"].get("database_path")
+    assert database_path is None or str(external) != database_path
+    assert external.read_text(encoding="utf-8") == "external sentinel"
+
+
 async def test_get_server_info_can_request_the_no_download_provider_probe(
     sample_vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -351,6 +370,48 @@ async def test_destructive_mcp_tools_require_explicit_approval(sample_vault: Pat
         await heal_frontmatter_tool(dry_run=False, vault_path=str(sample_vault))
 
     assert not (sample_vault / "04_Archive").exists()
+
+
+def test_mcp_error_text_is_bounded_and_secret_free() -> None:
+    """MCP errors do not reflect secret-bearing or unbounded exception text."""
+    error = RuntimeError("password=super-secret token=another-secret " + ("x" * 2048))
+
+    safe = _safe_mcp_error_text(error)
+
+    assert len(safe) <= 512
+    assert "super-secret" not in safe
+    assert "another-secret" not in safe
+    assert "<redacted>" in safe
+
+
+async def test_mcp_call_carries_bounded_request_correlation(sample_vault: Path) -> None:
+    """Native MCP results carry the server-generated request identity in metadata."""
+    result = await power_server.mcp.call_tool(
+        "search_vault_tool",
+        {"query": "", "vault_path": str(sample_vault)},
+    )
+
+    assert result.is_error is True
+    assert result.meta is not None
+    request_id = result.meta.get("power.request_id")
+    assert isinstance(request_id, str)
+    assert re.fullmatch(r"[a-f0-9]{32}", request_id)
+
+
+async def test_mcp_write_tools_require_explicit_approval(sample_vault: Path) -> None:
+    """Caller metadata is not enough to authorize non-destructive writes."""
+    with pytest.raises(ToolError, match="explicit approved=True"):
+        await generate_index(vault_path=str(sample_vault))
+    with pytest.raises(ToolError, match="explicit approved=True"):
+        await ingest_note(
+            name="01_Projects/RejectedMcpNote.md",
+            note_type="Project",
+            title="Rejected MCP note",
+            description="Must not be written",
+            content="No write",
+            vault_path=str(sample_vault),
+        )
+    assert not (sample_vault / "01_Projects" / "RejectedMcpNote.md").exists()
 
 
 async def test_mcp_read_tools_ignore_caller_selected_search_database(
@@ -490,7 +551,7 @@ def test_power_mcp_startup_keeps_stdout_protocol_only(sample_vault: Path) -> Non
 
 
 async def test_read_sub_index_existing_category(sample_vault: Path) -> None:
-    await ensure_sub_index(category="01_Projects", vault_path=str(sample_vault))
+    await ensure_sub_index(category="01_Projects", vault_path=str(sample_vault), approved=True)
     result = await read_sub_index(category="01_Projects", vault_path=str(sample_vault))
     assert "Test Project" in result
 
@@ -576,7 +637,9 @@ async def test_ensure_sub_index_can_return_requested_page(
 
     monkeypatch.setattr(application, "run_generate_sub_index", fake_generate)
 
-    result = await ensure_sub_index(category="01_Projects", page=2, vault_path=str(sample_vault))
+    result = await ensure_sub_index(
+        category="01_Projects", page=2, vault_path=str(sample_vault), approved=True
+    )
 
     assert result.startswith("Generated test catalog")
     assert "Page 2 of 2" in result
@@ -814,7 +877,7 @@ async def test_lint_vault_on_sample(sample_vault: Path) -> None:
 
 
 async def test_generate_index_tool(sample_vault: Path) -> None:
-    result = await generate_index(vault_path=str(sample_vault))
+    result = await generate_index(vault_path=str(sample_vault), approved=True)
     assert "hierarchical index" in result
     assert (sample_vault / "index.md").exists()
 
@@ -830,6 +893,7 @@ async def test_ingest_note_tool(sample_vault: Path) -> None:
         description="Created via MCP server tool",
         content="Hello world",
         vault_path=str(sample_vault),
+        approved=True,
     )
     assert "successfully ingested" in result
 
@@ -854,6 +918,7 @@ async def test_ingest_note_tool(sample_vault: Path) -> None:
             description="Created via MCP server tool",
             content="Hello world",
             vault_path=str(sample_vault),
+            approved=True,
         )
 
 
@@ -864,7 +929,7 @@ async def test_mcp_write_search_loop_survives_a_fresh_process(
     monkeypatch.delenv("POWER_SEARCH_DB", raising=False)
     marker = "mcp-fresh-process-acceptance-7f3c"
 
-    await sync_vault(fts_only=True, vault_path=str(sample_vault))
+    await sync_vault(fts_only=True, vault_path=str(sample_vault), approved=True)
     await ingest_note(
         name="03_Resources/fresh-process-probe",
         note_type="Resource",
@@ -872,6 +937,7 @@ async def test_mcp_write_search_loop_survives_a_fresh_process(
         description=f"A restart acceptance note carrying {marker}",
         content=f"# Probe\n\nThe body contains {marker}.\n",
         vault_path=str(sample_vault),
+        approved=True,
     )
 
     before = json.loads(
@@ -913,17 +979,18 @@ async def test_sync_vault_fails_closed_and_can_explicitly_allow_partial(
     sample_vault: Path,
 ) -> None:
     """Coverage omissions are an explicit MCP error, never an implied success."""
-    await sync_vault(fts_only=True, vault_path=str(sample_vault))
+    await sync_vault(fts_only=True, vault_path=str(sample_vault), approved=True)
     invalid = sample_vault / "03_Resources" / "broken-sync-note.md"
     invalid.write_text("# no OKF frontmatter\n", encoding="utf-8")
 
     with pytest.raises(ToolError, match=r"failed closed.*broken-sync-note\.md"):
-        await sync_vault(fts_only=True, vault_path=str(sample_vault))
+        await sync_vault(fts_only=True, vault_path=str(sample_vault), approved=True)
 
     report = await sync_vault(
         fts_only=True,
         allow_partial=True,
         vault_path=str(sample_vault),
+        approved=True,
     )
     assert "Notes excluded (invalid metadata): 1" in report
     assert "- 03_Resources/broken-sync-note.md: invalid_metadata" in report
@@ -939,9 +1006,14 @@ async def test_sync_vault_dense_loss_requires_explicit_acceptance(
     monkeypatch.setattr(power_server._index_limiter, "is_allowed", lambda _: True)
     monkeypatch.setattr(generation_index, "active_dense_chunk_count", lambda _: 3)
     with pytest.raises(ToolError, match=r"Refusing --fts-only.*3 chunks"):
-        await sync_vault(fts_only=True, vault_path=str(sample_vault))
+        await sync_vault(fts_only=True, vault_path=str(sample_vault), approved=True)
 
-    report = await sync_vault(fts_only=True, accept_dense_loss=True, vault_path=str(sample_vault))
+    report = await sync_vault(
+        fts_only=True,
+        accept_dense_loss=True,
+        vault_path=str(sample_vault),
+        approved=True,
+    )
     assert "Mode: FTS only" in report
 
 
@@ -957,11 +1029,16 @@ async def test_synthesize_session_serializes_write_and_stores_candidate_triplets
         description="A synthesis created through the MCP write queue.",
         content="POWER is a knowledge management framework.",
         vault_path=str(sample_vault),
+        approved=True,
     )
 
     assert "synthesized and ingested" in result
     assert (sample_vault / "06_Daily_Logs" / "McpSynthesis.md").exists()
-    with closing(sqlite3.connect(db_path)) as conn:
+    assert not db_path.exists()
+    from power_framework.core.vault_storage import vault_cache_dir
+
+    canonical_db = vault_cache_dir(sample_vault) / "search.db"
+    with closing(sqlite3.connect(canonical_db)) as conn:
         rows = conn.execute(
             "SELECT source_path, relation, status FROM relation_candidates WHERE source_path = ?",
             ("06_Daily_Logs/McpSynthesis.md",),
@@ -987,6 +1064,7 @@ async def test_mcp_write_tools_reject_path_traversal(
                 description="Must be rejected",
                 content="unsafe",
                 vault_path=str(sample_vault),
+                approved=True,
             )
     else:
         with pytest.raises(ToolError, match="Invalid note path"):
@@ -996,6 +1074,7 @@ async def test_mcp_write_tools_reject_path_traversal(
                 description="Must be rejected",
                 content="unsafe",
                 vault_path=str(sample_vault),
+                approved=True,
             )
 
     assert sentinel.read_text(encoding="utf-8") == "do not modify"

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -173,3 +173,39 @@ def test_cli_rename_command(tmp_path: Path):
     # References in Note A should be updated on disk
     content = read_file_content(note_a)
     assert "02_Areas/NoteB_new.md" in content
+
+
+@pytest.mark.parametrize("unsafe_target", ["../outside.md", "absolute-outside.md"])
+def test_cli_rename_rejects_paths_outside_vault(tmp_path: Path, unsafe_target: str) -> None:
+    """Physical rename targets must stay inside the configured vault."""
+    projects = tmp_path / "01_Projects"
+    projects.mkdir()
+    source = projects / "source.md"
+    source.write_text("source", encoding="utf-8")
+    outside = tmp_path.parent / "outside.md"
+    outside.write_text("sentinel", encoding="utf-8")
+    if unsafe_target == "absolute-outside.md":
+        unsafe_target = str(tmp_path.parent / unsafe_target)
+
+    with (
+        patch.object(
+            sys,
+            "argv",
+            [
+                "power",
+                "rename",
+                str(tmp_path),
+                "--old",
+                "01_Projects/source.md",
+                "--new",
+                unsafe_target,
+                "--no-dry-run",
+            ],
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+
+    assert exc.value.code == 1
+    assert source.read_text(encoding="utf-8") == "source"
+    assert outside.read_text(encoding="utf-8") == "sentinel"

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -209,3 +209,35 @@ def test_cli_rename_rejects_paths_outside_vault(tmp_path: Path, unsafe_target: s
     assert exc.value.code == 1
     assert source.read_text(encoding="utf-8") == "source"
     assert outside.read_text(encoding="utf-8") == "sentinel"
+
+
+def test_cli_rename_allows_a_valid_missing_destination_parent(tmp_path: Path) -> None:
+    """A contained rename may create its validated destination directory."""
+    projects = tmp_path / "01_Projects"
+    projects.mkdir()
+    source = projects / "source.md"
+    source.write_text("source", encoding="utf-8")
+    destination = tmp_path / "02_Areas" / "nested" / "destination.md"
+
+    with (
+        patch.object(
+            sys,
+            "argv",
+            [
+                "power",
+                "rename",
+                str(tmp_path),
+                "--old",
+                "01_Projects/source.md",
+                "--new",
+                "02_Areas/nested/destination.md",
+                "--no-dry-run",
+            ],
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+
+    assert exc.value.code == 0
+    assert destination.read_text(encoding="utf-8") == "source"
+    assert not source.exists()

--- a/tests/web/contract/test_foundation_hardening.py
+++ b/tests/web/contract/test_foundation_hardening.py
@@ -14,6 +14,7 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
+from power_framework.core.application import CompletedAfterBudgetError, DeadlineExceededError
 from power_framework.core.principal import Principal
 from power_framework.web.app import create_app
 from power_framework.web.clients.power import PowerClient
@@ -21,6 +22,7 @@ from power_framework.web.config import Settings
 from power_framework.web.errors import (
     PowerCallCompletedAfterCancellationError,
     PowerCallCompletedAfterDeadlineError,
+    public_error_details,
 )
 from power_framework.web.offload import run_power_call
 
@@ -182,9 +184,21 @@ def test_federation_config_rejects_unbounded_or_url_like_nodes(web_vault: Path) 
         federation_nodes=json.dumps(too_many),
     )
     assert _get_fleet_topology(settings) == DEFAULT_FLEET_TOPOLOGY
-
     settings.federation_nodes = json.dumps([{"host": "http://127.0.0.1", "port": 8080}])
     assert _get_fleet_topology(settings) == DEFAULT_FLEET_TOPOLOGY
+
+
+def test_web_error_mapping_preserves_execution_outcome_categories() -> None:
+    """Web public errors distinguish pre-start, late-budget, and late-cancel outcomes."""
+    assert public_error_details(DeadlineExceededError("before operation started"))[0] == (
+        "rejected_before_start"
+    )
+    assert public_error_details(CompletedAfterBudgetError("budget"))[0] == (
+        "completed_after_budget"
+    )
+    assert public_error_details(PowerCallCompletedAfterCancellationError())[0] == (
+        "completed_after_cancellation"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/web/contract/test_foundation_hardening.py
+++ b/tests/web/contract/test_foundation_hardening.py
@@ -1,0 +1,239 @@
+"""Web F1/F2/F5 contracts for the foundation hardening gate."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import anyio
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from power_framework.core.principal import Principal
+from power_framework.web.app import create_app
+from power_framework.web.clients.power import PowerClient
+from power_framework.web.config import Settings
+from power_framework.web.errors import (
+    PowerCallCompletedAfterCancellationError,
+    PowerCallCompletedAfterDeadlineError,
+)
+from power_framework.web.offload import run_power_call
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _csrf(html: str) -> str:
+    match = re.search(r'name="csrf_token"\s+value="([^"]+)"', html)
+    assert match
+    return match.group(1)
+
+
+def _proposal_id(html: str) -> str:
+    match = re.search(r'name="proposal_id"\s+value="([0-9a-f]{64})"', html)
+    assert match
+    return match.group(1)
+
+
+@pytest.fixture
+def web_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "web-foundation-vault"
+    vault.mkdir()
+    (vault / ".power").mkdir()
+    (vault / "01_Projects").mkdir()
+    (vault / "01_Projects" / "Note.md").write_text(
+        "---\ntype: Project\ntitle: Note\ndescription: Baseline\n"
+        "timestamp: 2026-09-09T00:00:00Z\n---\n\nBaseline\n",
+        encoding="utf-8",
+    )
+    return vault
+
+
+def _web_client(vault: Path, *, host: str = "127.0.0.1") -> TestClient:
+    settings = Settings(
+        vault_path=vault,
+        host=host,
+        auth_enabled=False,
+        cookie_secure=False,
+    )
+    return TestClient(create_app(settings))
+
+
+def test_web_apply_omitted_false_and_malformed_approval_fail_closed(
+    web_vault: Path,
+) -> None:
+    """An omitted or non-exact approval value cannot reach the apply client."""
+    client = _web_client(web_vault)
+    edit = client.get("/notes/edit?path=01_Projects/Note.md")
+    proposal = client.post(
+        "/notes/propose",
+        data={
+            "csrf_token": _csrf(edit.text),
+            "path": "01_Projects/Note.md",
+            "content": (
+                "---\ntype: Project\ntitle: Changed\ndescription: Updated\n"
+                "timestamp: 2026-09-09T00:00:00Z\n---\n\nChanged\n"
+            ),
+        },
+    )
+    assert proposal.status_code == 200
+    proposal_id = _proposal_id(proposal.text)
+    csrf = _csrf(proposal.text)
+
+    omitted = client.post(
+        "/notes/apply",
+        data={"csrf_token": csrf, "proposal_id": proposal_id},
+        follow_redirects=False,
+    )
+    assert omitted.status_code == 422
+
+    for value in ("false", "yes", "1"):
+        rejected = client.post(
+            "/notes/apply",
+            data={"csrf_token": csrf, "proposal_id": proposal_id, "approved": value},
+            follow_redirects=False,
+        )
+        assert rejected.status_code == 403, value
+
+    assert "Baseline" in (web_vault / "01_Projects" / "Note.md").read_text(encoding="utf-8")
+
+
+def test_web_session_subject_and_request_id_reach_application_receipt(web_vault: Path) -> None:
+    """The verified web binding is carried without conflating it with actor text."""
+    client = PowerClient(
+        web_vault,
+        principal=Principal.web_signed_session("admin"),
+        request_id="web-request-1",
+    )
+
+    envelope = client.discover(actor="forged-attribution")
+
+    assert envelope.receipt.request_id == "web-request-1"
+    assert envelope.receipt.principal_binding == "WEB_SIGNED_SESSION"
+    assert envelope.receipt.principal_ref is not None
+    assert envelope.receipt.principal_ref != "admin"
+
+
+def test_real_signed_web_session_populates_server_derived_principal(web_vault: Path) -> None:
+    """The middleware binds the verified session subject, not a request field."""
+    settings = Settings(
+        vault_path=web_vault,
+        auth_enabled=True,
+        admin_password="test-password",
+        cookie_secure=False,
+        session_max_age_seconds=300,
+    )
+    app = create_app(settings)
+
+    @app.get("/_foundation-principal")
+    async def foundation_principal(request: Request):
+        principal = request.state.principal
+        return {
+            "binding": principal.binding if principal is not None else None,
+            "ref": principal.ref if principal is not None else None,
+            "subject": request.state.session_subject,
+        }
+
+    client = TestClient(app)
+    login = client.get("/login")
+    response = client.post(
+        "/login",
+        data={"password": "test-password", "csrf_token": _csrf(login.text)},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    session = response.cookies.get("power_web_session")
+    assert session is not None
+    client.cookies.set("power_web_session", session)
+
+    principal = client.get("/_foundation-principal").json()
+
+    assert principal["binding"] == "WEB_SIGNED_SESSION"
+    assert principal["subject"] == "admin"
+    assert principal["ref"] != "admin"
+
+
+def test_auth_disabled_non_loopback_bind_fails_closed(web_vault: Path) -> None:
+    """Disabling login is not a remote anonymous mutation mode."""
+    remote_bind = ".".join(("0", "0", "0", "0"))
+    client = _web_client(web_vault, host=remote_bind)
+
+    private = client.get("/dashboard")
+    readiness = client.get("/readiness")
+
+    assert private.status_code == 403
+    assert readiness.status_code == 503
+    assert any("loopback" in issue for issue in readiness.json()["issues"])
+
+
+def test_federation_config_rejects_unbounded_or_url_like_nodes(web_vault: Path) -> None:
+    """Configured discovery probes have bounded, host/port-only input."""
+    from power_framework.web.routes.federation import DEFAULT_FLEET_TOPOLOGY, _get_fleet_topology
+
+    too_many = [{"host": "127.0.0.1", "port": 8080}] * 17
+    settings = Settings(
+        vault_path=web_vault,
+        auth_enabled=False,
+        federation_nodes=json.dumps(too_many),
+    )
+    assert _get_fleet_topology(settings) == DEFAULT_FLEET_TOPOLOGY
+
+    settings.federation_nodes = json.dumps([{"host": "http://127.0.0.1", "port": 8080}])
+    assert _get_fleet_topology(settings) == DEFAULT_FLEET_TOPOLOGY
+
+
+@pytest.mark.asyncio
+async def test_mutation_offload_joins_worker_and_reports_late_completion() -> None:
+    """A timed-out mutation worker is joined before the caller gets an error."""
+    app = FastAPI()
+    app.state.power_call_limiter = anyio.CapacityLimiter(1)
+    request = type("RequestStub", (), {})()
+    request.app = app
+    request.state = type("State", (), {"request_id": "offload-request-1"})()
+    settings = Settings(auth_enabled=False, power_call_timeout_seconds=0.1)
+    finished = threading.Event()
+
+    def slow_mutation() -> str:
+        time.sleep(0.15)
+        finished.set()
+        return "committed"
+
+    with pytest.raises(PowerCallCompletedAfterDeadlineError):
+        await run_power_call(
+            request,
+            settings,
+            slow_mutation,
+            mutation=True,
+        )
+
+    assert finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_canceled_mutation_offload_reports_joined_outcome() -> None:
+    """Cancellation cannot detach an in-flight mutation from its caller."""
+    app = FastAPI()
+    app.state.power_call_limiter = anyio.CapacityLimiter(1)
+    request = type("RequestStub", (), {})()
+    request.app = app
+    request.state = type("State", (), {"request_id": "cancel-request-1"})()
+    settings = Settings(auth_enabled=False, power_call_timeout_seconds=1.0)
+    finished = threading.Event()
+
+    def slow_mutation() -> str:
+        time.sleep(0.04)
+        finished.set()
+        return "committed"
+
+    running = asyncio.create_task(run_power_call(request, settings, slow_mutation, mutation=True))
+    await asyncio.sleep(0.005)
+    running.cancel()
+
+    with pytest.raises(PowerCallCompletedAfterCancellationError):
+        await running
+    assert finished.is_set()

--- a/tests/web/unit/test_auth.py
+++ b/tests/web/unit/test_auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from power_framework.web.auth.csrf import generate_csrf_token, verify_csrf_token
 from power_framework.web.auth.session import SessionManager
 
@@ -14,6 +16,10 @@ def test_session_manager_lifecycle() -> None:
 
     user = mgr.verify_session(raw_session, max_age_seconds=60)
     assert user == "user_admin"
+    verified = mgr.verify_session_details(raw_session, max_age_seconds=60)
+    assert verified is not None
+    assert verified[0] == "user_admin"
+    assert verified[1] > datetime.now(UTC)
 
 
 def test_session_manager_tamper_and_expiry() -> None:


### PR DESCRIPTION
## Scope

This is the single bounded Pre-Phase-5 Foundation Hardening admission for POWER 3.8.

- **F1:** ApplicationService mutation entry points require an explicit context, a valid server-bound principal, and the correct authority. Web approval is required and exact-true; PowerClient approval is keyword-only; MCP write tools enforce explicit approval; CLI actor remains attribution only.
- **F2:** Add typed `WEB_SIGNED_SESSION`, `LOCAL_CLI`, `LOCAL_MCP_STDIO`, and `SYSTEM_INTERNAL` principal bindings. Web preserves the verified signed subject with the token's actual expiry, auth-disabled Web is loopback-only, MCP derives local stdio identity, and request correlation is propagated without storing secrets.
- **F3:** Default ApplicationService retrieval and MCP diagnostics cannot use `POWER_SEARCH_DB`; the legacy override remains explicit lower-level compatibility only. Synthesis graph projection, control directories, source projection and CLI rename paths remain bounded.
- **F4:** Configured application audit hooks receive bounded failure receipts with safe categories, request/idempotency/principal metadata, empty-result digest and budget data. Exception text, tracebacks, request bodies, note content and credentials are excluded. MCP errors are bounded/redacted and call metadata carries a request ID.
- **F5:** Pre-start deadlines reject before action; synchronous mutations are joined and report `completed_after_deadline`/`completed_after_cancellation` truthfully; read detachment is read-only; worker and serialized-result budgets are bounded; mutation retries are not added.

## Non-goals

**NO PHASE 5 IMPLEMENTATION.** This PR does not implement the Phase 5 router, SearchScope pushdown, RetrievalPlanner, ContextPackCompiler, evaluation runtime, persistent IndexWorkQueue, capture adapters, conversation ingestion, Context Broker, vector database, model migration, Phase 6+, version bump, tag, release, OCI image, dependency refresh, lockfile change, or workflow/branch-protection change.

## Verification

- F1–F5 focused application/Web/MCP/CLI/security tests added.
- Full Python suite: `1817 passed, 14 skipped, 0 deselected`, coverage `83.20%` (baseline floor preserved; new tests increased count).
- Locked CI-equivalent local gates: `uv lock --check`, CI-profile `uv sync --locked --group dev --extra web --extra semantic --extra rerank`, `pip check`, Ruff, format, MyPy, doc drift, strict MkDocs, and `pip-audit --skip-editable` all pass.
- Existing PSE/Task/Decision/crash, Web, MCP, CLI, source-boundary, CSRF, package and benchmark tests remain green.
- Adversarial review: two fresh single-model cycles; valid findings repaired or explicitly classified. Codex cross-model was attempted with the requested Luna Max model but rejected by Codex/ChatGPT account (HTTP 400), then skipped explicitly; no unsupported fallback was run.

## Candidate epoch

- Base: `95f8cadd7e90ef4b16773b3c45bbc9ab40569e7a`
- Final local candidate head: `9b04bbea6d42d700ae9c28534ce87277afafe2da`
- Tree: `9a380020ad9b6356f69f6681d0b10aa921c832a0`
- Parent: `77eb706a9794eb04b570c53520a5a891b96335c6`
- Local GPG: verified with primary `2D49E810C7F2527E`

A changed candidate invalidates its prior evidence and starts a new epoch. Merge is authorized only after fresh exact-head required contexts, review/thread/security inspection, and one normal protected merge commit. No bypass, force, squash, rebase, queue override, or auto-merge.

## Governance hygiene

This PR also fixes the broken `Actions \`#396\`, capture...` continuation and makes the current-state snapshot fields unambiguous. Foundation closure is published only after protected post-merge readback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Access**
  * Added principal-based request identity and stricter authorization checks.
  * Web authentication now fails closed when disabled on non-loopback addresses.
  * Write operations require explicit approval; unsafe paths, symlinks, and invalid federation settings are rejected.

* **Reliability**
  * Added request deadlines, result-size limits, bounded concurrency, and clearer timeout outcomes.
  * Added idempotent handling for repeated proposals and note ingestion.

* **Diagnostics**
  * Failure receipts now provide structured, redacted error details.
  * MCP responses include request IDs for easier tracing.

* **Documentation**
  * Updated project status, planning, and release-gate documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->